### PR TITLE
Optional overriding of icon theme for panels

### DIFF
--- a/panel/config/configpaneldialog.cpp
+++ b/panel/config/configpaneldialog.cpp
@@ -56,3 +56,8 @@ void ConfigPanelDialog::showConfigPluginsPage()
 {
     showPage(mPluginsPage);
 }
+
+void ConfigPanelDialog::updateIconThemeSettings()
+{
+    mPanelPage->updateIconThemeSettings();
+}

--- a/panel/config/configpaneldialog.h
+++ b/panel/config/configpaneldialog.h
@@ -43,6 +43,7 @@ public:
 
     void showConfigPanelPage();
     void showConfigPluginsPage();
+    void updateIconThemeSettings();
 
 private:
     ConfigPanelWidget *mPanelPage;

--- a/panel/config/configpanelwidget.h
+++ b/panel/config/configpanelwidget.h
@@ -49,6 +49,7 @@ public:
 
     int screenNum() const { return mScreenNum; }
     ILXQtPanel::Position position() const { return mPosition; }
+    void updateIconThemeSettings();
 
 signals:
     void changed();
@@ -73,6 +74,7 @@ private:
     void addPosition(const QString& name, int screen, LXQtPanel::Position position);
     void fillComboBox_position();
     void fillComboBox_alignment();
+    void fillComboBox_icon();
     int indexForPosition(int screen, ILXQtPanel::Position position);
     int getMaxLength();
 

--- a/panel/config/configpanelwidget.ui
+++ b/panel/config/configpanelwidget.ui
@@ -555,6 +555,44 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_icon">
+     <property name="toolTip">
+      <string>A partial workaround for widget styles that
+cannot give a separate theme to the panel.
+
+You might also want to disable:
+
+LXQt Appearance Configuration →
+Icons Theme →
+Colorize icons based on widget style (palette)</string>
+     </property>
+     <property name="title">
+      <string>Override icon &amp;theme</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <property name="formAlignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Icon theme for panels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboBox_icon"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1362,6 +1362,28 @@ void LXQtPanel::setShowDelay(int showDelay, bool save)
         saveSettings(true);
 }
 
+QString LXQtPanel::iconTheme() const
+{
+    return mSettings->value("iconTheme").toString();
+}
+
+void LXQtPanel::setIconTheme(const QString& iconTheme)
+{
+    LXQtPanelApplication *a = reinterpret_cast<LXQtPanelApplication*>(qApp);
+    a->setIconTheme(iconTheme);
+}
+
+void LXQtPanel::updateConfigDialog() const
+{
+    if (!mConfigDialog.isNull() && mConfigDialog->isVisible())
+    {
+        mConfigDialog->updateIconThemeSettings();
+        const QList<QWidget*> widgets = mConfigDialog->findChildren<QWidget*>();
+        for (QWidget *widget : widgets)
+            widget->update();
+    }
+}
+
 bool LXQtPanel::isPluginSingletonAndRunnig(QString const & pluginId) const
 {
     Plugin const * plugin = mPlugins->pluginByID(pluginId);

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -223,6 +223,7 @@ public:
     bool hidable() const { return mHidable; }
     int animationTime() const { return mAnimationTime; }
     int showDelay() const { return mShowDelayTimer.interval(); }
+    QString iconTheme() const;
 
     /*!
      * \brief Checks if a given Plugin is running and has the
@@ -233,6 +234,11 @@ public:
      * ILXQtPanelPlugin::SingleInstance flag set, false otherwise.
      */
     bool isPluginSingletonAndRunnig(QString const & pluginId) const;
+    /*!
+     * \brief Updates the config dialog. Used for updating its icons
+     * when the panel-specific icon theme changes.
+     */
+    void updateConfigDialog() const;
 
 public slots:
     /**
@@ -300,6 +306,7 @@ public slots:
     void setHidable(bool hidable, bool save); //!< \sa setPanelSize()
     void setAnimationTime(int animationTime, bool save); //!< \sa setPanelSize()
     void setShowDelay(int showDelay, bool save); //!< \sa setPanelSize()
+    void setIconTheme(const QString& iconTheme);
 
     /**
      * @brief Saves the current configuration, i.e. writes the current
@@ -550,7 +557,7 @@ private:
      * @brief Stores if mLength is stored in pixels or relative to the
      * screen size in percents. If true, the length is stored in percents,
      * otherwise in pixels.
-     * 
+     *
      * \sa mLength
      */
     bool mLengthInPercents;

--- a/panel/lxqtpanelapplication.h
+++ b/panel/lxqtpanelapplication.h
@@ -69,12 +69,14 @@ public:
     explicit LXQtPanelApplication(int& argc, char** argv);
     ~LXQtPanelApplication();
 
+    void setIconTheme(const QString &iconTheme);
+
     /*!
      * \brief Determines the number of LXQtPanel objects
      * \return the current number of LXQtPanel objects
      */
-    int count() { return mPanels.count(); }
-    
+    int count() const { return mPanels.count(); }
+
     /*!
      * \brief Checks if a given Plugin is running and has the
      * ILXQtPanelPlugin::SingleInstance flag set. As Plugins are added to
@@ -122,6 +124,10 @@ private:
      * \brief Holds all the instances of LXQtPanel.
      */
     QList<LXQtPanel*> mPanels;
+    /*!
+     * \brief The global icon theme used by all apps (except for panels perhaps).
+     */
+    QString mGlobalIconTheme;
     /*!
      * \brief Creates a new LXQtPanel with the given name and connects the
      * appropriate signals and slots.


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/470

When a light widget style is used with a dark panel, the symbolic SVG icons follow the style and become dark on the panel. The right way of solving such issues is assigning a dark widget style to the panel but neither Fusion nor Breeze can do that.

This patch is about the "wrong way". It gives a separate icon set to the panel with unavoidable side effects but is optional and may be used as the last resort.