### PR TITLE
Taskbar wheel event additions

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -38,7 +38,6 @@
 #include <QWheelEvent>
 #include <QFlag>
 #include <QX11Info>
-#include <QDebug>
 #include <QTimer>
 
 #include <lxqt-globalkeys.h>

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -68,7 +68,8 @@ LXQtTaskBar::LXQtTaskBar(ILXQtPanelPlugin *plugin, QWidget *parent) :
     mGroupingEnabled(true),
     mShowGroupOnHover(true),
     mIconByClass(false),
-    mCycleOnWheelScroll(true),
+    mWheelEventsAction(1),
+    mWheelDeltaThreshold(300),
     mPlugin(plugin),
     mPlaceHolder(new QWidget(this)),
     mStyle(new LeftAlignedTextStyle())
@@ -469,7 +470,8 @@ void LXQtTaskBar::settingsChanged()
     mGroupingEnabled = mPlugin->settings()->value("groupingEnabled",true).toBool();
     mShowGroupOnHover = mPlugin->settings()->value("showGroupOnHover",true).toBool();
     mIconByClass = mPlugin->settings()->value("iconByClass", false).toBool();
-    mCycleOnWheelScroll = mPlugin->settings()->value("cycleOnWheelScroll", true).toBool();
+    mWheelEventsAction = mPlugin->settings()->value("wheelEventsAction", 1).toInt();
+    mWheelDeltaThreshold = mPlugin->settings()->value("wheelDeltaThreshold", 300).toInt();
 
     // Delete all groups if grouping feature toggled and start over
     if (groupingEnabledOld != mGroupingEnabled)
@@ -560,12 +562,13 @@ void LXQtTaskBar::realign()
  ************************************************/
 void LXQtTaskBar::wheelEvent(QWheelEvent* event)
 {
-    if (!mCycleOnWheelScroll)
+    // ignore wheel action unless user preference is "cycle windows"
+    if (mWheelEventsAction != 1)
         return QFrame::wheelEvent(event);
 
     static int threshold = 0;
     threshold += abs(event->delta());
-    if (threshold < 300)
+    if (threshold < mWheelDeltaThreshold)
         return QFrame::wheelEvent(event);
     else
         threshold = 0;

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -77,6 +77,8 @@ public:
     bool isGroupingEnabled() const { return mGroupingEnabled; }
     bool isShowGroupOnHover() const { return mShowGroupOnHover; }
     bool isIconByClass() const { return mIconByClass; }
+    int wheelEventsAction() const { return mWheelEventsAction; }
+    int wheelDeltaThreshold() const { return mWheelDeltaThreshold; }
     inline ILXQtPanel * panel() const { return mPlugin->panel(); }
     inline ILXQtPanelPlugin * plugin() const { return mPlugin; }
 
@@ -135,7 +137,8 @@ private:
     bool mGroupingEnabled;
     bool mShowGroupOnHover;
     bool mIconByClass;
-    bool mCycleOnWheelScroll; //!< flag for processing the wheelEvent
+    int mWheelEventsAction;
+    int mWheelDeltaThreshold;
 
     bool acceptWindow(WId window) const;
     void setButtonStyle(Qt::ToolButtonStyle buttonStyle);

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -45,6 +45,11 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     ui->buttonStyleCB->addItem(tr("Only icon"), "Icon");
     ui->buttonStyleCB->addItem(tr("Only text"), "Text");
 
+    ui->wheelEventsActionCB->addItem(tr("Disabled"), 0);
+    ui->wheelEventsActionCB->addItem(tr("Cycle windows on wheel scrolling"), 1);
+    ui->wheelEventsActionCB->addItem(tr("Scroll up to raise, down to minimize"), 2);
+    ui->wheelEventsActionCB->addItem(tr("Scroll up to minimize, up to raise"), 3);
+
     ui->showDesktopNumCB->addItem(tr("Current"), 0);
     //Note: in KWindowSystem desktops are numbered from 1..N
     const int desk_cnt = KWindowSystem::numberOfDesktops();
@@ -69,7 +74,8 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     connect(ui->groupingGB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->showGroupOnHoverCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->iconByClassCB, &QCheckBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
-    connect(ui->cycleOnWheelScroll, &QCheckBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->wheelEventsActionCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
+    connect(ui->wheelDeltaThresholdSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
 }
 
 LXQtTaskbarConfiguration::~LXQtTaskbarConfiguration()
@@ -95,7 +101,8 @@ void LXQtTaskbarConfiguration::loadSettings()
     ui->groupingGB->setChecked(settings().value("groupingEnabled",true).toBool());
     ui->showGroupOnHoverCB->setChecked(settings().value("showGroupOnHover",true).toBool());
     ui->iconByClassCB->setChecked(settings().value("iconByClass", false).toBool());
-    ui->cycleOnWheelScroll->setChecked(settings().value("cycleOnWheelScroll", true).toBool());
+    ui->wheelEventsActionCB->setCurrentIndex(ui->wheelEventsActionCB->findData(settings().value("wheelEventsAction", 0).toInt()));
+    ui->wheelDeltaThresholdSB->setValue(settings().value("wheelDeltaThreshold", 300).toInt());
 }
 
 void LXQtTaskbarConfiguration::saveSettings()
@@ -113,5 +120,6 @@ void LXQtTaskbarConfiguration::saveSettings()
     settings().setValue("groupingEnabled",ui->groupingGB->isChecked());
     settings().setValue("showGroupOnHover",ui->showGroupOnHoverCB->isChecked());
     settings().setValue("iconByClass",ui->iconByClassCB->isChecked());
-    settings().setValue("cycleOnWheelScroll",ui->cycleOnWheelScroll->isChecked());
+    settings().setValue("wheelEventsAction",ui->wheelEventsActionCB->itemData(ui->wheelEventsActionCB->currentIndex()));
+    settings().setValue("wheelDeltaThreshold",ui->wheelDeltaThresholdSB->value());
 }

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -48,7 +48,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     ui->wheelEventsActionCB->addItem(tr("Disabled"), 0);
     ui->wheelEventsActionCB->addItem(tr("Cycle windows on wheel scrolling"), 1);
     ui->wheelEventsActionCB->addItem(tr("Scroll up to raise, down to minimize"), 2);
-    ui->wheelEventsActionCB->addItem(tr("Scroll up to minimize, up to raise"), 3);
+    ui->wheelEventsActionCB->addItem(tr("Scroll up to minimize, down to raise"), 3);
 
     ui->showDesktopNumCB->addItem(tr("Current"), 0);
     //Note: in KWindowSystem desktops are numbered from 1..N

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -77,12 +77,62 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="WLMousewheelGB">
+     <property name="title">
+      <string>Mouse Wheel</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_mousewheel">
       <item>
-       <widget class="QCheckBox" name="cycleOnWheelScroll">
-        <property name="text">
-         <string>Cycle windows on wheel scrolling</string>
+       <widget class="QComboBox" name="wheelEventsActionCB"/>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>0</number>
         </property>
-       </widget>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="wheelDeltaThresholdLabel">
+          <property name="text">
+           <string>Wheel Delta Threshold</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+        <widget class="QSpinBox" name="wheelDeltaThresholdSB">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="suffix">
+          <string> px</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>300</number>
+         </property>
+        </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -274,6 +274,34 @@ void LXQtTaskButton::mouseReleaseEvent(QMouseEvent* event)
 /************************************************
 
  ************************************************/
+void LXQtTaskButton::wheelEvent(QWheelEvent* event)
+{
+    // ignore wheel event if it is not "raise" or "minimize" window
+    if (mParentTaskBar->wheelEventsAction() != 2 && mParentTaskBar->wheelEventsAction() != 3)
+        return QToolButton::wheelEvent(event);
+
+    static int threshold = 0;
+    threshold += abs(event->delta());
+    if (threshold < mParentTaskBar->wheelDeltaThreshold())
+        return QToolButton::wheelEvent(event);
+    else
+        threshold = 0;
+
+    int delta = event->delta() < 0 ? 1 : -1;
+    if (mParentTaskBar->wheelEventsAction() == 3)
+        delta *= -1;
+
+    if (delta < 0)
+        raiseApplication();
+    else if (delta > 0)
+        minimizeApplication();
+
+    QToolButton::wheelEvent(event);
+}
+
+/************************************************
+
+ ************************************************/
 QMimeData * LXQtTaskButton::mimeData()
 {
     QMimeData *mimedata = new QMimeData;

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -111,6 +111,7 @@ protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
+    void wheelEvent(QWheelEvent* event);
     virtual void contextMenuEvent(QContextMenuEvent *event);
     void paintEvent(QPaintEvent *);
 


### PR DESCRIPTION
This is related to wishlist issue https://github.com/lxqt/lxqt/issues/1496

I added support for using the mouse wheel to raise/minimize windows on the taskbar.  I made a modification to the "Configure Task Manager" settings screen, where I removed the "cycle through windows" checkbox and replaced it with a "Mouse Wheel" section that has a dropdown that lets the user choose disabled, cycle through (so this option is still there), or the raise/minimize behavior.

![2019-09-02-214839_1920x1080_scrot](https://user-images.githubusercontent.com/1706809/64140855-98f8ad00-cdcb-11e9-90f6-db76ca113028.png)

I added a configurable threshold value in this section.  My mouse wheel had an 80-90% success rate, but sometimes the "scroll amount" value from my wheel was too small (200px, maybe?) and the wheel event didn't register.  I set it to 0 personally, but I kept the default at the previous value of 300.

_I also attached a small fix for what appeared to be an unwanted behavior introduced by a semi-recent  QToolButton refactor, seen here:  https://codereview.qt-project.org/c/qt/qtbase/+/227511  Basically, the QToolButton is pre-emptively "eliding" the window text, but it's hard-coded to elide in the middle.  That meant the `LeftAlignedTextStyle::drawItemText` override no longer had the full text when it tried do a Qt::ElideRight call, because the text arrived pre-elided in the middle.  In regards to this specific commit, I can move it into its own pull request if needed._ **Edit - removed this commit and moved into a separate branch**

ps - attaching a screenshot that demonstrates the "center elide" issue
![2019-08-28-180532_1920x1080_scrot](https://user-images.githubusercontent.com/1706809/64140792-47e8b900-cdcb-11e9-8272-fc1acd58d62b.png)
