### PR TITLE
directory menu: Open in terminal

### DIFF
--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -31,6 +31,7 @@
 #include <QDebug>
 #include <QDesktopServices>
 #include <QProcess>
+#include <QStringList>
 #include <QFileInfo>
 #include <QUrl>
 #include <QIcon>
@@ -107,8 +108,11 @@ void DirectoryMenu::openDirectory(const QString& path)
 
 void DirectoryMenu::openInTerminal(const QString& path)
 {
-    QString action = mDefaultTerminal + " --workdir " + path;
-    QProcess::startDetached(action);
+    // Create list of arguments
+    QStringList args;
+    args << "--workdir" << QDir::toNativeSeparators(path);
+    // Execute the default terminal program with arguments
+    QProcess::startDetached(mDefaultTerminal, args);
 }
 
 void DirectoryMenu::addMenu(QString path)

--- a/plugin-directorymenu/directorymenu.h
+++ b/plugin-directorymenu/directorymenu.h
@@ -58,6 +58,7 @@ public:
 private slots:
     void showMenu();
     void openDirectory(const QString& path);
+    void openInTerminal(const QString &path);
     void addMenu(QString path);
 
 protected slots:
@@ -69,11 +70,13 @@ private:
     QToolButton mButton;
     QMenu *mMenu;
     QSignalMapper *mOpenDirectorySignalMapper;
+    QSignalMapper *mOpenTerminalSignalMapper; // New singal mapper to opening direcotry in term
     QSignalMapper *mMenuSignalMapper;
 
     QDir mBaseDirectory;
     QIcon mDefaultIcon;
     std::vector<QString> mPathStrings;
+    QString mDefaultTerminal;
 };
 
 class DirectoryMenuLibrary: public QObject, public ILXQtPanelPluginLibrary

--- a/plugin-directorymenu/directorymenuconfiguration.cpp
+++ b/plugin-directorymenu/directorymenuconfiguration.cpp
@@ -41,7 +41,8 @@ DirectoryMenuConfiguration::DirectoryMenuConfiguration(PluginSettings *settings,
     LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::DirectoryMenuConfiguration),
     mBaseDirectory(QDir::homePath()),
-    mDefaultIcon(XdgIcon::fromTheme("folder"))
+    mDefaultIcon(XdgIcon::fromTheme("folder")),
+    mDefaultTerminal("/usr/bin/qterminal")
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("DirectoryMenuConfigurationWindow");
@@ -54,6 +55,7 @@ DirectoryMenuConfiguration::DirectoryMenuConfiguration(PluginSettings *settings,
 
     connect(ui->baseDirectoryB, SIGNAL(clicked()), SLOT(showDirectoryDialog()));
     connect(ui->iconB, SIGNAL(clicked()), SLOT(showIconDialog()));
+    connect(ui->terminalB, SIGNAL(clicked()), SLOT(showTermDialog()));
 }
 
 DirectoryMenuConfiguration::~DirectoryMenuConfiguration()
@@ -78,12 +80,15 @@ void DirectoryMenuConfiguration::loadSettings()
     }
 
     ui->iconB->setIcon(mDefaultIcon);
+
+    ui->terminalB->setText(settings().value("defaultTerminal", QString()).toString());
 }
 
 void DirectoryMenuConfiguration::saveSettings()
 {
     settings().setValue("baseDirectory", mBaseDirectory.absolutePath());
     settings().setValue("icon", mIcon);
+    settings().setValue("defaultTerminal", mDefaultTerminal);
 }
 
 void DirectoryMenuConfiguration::showDirectoryDialog()
@@ -100,6 +105,20 @@ void DirectoryMenuConfiguration::showDirectoryDialog()
 
         saveSettings();
     }
+}
+
+void DirectoryMenuConfiguration::showTermDialog()
+{
+    QFileDialog d(this, tr("Choose Default Terminal"), "/usr/bin");
+    d.setFileMode(QFileDialog::ExistingFile);
+    d.setWindowModality(Qt::WindowModal);
+    
+    if (d.exec() && !d.selectedFiles().isEmpty())
+    {
+        mDefaultTerminal = d.selectedFiles().front();
+        saveSettings();
+    }
+    ui->terminalB->setText(mDefaultTerminal);
 }
 
 void DirectoryMenuConfiguration::showIconDialog()

--- a/plugin-directorymenu/directorymenuconfiguration.h
+++ b/plugin-directorymenu/directorymenuconfiguration.h
@@ -55,6 +55,7 @@ private:
     QDir mBaseDirectory;
     QString mIcon;
     QIcon mDefaultIcon;
+    QString mDefaultTerminal;
 
     /*
       Read settings from conf file and put data into controls.
@@ -68,6 +69,7 @@ private slots:
     void saveSettings();
     void showDirectoryDialog();
     void showIconDialog();
+    void showTermDialog();
 
 private:
 };

--- a/plugin-directorymenu/directorymenuconfiguration.ui
+++ b/plugin-directorymenu/directorymenuconfiguration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>342</width>
-    <height>168</height>
+    <height>195</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,6 +57,20 @@
         </property>
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="terminalL">
+        <property name="text">
+         <string>Terminal</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="terminalB">
+        <property name="text">
+         <string>Choose Default Terminal</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In issue lxqt/lxqt#1557, I proposed adding a feature to the directory menu plugin that would allow the user to open a selected terminal. I already have almost all of the code written, so I figured I would submit it. So far, it supports QTerminal and Konsole. I plan on adding support for xterm as well.