### PR TITLE
Ensure we operate on percentage, rather than absolute values

### DIFF
--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -198,7 +198,7 @@ void PulseAudioEngine::addOrUpdateSink(const pa_sink_info *info)
     m_cVolumeMap.insert(dev, info->volume);
 
     pa_volume_t v = pa_cvolume_avg(&(info->volume));
-    dev->setVolumeNoCommit(v);
+    dev->setVolumeNoCommit(((double)v*100.0) / m_maximumVolume);
 
     if (newSink) {
         m_sinks.append(dev);
@@ -216,7 +216,7 @@ void PulseAudioEngine::commitDeviceVolume(AudioDevice *device)
     if (!device || !m_ready)
         return;
 
-    pa_volume_t v = device->volume();
+    pa_volume_t v = (device->volume()/100.0) * m_maximumVolume;
     pa_cvolume tmpVolume = m_cVolumeMap.value(device);
     pa_cvolume *volume = pa_cvolume_set(&tmpVolume, tmpVolume.channels, v);
     // qDebug() << "PulseAudioEngine::commitDeviceVolume" << v;


### PR DESCRIPTION
This reverts part of ff992247be3f1cf00ff01bf7d31ff8734a275f14 and thus might break, what was fixed previously. But I don't quite understood the previous fix for 100% volumes. At least in pulseaudio >100% volume values are OK.
