### PR TITLE
Network Monitor plugin: fix faulty German translation

### DIFF
--- a/plugin-networkmonitor/translations/networkmonitor_de.desktop
+++ b/plugin-networkmonitor/translations/networkmonitor_de.desktop
@@ -5,9 +5,6 @@ ServiceTypes=LxQtPanel/Plugin
 Name=Network monitor
 Comment=Displays network status and activity.
 
-
-
-
 # Translations
-Comment[de]=LxQt Konfigurations Center
-Name[de]=Bildschirm Notizblock
+Name[de]=Netzwerk Monitor
+Comment[de]=Informationen zu Status und Aktivität des Netzwerks


### PR DESCRIPTION
This pull request fixes the German translation as part of the problem described in https://github.com/lxde/lxqt/issues/409.

In addition to this commit I'd strongly suggest to drop networkmonitor_de_DE.{desktop,ts}. There's hardly any difference regarding those technical terms among German speaking countries, imo.
