### PR TITLE
Remove contents margins and reduce spacing

### DIFF
--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -59,6 +59,8 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent):
     mLineEdit.setFixedWidth ( 10*fm.width ("a") );
 
     QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setContentsMargins (0, 0, 0, 0);
+    layout->setSpacing (1);
     setLayout(layout);
     layout->addWidget (&mButton);
     layout->addWidget (&mLineEdit);


### PR DESCRIPTION
If the widget has contents margins and the panel has a border and/or a padding added, then the color picker layout breaks. In addition, keep the spacing between the QPushButton and the QLineEdit to the minimum.

Before removing the contents margins:
![colorpicker-and-margins](https://user-images.githubusercontent.com/7717273/50888578-4a3e7300-13f6-11e9-81ae-69d71a92fd63.jpg)

After removing the contents margins:
![colorpicker-no-margins](https://user-images.githubusercontent.com/7717273/50888587-4dd1fa00-13f6-11e9-8446-36fe32a8c460.jpg)

I don't know if the `setFixedXXX` lines in `ColorPicker::realign()` are really necessary. The height is fine with all of them commented.

