### PR TITLE
 Allow to set tray icon size independently from the panel's icon size

### DIFF
--- a/plugin-tray/CMakeLists.txt
+++ b/plugin-tray/CMakeLists.txt
@@ -15,6 +15,7 @@ pkg_check_modules(XRENDER REQUIRED xrender)
 set(HEADERS
     lxqttrayplugin.h
     lxqttray.h
+    lxqttrayconfiguration.h
     trayicon.h
     xfitman.h
 )
@@ -22,6 +23,7 @@ set(HEADERS
 set(SOURCES
     lxqttrayplugin.cpp
     lxqttray.cpp
+    lxqttrayconfiguration.cpp
     trayicon.cpp
     xfitman.cpp
 )
@@ -33,6 +35,10 @@ set(LIBRARIES
     ${XRENDER_LIBRARIES}
     ${XCB_LIBRARIES}
     ${XCB_DAMAGE_LIBRARIES}
+)
+
+set(UIS
+    lxqttrayconfiguration.ui
 )
 
 BUILD_LXQT_PLUGIN(${PLUGIN})

--- a/plugin-tray/lxqttray.h
+++ b/plugin-tray/lxqttray.h
@@ -63,6 +63,9 @@ public:
     bool nativeEventFilter(const QByteArray &eventType, void *message, long *);
 
     void realign();
+    
+    void enableForcedIconSize(QSize iconSize);
+    void disableForcedIconSize();
 
 signals:
     void iconSizeChanged(int iconSize);
@@ -97,6 +100,13 @@ private:
     ILXQtPanelPlugin *mPlugin;
     Atom _NET_SYSTEM_TRAY_OPCODE;
     Display* mDisplay;
+    
+    // HACK to avoid having an unique global size policy for icons
+    /** This code is here to act as a customizable 'qproperty-iconSize' for
+     * system tray icons, as it seems this property isn't honored in CSS sheets.
+     */
+    bool mForceIconSize;
+    QSize mForcedIconSize;
 };
 
 

--- a/plugin-tray/lxqttrayconfiguration.cpp
+++ b/plugin-tray/lxqttrayconfiguration.cpp
@@ -1,0 +1,71 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXDE-Qt - a lightweight, Qt based, desktop toolset
+ * http://razor-qt.org
+ *
+ * Copyright: 2011 Razor team
+ * Authors:
+ *   Corentin Ferry <cferr@openmailbox.org>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+
+#include <QInputDialog>
+#include <QStandardItemModel>
+#include <QStandardItem>
+
+#include "lxqttrayconfiguration.h"
+#include "ui_lxqttrayconfiguration.h"
+
+LXQtTrayConfiguration::LXQtTrayConfiguration(PluginSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::LXQtTrayConfiguration)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setObjectName("TrayConfigurationWindow");
+    ui->setupUi(this);
+
+    //connect(ui->buttons, SIGNAL(clicked(QAbstractButton*)), SLOT(dialogButtonsAction(QAbstractButton*)));
+
+    loadSettings();
+    
+    connect(ui->buttons, SIGNAL(accepted()), SLOT(saveSettings()));
+    connect(ui->buttons, SIGNAL(rejected()), SLOT(reject()));
+}
+
+LXQtTrayConfiguration::~LXQtTrayConfiguration()
+{
+    delete ui;
+}
+
+void LXQtTrayConfiguration::loadSettings()
+{
+    /* Let's specify a custom icon size of 16px by default. There's nothing wrong
+       in setting it hard there, as the option isn't checked by default */
+    ui->useCustomSizeCB->setChecked(settings().value("useCustomTrayIconSize", false).toBool());
+    ui->iconSizeSB->setValue(settings().value("customTrayIconSize", TRAY_ICON_SIZE_DEFAULT).toInt());
+}
+
+void LXQtTrayConfiguration::saveSettings()
+{
+    settings().setValue("useCustomTrayIconSize", ui->useCustomSizeCB->isChecked());
+    settings().setValue("customTrayIconSize", ui->iconSizeSB->value());
+    
+    this->accept();
+}

--- a/plugin-tray/lxqttrayconfiguration.h
+++ b/plugin-tray/lxqttrayconfiguration.h
@@ -1,0 +1,69 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXDE-Qt - a lightweight, Qt based, desktop toolset
+ * http://razor-qt.org
+ *
+ * Copyright: 2011 Razor team
+ * Authors:
+ *   Corentin Ferry <cferr@openmailbox.org>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+
+#ifndef LXQTTRAYCONFIGURATION_H
+#define LXQTTRAYCONFIGURATION_H
+
+
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include "../panel/pluginsettings.h"
+
+#define TRAY_ICON_SIZE_DEFAULT 24
+
+#include <QObject>
+#include <QAbstractButton>
+
+namespace Ui {
+    class LXQtTrayConfiguration;
+}
+
+class LXQtTrayConfiguration : public LXQtPanelPluginConfigDialog
+{
+    Q_OBJECT
+
+public:
+    explicit LXQtTrayConfiguration(PluginSettings *settings, QWidget *parent = 0);
+    ~LXQtTrayConfiguration();
+
+private:
+    Ui::LXQtTrayConfiguration *ui;
+
+    /*
+      Read settings from conf file and put data into controls.
+    */
+    void loadSettings();
+
+private slots:
+    /*
+      Saves settings in conf file.
+    */
+    void saveSettings();
+
+};
+
+#endif // LXQTTRAYCONFIGURATION_H

--- a/plugin-tray/lxqttrayconfiguration.ui
+++ b/plugin-tray/lxqttrayconfiguration.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LXQtTrayConfiguration</class>
+ <widget class="QDialog" name="LXQtTrayConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>309</width>
+    <height>137</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Tray Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="iconSizeGB">
+     <property name="title">
+      <string>Icon size</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="useCustomSizeCB">
+        <property name="text">
+         <string>Use a custom size for system tray icons</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="iconSizeL">
+          <property name="text">
+           <string>Icon size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="iconSizeSB">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>1107</height>
+           </size>
+          </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
+          <property name="minimum">
+           <number>5</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/plugin-tray/lxqttrayplugin.cpp
+++ b/plugin-tray/lxqttrayplugin.cpp
@@ -25,15 +25,20 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#include <iostream>
 
 #include "lxqttrayplugin.h"
 #include "lxqttray.h"
 
+#define TRAY_ICON_SIZE_DEFAULT 24
+
 LXQtTrayPlugin::LXQtTrayPlugin(const ILXQtPanelPluginStartupInfo &startupInfo) :
     QObject(),
     ILXQtPanelPlugin(startupInfo),
-    mWidget(new LXQtTray(this))
+    mWidget(new LXQtTray(this)),
+    mIconSize(TRAY_ICON_SIZE_DEFAULT)
 {
+    settingsChanged();
 }
 
 LXQtTrayPlugin::~LXQtTrayPlugin()
@@ -51,4 +56,19 @@ void LXQtTrayPlugin::realign()
     mWidget->realign();
 }
 
+QDialog * LXQtTrayPlugin::configureDialog()
+{
+     return new LXQtTrayConfiguration(settings());
+}
 
+void LXQtTrayPlugin::settingsChanged()
+{
+    bool useCustomSize = settings()->value("useCustomTrayIconSize", false).toBool();
+    if(useCustomSize) {
+        mIconSize = settings()->value("customTrayIconSize", TRAY_ICON_SIZE_DEFAULT).toInt();
+        mWidget->enableForcedIconSize(QSize(mIconSize, mIconSize));
+    }
+    else
+        mWidget->disableForcedIconSize();
+    
+}

--- a/plugin-tray/lxqttrayplugin.h
+++ b/plugin-tray/lxqttrayplugin.h
@@ -30,6 +30,7 @@
 #define LXQTTRAYPLUGIN_H
 
 #include "../panel/ilxqtpanelplugin.h"
+#include "lxqttrayconfiguration.h"
 #include <QObject>
 
 class LXQtTray;
@@ -42,13 +43,17 @@ public:
 
     virtual QWidget *widget();
     virtual QString themeId() const { return "Tray"; }
-    virtual Flags flags() const { return  PreferRightAlignment | SingleInstance | NeedsHandle; }
+    virtual Flags flags() const { return  PreferRightAlignment | SingleInstance | NeedsHandle | HaveConfigDialog; }
     void realign();
 
     bool isSeparate() const { return true; }
-
+    QDialog * configureDialog();
+    
+    void settingsChanged();
+    
 private:
     LXQtTray *mWidget;
+    int mIconSize;
 
 };
 


### PR DESCRIPTION
Because of the "Icon Size" setting relative to the panel, and the way it is applied -by setting a custom style sheet, in `LXQtPanel::updateStyleSheet()`-, the `qproperty-iconSize` property in user-specified QSS stylesheets for the panel isn't honored.

To get around this issue, I've added a configuration dialog to the system tray, in which the user can set a custom size for tray icons: they may want to have them smaller than the rest of the panel button icons. 
If a custom size is set, then a stylesheet overrides the global panel stylesheet and sets the icon size according to user preferences.

Please note that the files `lxqttrayconfiguration.cpp` and `lxqttrayconfiguration.h` come straight from the clock plugin, and they've been modified to fit my purpose.

By the way, how icon size is set in `LXQtPanel::updateStyleSheet()` isn't a really clean method: my opinion is that there should be a way for user-defined stylesheets to override settings applied via stylesheets in here... Any ideas on why this isn't done this way / how to do that?
