### PR TITLE
mount: Store device names to show them upon remove

### DIFF
--- a/plugin-mount/actions/deviceaction.cpp
+++ b/plugin-mount/actions/deviceaction.cpp
@@ -83,12 +83,14 @@ QString DeviceAction::actionIdToString(DeviceAction::ActionId id)
 
 void DeviceAction::onDeviceAdded(Solid::Device device)
 {
+    mKnownDeviceDescriptions[device.udi()] = device.description();
     doDeviceAdded(device);
 }
 
 void DeviceAction::onDeviceRemoved(Solid::Device device)
 {
     doDeviceRemoved(device);
+    mKnownDeviceDescriptions.remove(device.udi());
 }
 
 DeviceAction::ActionId DeviceAction::stringToActionId(const QString &string, ActionId defaultValue)

--- a/plugin-mount/actions/deviceaction.h
+++ b/plugin-mount/actions/deviceaction.h
@@ -63,6 +63,7 @@ protected:
     virtual void doDeviceRemoved(Solid::Device device) = 0;
 
     LXQtMountPlugin *mPlugin;
+    QMap<QString/*!< device udi*/, QString/*!< device description*/> mKnownDeviceDescriptions;
 };
 
 #endif // DEVICEACTION_H

--- a/plugin-mount/actions/deviceaction_info.cpp
+++ b/plugin-mount/actions/deviceaction_info.cpp
@@ -42,7 +42,7 @@ void DeviceActionInfo::doDeviceAdded(Solid::Device device)
 
 void DeviceActionInfo::doDeviceRemoved(Solid::Device device)
 {
-    showMessage(tr("The device <b><nobr>\"%1\"</nobr></b> is removed.").arg(device.description()));
+    showMessage(tr("The device <b><nobr>\"%1\"</nobr></b> is removed.").arg(device.description().isEmpty() ? mKnownDeviceDescriptions[device.udi()] : device.description()));
 }
 
 void DeviceActionInfo::showMessage(const QString &text)


### PR DESCRIPTION
As at the time of removal we don't get the device description from
solid(kf5).

fixes lxqt/lxqt#1646