### PR TITLE
Allowed volume slider in plugin-volume to use 100% of max volume for a device.

### DIFF
--- a/plugin-volume/audiodevice.cpp
+++ b/plugin-volume/audiodevice.cpp
@@ -71,10 +71,11 @@ void AudioDevice::setIndex(uint index)
 }
 
 // this is just for setting the internal volume
-void AudioDevice::setVolumeNoCommit(int volume)
+void AudioDevice::setVolumeNoCommit(int volume, bool percentage)
 {
     if (m_engine) {
-	volume = volume*m_engine->volumeMax(this)/99;
+	if (percentage)
+		volume = volume*m_engine->volumeMax(this)/99;
         volume = qBound(0, volume, m_engine->volumeMax(this));
     }
     
@@ -111,12 +112,12 @@ void AudioDevice::setMuteNoCommit(bool state)
 }
 
 // this performs a volume change on the device
-void AudioDevice::setVolume(int volume)
+void AudioDevice::setVolume(int volume, bool percentage)
 {
     if (m_volume == volume)
         return;
 
-    setVolumeNoCommit(volume);
+    setVolumeNoCommit(volume,percentage);
     setMute(false);
 
     if (m_engine)

--- a/plugin-volume/audiodevice.h
+++ b/plugin-volume/audiodevice.h
@@ -60,8 +60,8 @@ public:
     void setIndex(uint index);
 
 public slots:
-    void setVolume(int volume);
-    void setVolumeNoCommit(int volume);
+    void setVolume(int volume,bool percent=false);
+    void setVolumeNoCommit(int volume,bool percent=false);
     void toggleMute();
     void setMute(bool state);
     void setMuteNoCommit(bool state);

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -109,7 +109,7 @@ void VolumePopup::handleSliderValueChanged(int value)
     if (!m_device)
         return;
     // qDebug("VolumePopup::handleSliderValueChanged: %d\n", value);
-    m_device->setVolume(value);
+    m_device->setVolume(value,true);
 }
 
 void VolumePopup::handleMuteToggleClicked()


### PR DESCRIPTION
On my machine using alsa, the volume slider wouldnt allow me to adjust the volume above 100 eventhough the device went to 127. Using function keys, however, would allow me to use the full range. These changes allow the full range provided by a device to be used with the slider.
