### PR TITLE
When realign function is called the plugin menus should not hide.

### DIFF
--- a/plugin-mount/lxqtmountplugin.cpp
+++ b/plugin-mount/lxqtmountplugin.cpp
@@ -65,8 +65,8 @@ QWidget *LxQtMountPlugin::widget()
 
 void LxQtMountPlugin::realign()
 {
-    if(mPopup)
-        mPopup->hide();
+//    if(mPopup)
+//        mPopup->hide();
 }
 
 

--- a/plugin-volume/lxqtvolume.cpp
+++ b/plugin-volume/lxqtvolume.cpp
@@ -229,7 +229,7 @@ QWidget *LxQtVolume::widget()
 
 void LxQtVolume::realign()
 {
-    m_volumeButton->hideVolumeSlider();
+    //m_volumeButton->hideVolumeSlider();
 }
 
 QDialog *LxQtVolume::configureDialog()


### PR DESCRIPTION
This pr is intended to be published after the autohide merge.
Its just a small fix.
