### PR TITLE
An option for invisibility of hidden panel margin

### DIFF
--- a/panel/config/configpanelwidget.cpp
+++ b/panel/config/configpanelwidget.cpp
@@ -76,6 +76,8 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
 
     mOldHidable = mPanel->hidable();
 
+    mOldVisibleMargin = mPanel->visibleMargin();
+
     mOldAnimation = mPanel->animationTime();
     mOldShowDelay = mPanel->showDelay();
 
@@ -103,6 +105,7 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
     connect(ui->comboBox_alignment,         SIGNAL(activated(int)),         this, SLOT(editChanged()));
     connect(ui->comboBox_position,          SIGNAL(activated(int)),         this, SLOT(positionChanged()));
     connect(ui->checkBox_hidable,           SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
+    connect(ui->checkBox_visibleMargin,     SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
     connect(ui->spinBox_animation,          SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
     connect(ui->spinBox_delay,              SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
 
@@ -134,6 +137,8 @@ void ConfigPanelWidget::reset()
     ui->comboBox_position->setCurrentIndex(indexForPosition(mOldScreenNum, mOldPosition));
 
     ui->checkBox_hidable->setChecked(mOldHidable);
+
+    ui->checkBox_visibleMargin->setChecked(mOldVisibleMargin);
 
     ui->spinBox_animation->setValue(mOldAnimation);
     ui->spinBox_delay->setValue(mOldShowDelay);
@@ -324,6 +329,7 @@ void ConfigPanelWidget::editChanged()
     mPanel->setAlignment(align, true);
     mPanel->setPosition(mScreenNum, mPosition, true);
     mPanel->setHidable(ui->checkBox_hidable->isChecked(), true);
+    mPanel->setVisibleMargin(ui->checkBox_visibleMargin->isChecked(), true);
     mPanel->setAnimationTime(ui->spinBox_animation->value(), true);
     mPanel->setShowDelay(ui->spinBox_delay->value(), true);
 

--- a/panel/config/configpanelwidget.h
+++ b/panel/config/configpanelwidget.h
@@ -91,6 +91,7 @@ private:
     LXQtPanel::Alignment mOldAlignment;
     ILXQtPanel::Position mOldPosition;
     bool mOldHidable;
+    bool mOldVisibleMargin;
     int mOldAnimation;
     int mOldShowDelay;
     int mOldScreenNum;

--- a/panel/config/configpanelwidget.ui
+++ b/panel/config/configpanelwidget.ui
@@ -321,6 +321,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="QCheckBox" name="checkBox_visibleMargin">
+           <property name="text">
+            <string>Visible thin margin for hidden panel</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -75,6 +75,7 @@
 #define CFG_KEY_RESERVESPACE       "reserve-space"
 #define CFG_KEY_PLUGINS            "plugins"
 #define CFG_KEY_HIDABLE            "hidable"
+#define CFG_KEY_VISIBLE_MARGIN     "visible-margin"
 #define CFG_KEY_ANIMATION          "animation-duration"
 #define CFG_KEY_SHOW_DELAY         "show-delay"
 #define CFG_KEY_LOCKPANEL          "lockPanel"
@@ -133,6 +134,7 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
     mScreenNum(0), //whatever (avoid conditional on uninitialized value)
     mActualScreenNum(0),
     mHidable(false),
+    mVisibleMargin(true),
     mHidden(false),
     mAnimationTime(0),
     mReserveSpace(true),
@@ -241,6 +243,8 @@ void LXQtPanel::readSettings()
     mHidable = mSettings->value(CFG_KEY_HIDABLE, mHidable).toBool();
     mHidden = mHidable;
 
+    mVisibleMargin = mSettings->value(CFG_KEY_VISIBLE_MARGIN, mVisibleMargin).toBool();
+
     mAnimationTime = mSettings->value(CFG_KEY_ANIMATION, mAnimationTime).toInt();
     mShowDelayTimer.setInterval(mSettings->value(CFG_KEY_SHOW_DELAY, mShowDelayTimer.interval()).toInt());
 
@@ -316,6 +320,7 @@ void LXQtPanel::saveSettings(bool later)
     mSettings->setValue(CFG_KEY_RESERVESPACE, mReserveSpace);
 
     mSettings->setValue(CFG_KEY_HIDABLE, mHidable);
+    mSettings->setValue(CFG_KEY_VISIBLE_MARGIN, mVisibleMargin);
     mSettings->setValue(CFG_KEY_ANIMATION, mAnimationTime);
     mSettings->setValue(CFG_KEY_SHOW_DELAY, mShowDelayTimer.interval());
 
@@ -554,9 +559,14 @@ void LXQtPanel::setMargins()
             else
                 mLayout->setContentsMargins(PANEL_HIDE_SIZE, 0, 0, 0);
         }
+        if (!mVisibleMargin)
+            setWindowOpacity(0.0);
     }
-    else
+    else {
         mLayout->setContentsMargins(0, 0, 0, 0);
+        if (!mVisibleMargin)
+            setWindowOpacity(1.0);
+    }
 }
 
 void LXQtPanel::realign()
@@ -1333,6 +1343,19 @@ void LXQtPanel::setHidable(bool hidable, bool save)
         return;
 
     mHidable = hidable;
+
+    if (save)
+        saveSettings(true);
+
+    realign();
+}
+
+void LXQtPanel::setVisibleMargin(bool visibleMargin, bool save)
+{
+    if (mVisibleMargin == visibleMargin)
+        return;
+
+    mVisibleMargin = visibleMargin;
 
     if (save)
         saveSettings(true);

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -221,6 +221,7 @@ public:
     int opacity() const { return mOpacity; }
     int reserveSpace() const { return mReserveSpace; }
     bool hidable() const { return mHidable; }
+    bool visibleMargin() const { return mVisibleMargin; }
     int animationTime() const { return mAnimationTime; }
     int showDelay() const { return mShowDelayTimer.interval(); }
     QString iconTheme() const;
@@ -304,6 +305,7 @@ public slots:
     void setOpacity(int opacity, bool save); //!< \sa setPanelSize()
     void setReserveSpace(bool reserveSpace, bool save); //!< \sa setPanelSize()
     void setHidable(bool hidable, bool save); //!< \sa setPanelSize()
+    void setVisibleMargin(bool visibleMargin, bool save); //!< \sa setPanelSize()
     void setAnimationTime(int animationTime, bool save); //!< \sa setPanelSize()
     void setShowDelay(int showDelay, bool save); //!< \sa setPanelSize()
     void setIconTheme(const QString& iconTheme);
@@ -608,13 +610,19 @@ private:
      * @brief Stores if the panel is hidable, i.e. if the panel will be
      * hidden after the cursor has left the panel area.
      *
-     * \sa mHidden, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
+     * \sa mVisibleMargin, mHidden, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
      */
     bool mHidable;
     /**
+     * @brief Stores if the hidable panel should have a visible margin.
+     *
+     * \sa mHidable, mHidden, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
+     */
+    bool mVisibleMargin;
+    /**
      * @brief Stores if the panel is currently hidden.
      *
-     * \sa mHidable, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
+     * \sa mHidable, mVisibleMargin, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
      */
     bool mHidden;
     /**
@@ -622,7 +630,7 @@ private:
      * area, this timer will be started. After this timer has timed out, the
      * panel will actually be hidden.
      *
-     * \sa mHidable, mHidden, showPanel(), hidePanel(), hidePanelWork()
+     * \sa mHidable, mVisibleMargin, mHidden, showPanel(), hidePanel(), hidePanelWork()
      */
     QTimer mHideTimer;
     /**


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-panel/issues/930

The default is the previous behavior, namely, the 4-px margin of a hidden panel is visible. If the option is toggled, the margin will still exist but invisibly.

NOTE: `realign()` doesn't seem needed inside `LXQtPanel::setVisibleMargin` but is harmless.

A screenshot of the new config:

![margin](https://user-images.githubusercontent.com/981076/51499904-455bc500-1de1-11e9-9e33-74533724401e.png)
