### PR TITLE
spacer: Change type of mExpandable

### DIFF
--- a/plugin-spacer/spacer.h
+++ b/plugin-spacer/spacer.h
@@ -77,7 +77,7 @@ private:
 private:
     SpacerWidget mSpacer;
     int mSize;
-    int mExpandable;
+    bool mExpandable;
 };
 
 class SpacerPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
It is always used as a boolen and assigned boolean values, so change the
type from int to bool.