### PR TITLE
* Workaround for Qt 5 bug #40681.

### DIFF
--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -105,6 +105,7 @@ public slots:
     void setAlignment(LxQtPanel::Alignment value);
 
     void saveSettings(bool later=false);
+    void ensureVisible();
 
 signals:
     void realigned();
@@ -115,7 +116,6 @@ protected:
     void showEvent(QShowEvent *event);
     
 private slots:
-    void screensChangeds();
     void addPlugin(const LxQt::PluginInfo &desktopFile);
     void showConfigDialog();
     void showAddPluginDialog();
@@ -123,7 +123,6 @@ private slots:
     void removePlugin();
     void pluginMoved();
     void userRequestForDeletion();
-
 private:
     LxQtPanelLayout* mLayout;
     LxQt::Settings *mSettings;

--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -33,6 +33,10 @@
 #include <QUuid>
 #include <X11/Xlib.h>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QScreen>
+#include <QWindow>
+#endif
 
 LxQtPanelApplication::LxQtPanelApplication(int& argc, char** argv, const QString &configFile)
     : LxQt::Application(argc, argv)
@@ -43,7 +47,15 @@ LxQtPanelApplication::LxQtPanelApplication(int& argc, char** argv, const QString
         mSettings = new LxQt::Settings(configFile, QSettings::IniFormat, this);
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		qApp->installNativeEventFilter(this);
+    qApp->installNativeEventFilter(this);
+
+    // This is a workaround for Qt 5 bug #40681.
+    Q_FOREACH(QScreen* screen, screens())
+    {
+        connect(screen, &QScreen::destroyed, this, &LxQtPanelApplication::screenDestroyed);
+    }
+    connect(this, &QGuiApplication::screenAdded, this, &LxQtPanelApplication::handleScreenAdded);
+
 #endif
 
     QStringList panels = mSettings->value("panels").toStringList();
@@ -78,16 +90,113 @@ void LxQtPanelApplication::addNewPanel()
     mSettings->setValue("panels", panels);
 }
 
-void LxQtPanelApplication::addPanel(const QString &name)
+LxQtPanel* LxQtPanelApplication::addPanel(const QString& name)
 {
     LxQtPanel *panel = new LxQtPanel(name);
     mPanels << panel;
     connect(panel, SIGNAL(deletedByUser(LxQtPanel*)),
             this, SLOT(removePanel(LxQtPanel*)));
+    return panel;
+}
+
+// This slot is for Qt 5 onlt, but the stupid Qt moc cannot do conditional compilation
+// so we have to define it for Qt 4 as well.
+void LxQtPanelApplication::handleScreenAdded(QScreen* newScreen)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    // qDebug() << "LxQtPanelApplication::handleScreenAdded" << newScreen;
+    connect(newScreen, &QScreen::destroyed, this, &LxQtPanelApplication::screenDestroyed);
+#endif
+}
+
+// This slot is for Qt 5 onlt, but the stupid Qt moc cannot do conditional compilation
+// so we have to define it for Qt 4 as well.
+void LxQtPanelApplication::reloadPanelsAsNeeded()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    // NOTE by PCMan: This is a workaround for Qt 5 bug #40681.
+    // Here we try to re-create the missing panels which are deleted in 
+    // LxQtPanelApplication::screenDestroyed().
+
+    // qDebug() << "LxQtPanelApplication::reloadPanelsAsNeeded()";
+    QStringList names = mSettings->value("panels").toStringList();
+    Q_FOREACH(const QString& name, names)
+    {
+        bool found = false;
+        Q_FOREACH(LxQtPanel* panel, mPanels)
+        {
+            if(panel->name() == name)
+            {
+                found = true;
+                break;
+            }
+        }
+        if(!found)
+        {
+            // the panel is found in the config file but does not exist, create it.
+            qDebug() << "Workaround Qt 5 bug #40681: re-create panel:" << name;
+            addPanel(name);
+        }
+    }
+    qApp->setQuitOnLastWindowClosed(true);
+#endif
+}
+
+// This slot is for Qt 5 onlt, but the stupid Qt moc cannot do conditional compilation
+// so we have to define it for Qt 4 as well.
+void LxQtPanelApplication::screenDestroyed(QObject* screenObj)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    // NOTE by PCMan: This is a workaround for Qt 5 bug #40681.
+    // With this very dirty workaround, we can fix lxde/lxde-qt bug #204, #205, and #206.
+    // Qt 5 has two new regression bugs which breaks lxqt-panel in a multihead environment.
+    // #40681: Regression bug: QWidget::winId() returns old value and QEvent::WinIdChange event is not emitted sometimes. (multihead setup) 
+    // #40791: Regression: QPlatformWindow, QWindow, and QWidget::winId() are out of sync.
+    // Explanations for the workaround:
+    // Internally, Qt mantains a list of QScreens and update it when XRandR configuration changes.
+    // When the user turn off an monitor with xrandr --output <xxx> --off, this will destroy the QScreen
+    // object which represent the output. If the QScreen being destroyed contains our panel widget,
+    // Qt will call QWindow::setScreen(0) on the internal windowHandle() of our panel widget to move it
+    // to the primary screen. However, moving a window to a different screen is more than just changing
+    // its position. With XRandR, all screens are actually part of the same virtual desktop. However,
+    // this is not the case in other setups, such as Xinerama and moving a window to another screen is 
+    // not possible unless you destroy the widget and create it again for a new screen.
+    // Therefore, Qt destroy the widget and re-create it when moving our panel to a new screen.
+    // Unfortunately, destroying the window also destroy the child windows embedded into it,
+    // using XEMBED such as the tray icons. (#206)
+    // Second, when the window is re-created, the winId of the QWidget is changed, but Qt failed to
+    // generate QEvent::WinIdChange event so we have no way to know that. We have to set
+    // some X11 window properties using the native winId() to make it a dock, but this stop working
+    // because we cannot get the correct winId(), so this causes #204 and #205.
+    //
+    // The workaround is very simple. Just completely destroy the panel before Qt has a chance to do
+    // QWindow::setScreen() for it. Later, we reload the panel ourselves. So this can bypassing the Qt bugs.
+    QScreen* screen = static_cast<QScreen*>(screenObj);
+    bool reloadNeeded = false;
+    qApp->setQuitOnLastWindowClosed(false);
+    Q_FOREACH(LxQtPanel* panel, mPanels)
+    {
+        QWindow* panelWindow = panel->windowHandle();
+        if(panelWindow && panelWindow->screen() == screen)
+        {
+            // the screen containing the panel is destroyed
+            // delete and then re-create the panel ourselves
+            QString name = panel->name();
+            panel->saveSettings(false);
+            delete panel; // delete the panel, so Qt does not have a chance to set a new screen to it.
+            mPanels.removeAll(panel);
+            reloadNeeded = true;
+            qDebug() << "Workaround Qt 5 bug #40681: delete panel:" << name;
+        }
+    }
+    if(reloadNeeded)
+        QTimer::singleShot(1000, this, SLOT(reloadPanelsAsNeeded()));
+    else
+        qApp->setQuitOnLastWindowClosed(true);
+#endif
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-
 // Qt5 uses native event filter
 bool LxQtPanelApplication::nativeEventFilter(const QByteArray & eventType, void * message, long * result)
 {

--- a/panel/lxqtpanelapplication.h
+++ b/panel/lxqtpanelapplication.h
@@ -36,6 +36,8 @@
 #include <QAbstractNativeEventFilter>
 #endif
 
+class QScreen;
+
 class LxQtPanel;
 namespace LxQt {
 class Settings;
@@ -70,10 +72,17 @@ public slots:
 private:
     QList<LxQtPanel*> mPanels;
 
-    void addPanel(const QString &name);
+    LxQtPanel* addPanel(const QString &name);
 
 private slots:
     void removePanel(LxQtPanel* panel);
+
+    // These slots are for Qt 5 onlt, but the stupid Qt moc cannot do conditional compilation
+    // so we have to provide them for Qt 4 as well.
+    void handleScreenAdded(QScreen* newScreen);
+    void screenDestroyed(QObject* screenObj);
+    void reloadPanelsAsNeeded();
+    // end Qt5 only slots
 
 private:
     LxQt::Settings *mSettings;

--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -78,7 +78,8 @@ LxQtTray::LxQtTray(ILxQtPanelPlugin *plugin, QWidget *parent):
     mDamageEvent(0),
     mDamageError(0),
     mIconSize(TRAY_ICON_SIZE_DEFAULT, TRAY_ICON_SIZE_DEFAULT),
-    mPlugin(plugin)
+    mPlugin(plugin),
+    mDisplay(QX11Info::display())
 {
     mLayout = new LxQt::GridLayout(this);
     realign();
@@ -246,7 +247,7 @@ TrayIcon* LxQtTray::findIcon(Window id)
 void LxQtTray::setIconSize(QSize iconSize)
 {
     unsigned long size = qMin(mIconSize.width(), mIconSize.height());
-    XChangeProperty(QX11Info::display(),
+    XChangeProperty(mDisplay,
                     mTrayId,
                     xfitMan().atom("_NET_SYSTEM_TRAY_ICON_SIZE"),
                     XA_CARDINAL,
@@ -267,7 +268,7 @@ void LxQtTray::setIconSize(QSize iconSize)
 VisualID LxQtTray::getVisual()
 {
     VisualID visualId = 0;
-    Display* dsp = QX11Info::display();
+    Display* dsp = mDisplay;
 
     XVisualInfo templ;
     templ.screen=QX11Info::appScreen();
@@ -304,7 +305,7 @@ VisualID LxQtTray::getVisual()
  ************************************************/
 void LxQtTray::startTray()
 {
-    Display* dsp = QX11Info::display();
+    Display* dsp = mDisplay;
     Window root = QX11Info::appRootWindow();
 
     QString s = QString("_NET_SYSTEM_TRAY_S%1").arg(DefaultScreen(dsp));
@@ -343,7 +344,7 @@ void LxQtTray::startTray()
     VisualID visualId = getVisual();
     if (visualId)
     {
-        XChangeProperty(QX11Info::display(),
+        XChangeProperty(mDisplay,
                         mTrayId,
                         xfitMan().atom("_NET_SYSTEM_TRAY_VISUAL"),
                         XA_VISUALID,
@@ -368,7 +369,7 @@ void LxQtTray::startTray()
     ev.data.l[4] = 0;
     XSendEvent(dsp, root, False, StructureNotifyMask, (XEvent*)&ev);
 
-    XDamageQueryExtension(QX11Info::display(), &mDamageEvent, &mDamageError);
+    XDamageQueryExtension(mDisplay, &mDamageEvent, &mDamageError);
 
     qDebug() << "Systray started";
     mValid = true;
@@ -383,7 +384,7 @@ void LxQtTray::stopTray()
     qDeleteAll(mIcons);
     if (mTrayId)
     {
-        XDestroyWindow(QX11Info::display(), mTrayId);
+        XDestroyWindow(mDisplay, mTrayId);
         mTrayId = 0;
     }
     mValid = false;

--- a/plugin-tray/lxqttray.h
+++ b/plugin-tray/lxqttray.h
@@ -86,6 +86,7 @@ private:
     LxQt::GridLayout *mLayout;
     ILxQtPanelPlugin *mPlugin;
     Atom _NET_SYSTEM_TRAY_OPCODE;
+    Display* mDisplay;
 };
 
 

--- a/plugin-tray/trayicon.h
+++ b/plugin-tray/trayicon.h
@@ -72,6 +72,7 @@ private:
     bool mValid;
     QSize mIconSize;
     Damage mDamage;
+    Display* mDisplay;
 
     static bool isXCompositeAvailable();
 };


### PR DESCRIPTION
- Workaround for Qt 5 bug #40681 by monitoring QScreen::destroyed() and re-create affected panels manually.
- This closes lxde/lxde-qt bug #204, #205, and #206 at the same time.
- Store the result of QX11Info::display() and avoid repeated calls to the methods.
  (When called during the primary screen being destroyed, QX11Info::display() crashes.)
