### PR TITLE
plugin-mount: fix a small typo in the UI string

### DIFF
--- a/plugin-mount/configuration.ui
+++ b/plugin-mount/configuration.ui
@@ -23,7 +23,7 @@
       <item>
        <widget class="QLabel" name="devAddedLabel">
         <property name="text">
-         <string>When a device is connected :</string>
+         <string>When a device is connected:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
cast @paulolieuthier 

See: https://github.com/lxqt/lxqt-panel/commit/b1985c2d81abbfff95b4bb636ed726b58870cdf0#diff-efb2349ba1b275391f1998388d043c55R26