### PR TITLE
Avoid using XdgDesktopFileCache to speed up program startup by 20%.

### DIFF
--- a/plugin-quicklaunch/CMakeLists.txt
+++ b/plugin-quicklaunch/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HEADERS
   lxqtquicklaunch.h
   quicklaunchbutton.h
   quicklaunchaction.h
+  desktopfile.h
 )
 
 set(SOURCES
@@ -19,6 +20,7 @@ set(SOURCES
   lxqtquicklaunch.cpp
   quicklaunchbutton.cpp
   quicklaunchaction.cpp
+  desktopfile.cpp
 )
 
 set(MOCS

--- a/plugin-quicklaunch/desktopfile.cpp
+++ b/plugin-quicklaunch/desktopfile.cpp
@@ -1,0 +1,56 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXDE-Qt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2014 LXQt team
+ * Authors:
+ *   Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include <XdgDesktopFile>
+#include <XdgDirs>
+#include <QDir>
+#include <QDebug>
+
+bool loadDesktopFile(XdgDesktopFile& xdg, QString fileName)
+{
+	if(fileName.startsWith(QDir::separator())) // absolute path
+	    return xdg.load(fileName);
+
+	// desktop file name
+    QStringList dataDirs = XdgDirs::dataDirs();
+    dataDirs.prepend(XdgDirs::dataHome(false));
+    foreach (const QString dirname, dataDirs)
+    {
+		for(int sep = 0; ; ++sep)
+		{
+			QString filePath = dirname + "/applications/" + fileName;
+			qDebug() << "load: " << filePath;
+			if(xdg.load(filePath))
+				return xdg.isValid();
+			sep = fileName.indexOf('-', sep);
+			if(sep == -1)
+                break;
+            fileName[sep] = '/';
+		}
+    }
+    return false;
+}

--- a/plugin-quicklaunch/desktopfile.h
+++ b/plugin-quicklaunch/desktopfile.h
@@ -1,0 +1,37 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXDE-Qt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2014 LXQt team
+ * Authors:
+ *   Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#ifndef _DESKTOPFILE_H_
+#define _DESKTOPFILE_H_
+
+#include <QString>
+
+class XdgDesktopFile;
+
+bool loadDesktopFile(XdgDesktopFile& xdg, QString fileName);
+
+#endif

--- a/plugin-quicklaunch/lxqtquicklaunch.cpp
+++ b/plugin-quicklaunch/lxqtquicklaunch.cpp
@@ -46,6 +46,7 @@
 #include <QFileIconProvider>
 #include <QSettings>
 #include <QLabel>
+#include "desktopfile.h"
 
 LxQtQuickLaunch::LxQtQuickLaunch(ILxQtPanelPlugin *plugin, QWidget* parent) :
     QFrame(parent),
@@ -72,19 +73,19 @@ LxQtQuickLaunch::LxQtQuickLaunch(ILxQtPanelPlugin *plugin, QWidget* parent) :
         file = settings->value("file", "").toString();
         if (! desktop.isEmpty())
         {
-            XdgDesktopFile * xdg = XdgDesktopFileCache::getFile(desktop);
-            if (!xdg->isValid())
+            XdgDesktopFile xdg;
+            if(!loadDesktopFile(xdg, desktop))
             {
                 qDebug() << "XdgDesktopFile" << desktop << "is not valid";
                 continue;
             }
-            if (!xdg->isSuitable())
+            if (!xdg.isSuitable())
             {
                 qDebug() << "XdgDesktopFile" << desktop << "is not applicable";
                 continue;
             }
 
-            addButton(new QuickLaunchAction(xdg, this));
+            addButton(new QuickLaunchAction(&xdg, this));
         }
         else if (! file.isEmpty())
         {
@@ -204,13 +205,13 @@ void LxQtQuickLaunch::dropEvent(QDropEvent *e)
         QString fileName(url.toLocalFile());
         #endif
 
-        XdgDesktopFile * xdg = XdgDesktopFileCache::getFile(fileName);
+		XdgDesktopFile xdg;
         QFileInfo fi(fileName);
 
-        if (xdg->isValid())
+        if (loadDesktopFile(xdg, fileName))
         {
-            if (xdg->isSuitable())
-                addButton(new QuickLaunchAction(xdg, this));
+            if (xdg.isSuitable())
+                addButton(new QuickLaunchAction(&xdg, this));
         }
         else if (fi.exists() && fi.isExecutable() && !fi.isDir())
         {

--- a/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/plugin-quicklaunch/quicklaunchaction.cpp
@@ -39,7 +39,7 @@
 #include <XdgDesktopFile>
 #include <XdgIcon>
 #include <XdgMimeType>
-
+#include "desktopfile.h"
 
 QuickLaunchAction::QuickLaunchAction(const QString & name,
                                      const QString & exec,
@@ -121,9 +121,9 @@ void QuickLaunchAction::execAction()
             break;
         case ActionXdg:
         {
-            XdgDesktopFile * xdg = XdgDesktopFileCache::getFile(exec);
-            if (xdg->isValid())
-                xdg->startDetached();
+            XdgDesktopFile xdg;
+            if(loadDesktopFile(xdg, exec))
+                xdg.startDetached();
             break;
         }
         case ActionFile:


### PR DESCRIPTION
The original code used XdgDesktopFileCache::getFile() to load the desktop files for the quick launch buttons.
When this method is called the first time, it tries to search for all *.desktop files installed in the system.
This large amount of I/O can block program startup for several seconds.
I use callgrind to profiling lxqt-panel and it showed that this cost 20-23% of total execution time, which is quite a lot.
The intention of using this is, the mainmenu plugin also needs to load all app desktop files.
So quick launch and mainmenu can share the cache and reduce I/O. However, this is still slow.
When compiled with menu-cache support, mainmenu plugin loads a cached version of app menu without parsing any *.desktop files.
Unless the cache is invalidated and requires reload, this is a very fast operation.
In this case, mainmenu no longer need the XdgDesktopFileCache, so loading all app dirs just to look up several files for quicklaunch becomes the bottle neck of lxqt-panel startup.

In this patch, I load the desktop files directly instead of searching in the cache. This actually is much faster because:
1. When menu-cache is enabled, we avoid loading all *.desktop files and only load what we need, so it's much faster.
2. When menu-cache is disabled, all *.desktop files are just read by the mainmenu plugin so these files are still in the filesystem cache of the OS. So loading these files again from quicklaunch is still as fast even without our own cache.
3. If the user does not use mainmenu and only uses quicklaunch plugin, then it's the same as case #1, so it's still faster.

Please help review and test the patch and hopefully you can accept it.
Thank you.
