### PR TITLE
Only override the menu icon size if a custom font size is selected.

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -435,7 +435,9 @@ void LXQtMainMenu::setMenuFontSize()
         return;
 
     QFont menuFont = mButton.font();
-    if(settings()->value("customFont", false).toBool())
+    bool customFont = settings()->value("customFont", false).toBool();
+
+    if(customFont)
     {
         menuFont = mMenu->font();
         menuFont.setPointSize(settings()->value("customFontSize").toInt());
@@ -453,9 +455,15 @@ void LXQtMainMenu::setMenuFontSize()
         mSearchView->setFont(menuFont);
     }
 
-    //icon size the same as the font height
-    const int icon_size = QFontMetrics(menuFont).height();
+    // icon size the same as the font height if a custom font is selected,
+    // otherwise use the default size
+    int icon_size = (customFont ? QFontMetrics(menuFont).height()
+                                : MenuStyle::DEFAULT_ICON_SIZE);
     mTopMenuStyle.setIconSize(icon_size);
+
+    // get the size back from the style (this will resolve DEFAULT_ICON_SIZE
+    // to an actual pixel size if necessary)
+    icon_size = mTopMenuStyle.pixelMetric(QStyle::PM_SmallIconSize);
     mSearchView->setIconSize(QSize{icon_size, icon_size});
 }
 

--- a/plugin-mainmenu/menustyle.cpp
+++ b/plugin-mainmenu/menustyle.cpp
@@ -36,7 +36,7 @@
 MenuStyle::MenuStyle():
     QProxyStyle()
 {
-    mIconSize = 16;
+    mIconSize = DEFAULT_ICON_SIZE;
 }
 
 
@@ -45,7 +45,7 @@ MenuStyle::MenuStyle():
  ************************************************/
 int MenuStyle::pixelMetric(PixelMetric metric, const QStyleOption * option, const QWidget * widget) const
 {
-    if (metric == QProxyStyle::PM_SmallIconSize)
+    if (metric == QStyle::PM_SmallIconSize && mIconSize != DEFAULT_ICON_SIZE)
         return mIconSize;
 
     return QProxyStyle::pixelMetric(metric, option, widget);

--- a/plugin-mainmenu/menustyle.h
+++ b/plugin-mainmenu/menustyle.h
@@ -35,6 +35,9 @@ class MenuStyle : public QProxyStyle
 {
     Q_OBJECT
 public:
+    // reserved value which gets the icon size from the parent style
+    static constexpr int DEFAULT_ICON_SIZE = -1;
+
     explicit MenuStyle();
     int pixelMetric(PixelMetric metric, const QStyleOption * option = 0, const QWidget * widget = 0 ) const;
     int styleHint(StyleHint hint, const QStyleOption* option = 0, const QWidget* widget = 0, QStyleHintReturn* returnData = 0) const;


### PR DESCRIPTION
If we're using the default font size from the desktop theme, we
should use the default icon size as well.  Otherwise we'll frequently
end up with a size that requires re-scaling icons, causing them to
appear blurry.