### PR TITLE
Fix quicklaunch executable icon issue

### DIFF
--- a/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/plugin-quicklaunch/quicklaunchaction.cpp
@@ -53,7 +53,7 @@ QuickLaunchAction::QuickLaunchAction(const QString & name,
     m_settingsMap["exec"] = exec;
     m_settingsMap["icon"] = icon;
 
-    if (icon.isNull())
+    if (icon == "" || icon.isNull())
         setIcon(XdgIcon::defaultApplicationIcon());
     else
         setIcon(QIcon(icon));


### PR DESCRIPTION
Fix default application icon not displaying when executables are added to quicklaunch problem.  Addresses #39.
