### PR TITLE
cmake: Enhance lxqt-globalkeys minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_AUTORCC ON)
 
 set(REQUIRED_QT_VERSION "5.7.1")
 set(KF5_MINIMUM_VERSION "5.36.0")
+set(LXQT_GLOBALKEYS_MINIMUM_VERSION "0.14.1")
 set(LXQT_MINIMUM_VERSION "0.14.1")
 
 find_package(Qt5DBus ${REQUIRED_QT_VERSION} REQUIRED)
@@ -40,8 +41,7 @@ find_package(Qt5X11Extras ${REQUIRED_QT_VERSION} REQUIRED)
 find_package(Qt5Xml ${REQUIRED_QT_VERSION} REQUIRED)
 find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
-find_package(lxqt-globalkeys ${LXQT_MINIMUM_VERSION} REQUIRED)
-find_package(lxqt-globalkeys-ui ${LXQT_MINIMUM_VERSION} REQUIRED)
+find_package(lxqt-globalkeys-ui ${LXQT_GLOBALKEYS_MINIMUM_VERSION} REQUIRED)
 
 # Patch Version
 set(LXQT_PANEL_PATCH_VERSION 1)


### PR DESCRIPTION
Stop using LXQT_MINIMUM_VERSION as the minimum required version for
lxqt-globalkeys.
lxqt-globalkeys is a lxqt-globalkeys-ui dependency.
Closes #1022.