### PR TITLE
Only show group popup on left clicking a grouping task button

### DIFF
--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -584,6 +584,19 @@ void LXQtTaskGroup::mouseMoveEvent(QMouseEvent* event)
 /************************************************
 
  ************************************************/
+
+void LXQtTaskGroup::mouseReleaseEvent(QMouseEvent* event)
+{
+    // do nothing on left button release if there is a group
+    if (event->button() == Qt::LeftButton && visibleButtonsCount() == 1)
+        LXQtTaskButton::mouseReleaseEvent(event);
+    else
+        QToolButton::mouseReleaseEvent(event);
+}
+
+/************************************************
+
+ ************************************************/
 bool LXQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2)
 { // returns true if the class is preserved
     bool needsRefreshVisibility{false};

--- a/plugin-taskbar/lxqttaskgroup.h
+++ b/plugin-taskbar/lxqttaskgroup.h
@@ -82,6 +82,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent * event);
     void contextMenuEvent(QContextMenuEvent * event);
     void mouseMoveEvent(QMouseEvent * event);
+    void mouseReleaseEvent(QMouseEvent *event);
     int recalculateFrameHeight() const;
     int recalculateFrameWidth() const;
 


### PR DESCRIPTION
And do nothing with its corresponding windows.

IMHO, the left click behavior of the task manager is counter-intuitive when there is a group of two or more buttons because the user cannot predict what will happen to which window of the same app on clicking its single task button (unless he remembers the order of appearance of its windows).

This patch prevents confusion by showing the group popup in such cases, so that the user could choose what to do with each window. That's similar to the behavior of KDE Plasma's task manager too.

Closes https://github.com/lxqt/lxqt/issues/1725