### PR TITLE
Fix the bug that 100% volume cannot be used

### DIFF
--- a/plugin-volume/alsaengine.cpp
+++ b/plugin-volume/alsaengine.cpp
@@ -63,15 +63,9 @@ AlsaEngine *AlsaEngine::instance()
 
 int AlsaEngine::volumeMax(AudioDevice *device) const
 {
-    AlsaDevice *dev = qobject_cast<AlsaDevice*>(device);
-    if (!dev || !dev->element())
-        return 100;
-
-    long vmin;
-    long vmax;
-    snd_mixer_selem_get_playback_volume_range(dev->element(), &vmin, &vmax);
-
-    return vmax;
+    // We already did snd_mixer_selem_set_playback_volume_range(mixerElem, 0, 100);
+    // during initialization. So we can return 100 directly here.
+    return 100;
 }
 
 AlsaDevice *AlsaEngine::getDeviceByAlsaElem(snd_mixer_elem_t *elem) const
@@ -117,6 +111,7 @@ void AlsaEngine::updateDevice(AlsaDevice *device)
 
     long value;
     snd_mixer_selem_get_playback_volume(device->element(), (snd_mixer_selem_channel_id_t)0, &value);
+    // qDebug() << "updateDevice:" << device->name() << value;
     device->setVolumeNoCommit(value);
 
     if (snd_mixer_selem_has_playback_switch(device->element())) {
@@ -195,8 +190,11 @@ void AlsaEngine::discoverDevices()
                     dev->setMixer(mixer);
                     dev->setElement(mixerElem);
 
+                    // set the range of volume to 0-100
+                    snd_mixer_selem_set_playback_volume_range(mixerElem, 0, 100);
                     long value;
                     snd_mixer_selem_get_playback_volume(mixerElem, (snd_mixer_selem_channel_id_t)0, &value);
+                    // qDebug() << dev->name() << "initial volume" << value;
                     dev->setVolumeNoCommit(value);
 
                     if (snd_mixer_selem_has_playback_switch(mixerElem)) {

--- a/plugin-volume/audiodevice.cpp
+++ b/plugin-volume/audiodevice.cpp
@@ -120,3 +120,9 @@ void AudioDevice::setVolume(int volume)
     if (m_engine)
         m_engine->commitDeviceVolume(this);
 }
+
+int AudioDevice::maxVolume() {
+    if(m_engine)
+        return m_engine->volumeMax(this);
+    return 100;
+}

--- a/plugin-volume/audiodevice.h
+++ b/plugin-volume/audiodevice.h
@@ -48,7 +48,9 @@ public:
     AudioDevice(AudioDeviceType t, AudioEngine *engine, QObject *parent = 0);
     ~AudioDevice();
 
+    // the volume can range from 0 to maxVolume().
     int volume() const { return m_volume; }
+    int maxVolume();
     bool mute() const { return m_mute; }
     AudioDeviceType type() const { return m_type; }
     const QString &name() const { return m_name; }
@@ -58,6 +60,8 @@ public:
     void setName(const QString &name);
     void setDescription(const QString &description);
     void setIndex(uint index);
+    
+    AudioEngine* engine() { return m_engine; }
 
 public slots:
     void setVolume(int volume);

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -49,6 +49,10 @@ LxQtVolumeConfiguration::LxQtVolumeConfiguration(QSettings &settings, QWidget *p
     connect(ui->stepSpinBox, SIGNAL(valueChanged(int)), this, SLOT(stepSpinBoxChanged(int)));
     connect(ui->ignoreMaxVolumeCheckBox, SIGNAL(toggled(bool)), this, SLOT(ignoreMaxVolumeCheckBoxChanged(bool)));
 
+    // currently, this option is only supported by the pulse audio backend
+    if(!ui->pulseAudioRadioButton->isChecked())
+        ui->ignoreMaxVolumeCheckBox->setEnabled(false);
+
 #ifdef USE_PULSEAUDIO
     connect(ui->pulseAudioRadioButton, SIGNAL(toggled(bool)), this, SLOT(audioEngineChanged(bool)));
 #else
@@ -86,12 +90,17 @@ void LxQtVolumeConfiguration::audioEngineChanged(bool checked)
     if (!checked)
         return;
 
+    bool canIgnoreMaxVolume = false;
     if (ui->pulseAudioRadioButton->isChecked())
+    {
         settings().setValue(SETTINGS_AUDIO_ENGINE, "PulseAudio");
+        canIgnoreMaxVolume = true;
+    }
     else if(ui->alsaRadioButton->isChecked())
         settings().setValue(SETTINGS_AUDIO_ENGINE, "Alsa");
     else
         settings().setValue(SETTINGS_AUDIO_ENGINE, "Oss");
+    ui->ignoreMaxVolumeCheckBox->setEnabled(canIgnoreMaxVolume);
 }
 
 void LxQtVolumeConfiguration::sinkSelectionChanged(int index)

--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -198,7 +198,7 @@ void PulseAudioEngine::addOrUpdateSink(const pa_sink_info *info)
     m_cVolumeMap.insert(dev, info->volume);
 
     pa_volume_t v = pa_cvolume_avg(&(info->volume));
-    dev->setVolumeNoCommit(((double)v*100.0) / m_maximumVolume);
+    dev->setVolumeNoCommit(v);
 
     if (newSink) {
         m_sinks.append(dev);
@@ -216,10 +216,10 @@ void PulseAudioEngine::commitDeviceVolume(AudioDevice *device)
     if (!device || !m_ready)
         return;
 
-    pa_volume_t v = (device->volume()/100.0) * m_maximumVolume;
+    pa_volume_t v = device->volume();
     pa_cvolume tmpVolume = m_cVolumeMap.value(device);
     pa_cvolume *volume = pa_cvolume_set(&tmpVolume, tmpVolume.channels, v);
-qDebug() << "PulseAudioEngine::commitDeviceVolume" << v;
+    // qDebug() << "PulseAudioEngine::commitDeviceVolume" << v;
     pa_threaded_mainloop_lock(m_mainLoop);
 
     pa_operation *operation;

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -53,7 +53,7 @@ signals:
     void mouseEntered();
     void mouseLeft();
 
-    void volumeChanged(int value);
+    // void volumeChanged(int value);
     void deviceChanged();
     void launchMixer();
     void stockIconChanged(const QString &iconName);


### PR DESCRIPTION
I tried to fix this known bug by correctly set the range of the volume slider to (0, 100) and convert the volume value to perent before set to the slider. Vice versa, new value set by the slider is converted back from percent to real volume value before set to the audio device.
