### PR TITLE
Fetch window icons in an appropriate size to avoid scaling

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -83,6 +83,7 @@ LXQtTaskButton::LXQtTaskButton(const WId window, LXQtTaskBar * taskbar, QWidget 
     mDrawPixmap(false),
     mParentTaskBar(taskbar),
     mPlugin(mParentTaskBar->plugin()),
+    mIconSize(mPlugin->panel()->iconSize()),
     mDNDTimer(new QTimer(this))
 {
     Q_ASSERT(taskbar);
@@ -135,7 +136,7 @@ void LXQtTaskButton::updateIcon()
     }
     if (ico.isNull())
     {
-        ico = KWindowSystem::icon(mWindow);
+        ico = KWindowSystem::icon(mWindow, mIconSize, mIconSize);
     }
     setIcon(ico.isNull() ? XdgIcon::defaultApplicationIcon() : ico);
 }
@@ -161,6 +162,26 @@ void LXQtTaskButton::refreshIconGeometry(QRect const & geom)
         nrect.size.width = geom.width();
         info.setIconGeometry(nrect);
     }
+}
+
+/************************************************
+
+ ************************************************/
+void LXQtTaskButton::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::StyleChange)
+    {
+        // When the icon size changes, the panel doesn't emit any specific
+        // signal, but it triggers a stylesheet update, which we can detect
+        int newIconSize = mPlugin->panel()->iconSize();
+        if (newIconSize != mIconSize)
+        {
+            mIconSize = newIconSize;
+            updateIcon();
+        }
+    }
+
+    QToolButton::changeEvent(event);
 }
 
 /************************************************

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -136,7 +136,12 @@ void LXQtTaskButton::updateIcon()
     }
     if (ico.isNull())
     {
-        ico = KWindowSystem::icon(mWindow, mIconSize, mIconSize);
+#if QT_VERSION >= 0x050600
+        int devicePixels = mIconSize * devicePixelRatioF();
+#else
+        int devicePixels = mIconSize * devicePixelRatio();
+#endif
+        ico = KWindowSystem::icon(mWindow, devicePixels, devicePixels);
     }
     setIcon(ico.isNull() ? XdgIcon::defaultApplicationIcon() : ico);
 }

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -103,6 +103,7 @@ public slots:
     void updateIcon();
 
 protected:
+    virtual void changeEvent(QEvent *event);
     virtual void dragEnterEvent(QDragEnterEvent *event);
     virtual void dragMoveEvent(QDragMoveEvent * event);
     virtual void dragLeaveEvent(QDragLeaveEvent *event);
@@ -128,6 +129,7 @@ private:
     bool mDrawPixmap;
     LXQtTaskBar * mParentTaskBar;
     ILXQtPanelPlugin * mPlugin;
+    int mIconSize;
 
     // Timer for when draggind something into a button (the button's window
     // must be activated so that the use can continue dragging to the window


### PR DESCRIPTION
Window icons typically come in several sizes, and KWindowSystem::icon() allows us to provide a size hint to get an icon close to the size we want to display.  Providing this hint makes the icons displayed in the taskbar clearer, since for common sizes (16x16, 24x24, etc.) they won't need to be scaled.