### PR TITLE
Fix #271 - translation in liblxqt. Use /usr/share/lxqt for all components

### DIFF
--- a/cmake/LxQtTranslate.cmake
+++ b/cmake/LxQtTranslate.cmake
@@ -69,7 +69,7 @@ endif()
 
 function(lxqt_translate_ts _qmFiles)
     set(_translationDir "translations")
-    set(_installDir "${CMAKE_INSTALL_PREFIX}/share/${LXQT_LIBRARY}/${PROJECT_NAME}")
+    set(_installDir "${CMAKE_INSTALL_PREFIX}/share/lxqt/${PROJECT_NAME}")
     
     # Parse arguments ***************************************
     set(_state "")


### PR DESCRIPTION
Previously, some components install files to /usr/share/lxqt-qt5, which caused inconsistency and broken translations. All components should install data files to /usr/share/lxqt. This patch fix the bug.
