### PR TITLE
plugin-worldclock: Makes showing the week number optional

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -28,6 +28,8 @@
 
 #include "lxqtworldclock.h"
 
+#include <LXQt/Globals>
+
 #include <QCalendarWidget>
 #include <QDate>
 #include <QDesktopWidget>
@@ -47,6 +49,7 @@ LXQtWorldClock::LXQtWorldClock(const ILXQtPanelPluginStartupInfo &startupInfo):
     mTimer(new QTimer(this)),
     mUpdateInterval(1),
     mAutoRotate(true),
+    mShowWeekNumber(true),
     mPopupContent(nullptr)
 {
     mMainWidget = new QWidget();
@@ -346,6 +349,12 @@ void LXQtWorldClock::settingsChanged()
         realign();
     }
 
+    bool showWeekNumber = settings()->value(QL1S("showWeekNumber"), true).toBool();
+    if (showWeekNumber != mShowWeekNumber)
+    {
+        mShowWeekNumber = showWeekNumber;
+    }
+
     if (mPopup)
     {
         updatePopupContent();
@@ -393,6 +402,8 @@ void LXQtWorldClock::activated(ActivationReason reason)
 
             mPopup->layout()->setContentsMargins(0, 0, 0, 0);
             QCalendarWidget *calendarWidget = new QCalendarWidget(mPopup);
+            if (!mShowWeekNumber)
+                calendarWidget->setVerticalHeaderFormat(QCalendarWidget::NoVerticalHeader);
             mPopup->layout()->addWidget(calendarWidget);
 
             QString timeZoneName = mActiveTimeZone;

--- a/plugin-worldclock/lxqtworldclock.h
+++ b/plugin-worldclock/lxqtworldclock.h
@@ -84,6 +84,7 @@ private:
     QString mFormat;
 
     bool mAutoRotate;
+    bool mShowWeekNumber;
     QLabel *mPopupContent;
 
     QDateTime mShownTime;

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -34,6 +34,8 @@
 #include "lxqtworldclockconfigurationtimezones.h"
 #include "lxqtworldclockconfigurationmanualformat.h"
 
+#include <LXQt/Globals>
+
 #include <QInputDialog>
 
 
@@ -82,6 +84,7 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
     connect(ui->moveDownPB, SIGNAL(clicked()), SLOT(moveTimeZoneDown()));
 
     connect(ui->autorotateCB, SIGNAL(clicked()), SLOT(saveSettings()));
+    connect(ui->showWeekNumberCB, &QCheckBox::clicked, this, &LXQtWorldClockConfiguration::saveSettings);
 
     loadSettings();
 }
@@ -230,6 +233,7 @@ void LXQtWorldClockConfiguration::loadSettings()
 
 
     ui->autorotateCB->setChecked(settings().value("autoRotate", true).toBool());
+    ui->showWeekNumberCB->setChecked(settings().value(QL1S("showWeekNumber"), true).toBool());
 
 
     mLockCascadeSettingChanges = false;
@@ -375,6 +379,7 @@ void LXQtWorldClockConfiguration::saveSettings()
     settings().setValue(QLatin1String("defaultTimeZone"), mDefaultTimeZone);
     settings().setValue(QLatin1String("useAdvancedManualFormat"), ui->advancedManualGB->isChecked());
     settings().setValue(QLatin1String("autoRotate"), ui->autorotateCB->isChecked());
+    settings().setValue(QL1S("showWeekNumber"), ui->showWeekNumberCB->isChecked());
 }
 
 void LXQtWorldClockConfiguration::timeFormatChanged(int index)

--- a/plugin-worldclock/lxqtworldclockconfiguration.ui
+++ b/plugin-worldclock/lxqtworldclockconfiguration.ui
@@ -530,6 +530,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="showWeekNumberCB">
+         <property name="text">
+          <string>Show &amp;week number</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Adds the option to not show the week number in the calendar widget.

Implements https://github.com/lxqt/lxqt/issues/1620