### PR TITLE
Relax limits on size and update frequency

### DIFF
--- a/plugin-sysstat/lxqtsysstatconfiguration.ui
+++ b/plugin-sysstat/lxqtsysstatconfiguration.ui
@@ -86,7 +86,7 @@
            <number>2</number>
           </property>
           <property name="maximum">
-           <number>120</number>
+           <number>500</number>
           </property>
           <property name="value">
            <number>30</number>
@@ -102,13 +102,13 @@
            <number>1</number>
           </property>
           <property name="minimum">
-           <double>0.500000000000000</double>
+           <double>0.100000000000000</double>
           </property>
           <property name="maximum">
            <double>60.000000000000000</double>
           </property>
           <property name="singleStep">
-           <double>0.500000000000000</double>
+           <double>0.250000000000000</double>
           </property>
           <property name="value">
            <double>1.000000000000000</double>


### PR DESCRIPTION
The current size and frequency limits appear arbitrary. Some users (like me) might want a higher update frequency and/or larger size of the plot. This patch grants them. 100ms is the new lower bound. I understand that lower values might eat up the CPU. The user should realize this latest by looking at the plot itself..
