### PR TITLE
Qt 5.11 beta: lxqtmainmenuconfiguration.cpp: include QAction explicitely

### DIFF
--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -33,6 +33,7 @@
 #include <lxqt-globalkeys.h>
 #include <LXQt/Settings>
 
+#include <QAction>
 #include <QFileDialog>
 
 LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, GlobalKeyShortcut::Action * shortcut, const QString &defaultShortcut, QWidget *parent) :


### PR DESCRIPTION
5.11 Qt headers do not indirectly include QAction resulting in compile
time errors like:
| lxqtmainmenuconfiguration.cpp:71:105: error: no matching function for call to 'LXQtMainMenuConfiguration::connect(QAction*, const char [13], LXQtMainMenuConfiguration*, const char [17])'

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>