### PR TITLE
Show system tray icons in a predictable order

### DIFF
--- a/plugin-tray/CMakeLists.txt
+++ b/plugin-tray/CMakeLists.txt
@@ -11,6 +11,7 @@ pkg_check_modules(XDAMAGE REQUIRED xdamage)
 pkg_check_modules(XRENDER REQUIRED xrender)
 
 set(HEADERS
+    lxqttrayconfiguration.h
     lxqttrayplugin.h
     lxqttray.h
     trayicon.h
@@ -18,10 +19,15 @@ set(HEADERS
 )
 
 set(SOURCES
+    lxqttrayconfiguration.cpp
     lxqttrayplugin.cpp
     lxqttray.cpp
     trayicon.cpp
     xfitman.cpp
+)
+
+set(UIS
+    lxqttrayconfiguration.ui
 )
 
 set(LIBRARIES

--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -77,6 +77,7 @@ LXQtTray::LXQtTray(ILXQtPanelPlugin *plugin, QWidget *parent):
     mDisplay(QX11Info::display())
 {
     mLayout = new LXQt::GridLayout(this);
+    mLayout->setSpacing((TRAY_ICON_SIZE_DEFAULT + 4) / 8);
     realign();
     _NET_SYSTEM_TRAY_OPCODE = XfitMan::atom("_NET_SYSTEM_TRAY_OPCODE");
     // Init the selection later just to ensure that no signals are sent until
@@ -228,6 +229,7 @@ void LXQtTray::setIconSize(QSize iconSize)
 {
     mIconSize = iconSize;
     unsigned long size = qMin(mIconSize.width(), mIconSize.height());
+    mLayout->setSpacing(((int)size + 4) / 8);
     XChangeProperty(mDisplay,
                     mTrayId,
                     XfitMan::atom("_NET_SYSTEM_TRAY_ICON_SIZE"),

--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -394,7 +394,24 @@ void LXQtTray::addIcon(Window winId)
 
     icon = new TrayIcon(winId, mIconSize, this);
     mIcons.append(icon);
+
+    QString name = icon->appName();
+    int insertIdx = mLayout->count();
+    int moveToIdx;
+
+    // insert the icon sorted alphabetically, so that icons show up in a
+    // predictable order (otherwise it varies depending on startup times)
+    for (moveToIdx = 0; moveToIdx < insertIdx; moveToIdx++)
+    {
+        auto layoutItem = mLayout->itemAt(moveToIdx);
+        auto existingIcon = static_cast<TrayIcon *>(layoutItem->widget());
+        if (name < existingIcon->appName())
+            break;
+    }
+
     mLayout->addWidget(icon);
+    mLayout->moveItem(insertIdx, moveToIdx);
+
     connect(icon, &QObject::destroyed, this, &LXQtTray::onIconDestroyed);
 }
 

--- a/plugin-tray/lxqttray.h
+++ b/plugin-tray/lxqttray.h
@@ -63,6 +63,7 @@ public:
     bool nativeEventFilter(const QByteArray &eventType, void *message, long *);
 
     void realign();
+    void settingsChanged();
 
 signals:
     void iconSizeChanged(int iconSize);
@@ -85,6 +86,8 @@ private:
                       long unsigned int data4 = 0) const;
 
     void addIcon(Window id);
+    void sortIcons();
+
     TrayIcon* findIcon(Window trayId);
 
     bool mValid;

--- a/plugin-tray/lxqttrayconfiguration.cpp
+++ b/plugin-tray/lxqttrayconfiguration.cpp
@@ -1,0 +1,56 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2019 LXQt team
+ * Authors:
+ *   John Lindgren <john@jlindgren.net>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "lxqttrayconfiguration.h"
+#include "ui_lxqttrayconfiguration.h"
+
+LXQtTrayConfiguration::LXQtTrayConfiguration(PluginSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::LXQtTrayConfiguration)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    ui->setupUi(this);
+
+    loadSettings();
+
+    connect(ui->sortIconsCB, &QAbstractButton::toggled, [settings](bool value) {
+        settings->setValue("sortIcons", value);
+    });
+    connect(ui->spacingSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [settings](int value) {
+        settings->setValue("spacing", value);
+    });
+
+    connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtTrayConfiguration::dialogButtonsAction);
+}
+
+LXQtTrayConfiguration::~LXQtTrayConfiguration() {}
+
+void LXQtTrayConfiguration::loadSettings()
+{
+    ui->sortIconsCB->setChecked(settings().value("sortIcons", false).toBool());
+    ui->spacingSB->setValue(settings().value("spacing", 0).toInt());
+}

--- a/plugin-tray/lxqttrayconfiguration.h
+++ b/plugin-tray/lxqttrayconfiguration.h
@@ -4,9 +4,9 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2013 Razor team
+ * Copyright: 2019 LXQt team
  * Authors:
- *   Alexander Sokoloff <sokoloff.a@gmail.com>
+ *   John Lindgren <john@jlindgren.net>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,40 +25,29 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#ifndef LXQTTRAYCONFIGURATION_H
+#define LXQTTRAYCONFIGURATION_H
 
-#include "lxqttrayplugin.h"
-#include "lxqttrayconfiguration.h"
-#include "lxqttray.h"
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include <memory>
 
-LXQtTrayPlugin::LXQtTrayPlugin(const ILXQtPanelPluginStartupInfo &startupInfo) :
-    QObject(),
-    ILXQtPanelPlugin(startupInfo),
-    mWidget(new LXQtTray(this))
-{
+namespace Ui {
+    class LXQtTrayConfiguration;
 }
 
-LXQtTrayPlugin::~LXQtTrayPlugin()
+class LXQtTrayConfiguration : public LXQtPanelPluginConfigDialog
 {
-    delete mWidget;
-}
+    Q_OBJECT
 
-QWidget *LXQtTrayPlugin::widget()
-{
-    return mWidget;
-}
+public:
+    explicit LXQtTrayConfiguration(PluginSettings *settings, QWidget *parent = nullptr);
+    ~LXQtTrayConfiguration();
 
-QDialog *LXQtTrayPlugin::configureDialog()
-{
-    return new LXQtTrayConfiguration(settings());
-}
+private slots:
+    void loadSettings() override;
 
-void LXQtTrayPlugin::realign()
-{
-    mWidget->realign();
-}
+private:
+    std::unique_ptr<Ui::LXQtTrayConfiguration> ui;
+};
 
-void LXQtTrayPlugin::settingsChanged()
-{
-    mWidget->settingsChanged();
-}
-
+#endif // LXQTTRAYCONFIGURATION_H

--- a/plugin-tray/lxqttrayconfiguration.ui
+++ b/plugin-tray/lxqttrayconfiguration.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LXQtTrayConfiguration</class>
+ <widget class="QDialog" name="LXQtTrayConfiguration">
+  <property name="windowTitle">
+   <string>System Tray Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="generalGB">
+     <property name="title">
+      <string>General</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="0">
+       <widget class="QLabel" name="spacingLabel">
+        <property name="text">
+         <string>Spacing between icons:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="spacingSB">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="sortIconsCB">
+        <property name="text">
+         <string>Sort icons by window class</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/plugin-tray/lxqttrayplugin.h
+++ b/plugin-tray/lxqttrayplugin.h
@@ -44,8 +44,12 @@ public:
 
     virtual QWidget *widget();
     virtual QString themeId() const { return "Tray"; }
-    virtual Flags flags() const { return  PreferRightAlignment | SingleInstance | NeedsHandle; }
+    virtual Flags flags() const { return HaveConfigDialog | PreferRightAlignment | SingleInstance | NeedsHandle; }
+
+    QDialog *configureDialog();
+
     void realign();
+    void settingsChanged();
 
     bool isSeparate() const { return true; }
 

--- a/plugin-tray/trayicon.cpp
+++ b/plugin-tray/trayicon.cpp
@@ -73,6 +73,7 @@ TrayIcon::TrayIcon(Window iconId, QSize const & iconSize, QWidget* parent):
     QFrame(parent),
     mIconId(iconId),
     mWindowId(0),
+    mAppName(xfitMan().getApplicationName(mIconId)),
     mIconSize(iconSize),
     mDamage(0),
     mDisplay(QX11Info::display())

--- a/plugin-tray/trayicon.h
+++ b/plugin-tray/trayicon.h
@@ -50,8 +50,10 @@ public:
     TrayIcon(Window iconId, QSize const & iconSize, QWidget* parent);
     virtual ~TrayIcon();
 
-    Window iconId() { return mIconId; }
-    Window windowId() { return mWindowId; }
+    Window iconId() const { return mIconId; }
+    Window windowId() const { return mWindowId; }
+    QString appName() const { return mAppName; }
+
     void windowDestroyed(Window w);
 
     QSize iconSize() const { return mIconSize; }
@@ -68,6 +70,7 @@ private:
     QRect iconGeometry();
     Window mIconId;
     Window mWindowId;
+    QString mAppName;
     QSize mIconSize;
     Damage mDamage;
     Display* mDisplay;


### PR DESCRIPTION
It's mildly annoying that system tray icons show up in a different order each time LXQt is started.  Alphabetical order isn't always ideal, but at least it's consistent.  Potentially, in future, we could make the icon order customizable by the user.