### PR TITLE
plugin-kbindicator: Go directly to the Keyboard Layout config page

### DIFF
--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -24,8 +24,11 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#include <LXQt/Globals>
+
 #include <QDebug>
 #include <QProcess>
+
 #include "kbdstateconfig.h"
 #include "ui_kbdstateconfig.h"
 #include "settings.h"
@@ -106,5 +109,5 @@ void KbdStateConfig::save()
 
 void KbdStateConfig::configureLayouts()
 {
-    QProcess::startDetached(QLatin1String("lxqt-config-input"));
+    QProcess::startDetached(QL1S("lxqt-config-input --show-page \"Keyboard Layout\""));
 }


### PR DESCRIPTION
Previously the 'Configure layouts' button opened the config-input dialog in
the default (Mouse) page.
Now it opens in the 'Keyboard Layout' page. That's more user friendly.