### PR TITLE
Implements Urgency Hint handling

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -206,7 +206,11 @@ void LxQtTaskBar::activeWindowChanged()
     LxQtTaskButton* btn = buttonByWindow(window);
 
     if (btn)
+    {
         btn->setChecked(true);
+        if (btn->hasUrgencyHint())
+            btn->setUrgencyHint(false);
+    }
     else
         LxQtTaskButton::unCheckAll();
 }

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -72,7 +72,6 @@ LxQtTaskButton::LxQtTaskButton(const Window window, QWidget *parent) :
 
     connect(this, SIGNAL(toggled(bool)), this, SLOT(checkedChanged(bool)));
 
-
     XWindowAttributes oldAttr;
     XGetWindowAttributes(QX11Info::display(), mWindow, &oldAttr);
 
@@ -250,6 +249,8 @@ void LxQtTaskButton::raiseApplication()
     if (xfitMan().getActiveDesktop() != winDesktop)
         xfitMan().setActiveDesktop(winDesktop);
     xfitMan().raiseWindow(mWindow);
+
+    setUrgencyHint(false);
 }
 
 
@@ -578,12 +579,37 @@ void  LxQtTaskButton::handlePropertyNotify(XEventType* event)
         return;
     }
 
+    if (prop_event->atom == XfitMan::atom("WM_HINTS"))
+    {
+        WMHintsFlags flags = XfitMan().getWMHintsFlags(prop_event->window);
+        if (flags & WMUrgencyHint)
+        {
+            if (prop_event->window != xfitMan().getActiveAppWindow())
+                setUrgencyHint(true);
+        }
+        else
+            setUrgencyHint(false);
+        return;
+    }
 
-//    char* aname = XGetAtomName(QX11Info::display(), event->atom);
-//    qDebug() << "** XPropertyEvent ********************";
-//    qDebug() << "  atom:       0x" << hex << event->atom
-//            << " (" << (aname ? aname : "Unknown") << ')';
+//     char* aname = XGetAtomName(QX11Info::display(), event->atom);
+//     qDebug() << "** XPropertyEvent ********************";
+//     qDebug() << "  atom:       0x" << hex << event->atom
+//             << " (" << (aname ? aname : "Unknown") << ')';
+//     qDebug() << "  window:      " << event->window;
+}
 
+
+/************************************************
+
+ ************************************************/
+void LxQtTaskButton::setUrgencyHint(bool set)
+{
+    mUrgencyHint = set;
+    setProperty("urgent", set);
+    style()->unpolish(this);
+    style()->polish(this);
+    update();
 }
 
 

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -64,6 +64,9 @@ public:
     bool isApplicationActive() const;
     Window windowId() const { return mWindow; }
 
+    bool hasUrgencyHint() const { return mUrgencyHint; }
+    void setUrgencyHint(bool set);
+
     static void unCheckAll();
     int desktopNum() const;
 
@@ -98,6 +101,7 @@ private:
     Window mWindow;
     static LxQtTaskButton* mCheckedBtn;
     ElidedButtonStyle mStyle;
+    bool mUrgencyHint;
     const QMimeData *mDraggableMimeData;
     static bool mShowOnlyCurrentDesktopTasks;
     static bool mCloseOnMiddleClick;


### PR DESCRIPTION
First of all, this dependes on lxde/liblxqt#11. As asked in #41, this PR intends to implement Urgency Hint for the taskbar. The taskbar button blinks when the urgency flag for it's window is set.
More info: http://tronche.com/gui/x/icccm/sec-4.html#s-4.1.2.4

There may be a more lightweight solution than using QPropertyAnimation for the blinking animation, please comment. Also, how can I get a better color for the blinking, maybe based on the current theme?

@willbprog127 could you test it, if you have time?

Screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/1238157/3335315/91ed114e-f811-11e3-9afb-2cb855d78dec.jpg)

Fixes #41.
