### PR TITLE
 statusnotifier: Enhance service name registration

### DIFF
--- a/plugin-statusnotifier/sniasync.h
+++ b/plugin-statusnotifier/sniasync.h
@@ -79,7 +79,7 @@ public:
                 {
                     QDBusPendingReply<QVariant> reply = *call;
                     if (reply.isError())
-                        qDebug() << "Error on DBus request:" << reply.error();
+                        qDebug().noquote().nospace() << "Error on DBus request(" << mSni.service() << ',' << mSni.path() << "): " << reply.error();
                     finished(qdbus_cast<typename std::function<typename call_signature<F>::type>::argument_type>(reply.value()));
                     call->deleteLater();
                 }

--- a/plugin-statusnotifier/statusnotifierwatcher.cpp
+++ b/plugin-statusnotifier/statusnotifierwatcher.cpp
@@ -40,8 +40,17 @@ StatusNotifierWatcher::StatusNotifierWatcher(QObject *parent) : QObject(parent)
     qDBusRegisterMetaType<ToolTip>();
 
     QDBusConnection dbus = QDBusConnection::sessionBus();
-    if (!dbus.registerService("org.kde.StatusNotifierWatcher"))
-        qDebug() << QDBusConnection::sessionBus().lastError().message();
+    switch (dbus.interface()->registerService("org.kde.StatusNotifierWatcher", QDBusConnectionInterface::QueueService).value())
+    {
+        case QDBusConnectionInterface::ServiceNotRegistered:
+            qWarning() << "StatusNotifier: unable to register service for org.kde.StatusNotifierWatcher";
+            break;
+        case QDBusConnectionInterface::ServiceQueued:
+            qWarning() << "StatusNotifier: registration of service org.kde.StatusNotifierWatcher queued, we can become primary after existing one deregisters";
+            break;
+        case QDBusConnectionInterface::ServiceRegistered:
+            break;
+    }
     if (!dbus.registerObject("/StatusNotifierWatcher", this, QDBusConnection::ExportScriptableContents))
         qDebug() << QDBusConnection::sessionBus().lastError().message();
 

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -31,6 +31,7 @@
 #include <QDebug>
 #include <QFutureWatcher>
 #include <QtConcurrent>
+#include <QDBusConnectionInterface>
 #include "../panel/ilxqtpanelplugin.h"
 
 StatusNotifierWidget::StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *parent) :
@@ -57,8 +58,8 @@ StatusNotifierWidget::StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *pa
     QFuture<StatusNotifierWatcher *> future = QtConcurrent::run([]
         {
             QString dbusName = QString("org.kde.StatusNotifierHost-%1-%2").arg(QApplication::applicationPid()).arg(1);
-            if (!QDBusConnection::sessionBus().registerService(dbusName))
-                qDebug() << QDBusConnection::sessionBus().lastError().message();
+            if (QDBusConnectionInterface::ServiceNotRegistered == QDBusConnection::sessionBus().interface()->registerService(dbusName, QDBusConnectionInterface::DontQueueService))
+                qDebug() << "unable to register service for " << dbusName;
 
             StatusNotifierWatcher * watcher = new StatusNotifierWatcher;
             watcher->RegisterStatusNotifierHost(dbusName);


### PR DESCRIPTION
In case there is another "server" serving the SNI, allow queuing our
registration to overtake SNI serving after the existing one shuts down:
- allow waiting for org.kde.StatusNotifierWatcher registration
- do better logging