### PR TITLE
Use vanilla Qt instead of patched one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,4 @@ arch:
     - lxmenu-data
     - libdbusmenu-qt5
     - lxqt-globalkeys-git
-    # Using the -nostatx variant as Travis builders come with older kernels
-    - qt5-base-nostatx
   script: bash ./.ci/build.sh


### PR DESCRIPTION
Since Qt 5.12.3 [1], Qt binaries can run on old kernels even if it's
compiled with statx support.

This eliminates the need to maintain another qt package, and it is also a preparation step for the upcoming Qt 5.13 update in Arch Linux.

[1] https://github.com/qt/qtbase/commit/7148dfc67ff20c1c625d203aa47b574b3aaa5db1