### PR TITLE
Fix a crash under kwin_wayland

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -151,7 +151,13 @@ void LXQtTaskButton::updateIcon()
  ************************************************/
 void LXQtTaskButton::refreshIconGeometry(QRect const & geom)
 {
-    NETWinInfo info(QX11Info::connection(),
+    xcb_connection_t* x11conn = QX11Info::connection();
+
+    if (!x11conn) {
+        return;
+    }
+
+    NETWinInfo info(x11conn,
                     windowId(),
                     (WId) QX11Info::appRootWindow(),
                     NET::WMIconGeometry,


### PR DESCRIPTION
lxqt-panel is still far from usable under kwin_wayland. At least it doesn't crash often now.

Ref: https://github.com/lxqt/lxqt/issues/10