### PR TITLE
Smoother menu search

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -78,6 +78,10 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
     mHideTimer.setSingleShot(true);
     mHideTimer.setInterval(250);
 
+    mSearchTimer.setSingleShot(true);
+    connect(&mSearchTimer, &QTimer::timeout, this, &LXQtMainMenu::searchMenu);
+    mSearchTimer.setInterval(350); // typing speed (not very fast)
+
     mButton.setAutoRaise(true);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
     //Notes:
@@ -96,7 +100,9 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
     mSearchEdit = new QLineEdit;
     mSearchEdit->setClearButtonEnabled(true);
     mSearchEdit->setPlaceholderText(LXQtMainMenu::tr("Search..."));
-    connect(mSearchEdit, &QLineEdit::textChanged, this, &LXQtMainMenu::searchTextChanged);
+    connect(mSearchEdit, &QLineEdit::textChanged, [this] (QString const &) {
+        mSearchTimer.start();
+    });
     connect(mSearchEdit, &QLineEdit::returnPressed, mSearchView, &ActionView::activateCurrent);
     mSearchEditAction->setDefaultWidget(mSearchEdit);
     QTimer::singleShot(0, [this] { settingsChanged(); });
@@ -333,8 +339,9 @@ static void setTranslucentMenus(QMenu * menu)
 /************************************************
 
  ************************************************/
-void LXQtMainMenu::searchTextChanged(QString const & text)
+void LXQtMainMenu::searchMenu()
 {
+    const QString text = mSearchEdit->text();
     if (mFilterShow)
     {
         mHeavyMenuChanges = true;
@@ -422,7 +429,7 @@ void LXQtMainMenu::buildMenu()
     mSearchEditAction->setVisible(mFilterMenu || mFilterShow);
     mSearchView->fillActions(mMenu);
 
-    searchTextChanged(mSearchEdit->text());
+    searchMenu();
     setMenuFontSize();
 }
 

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -111,6 +111,7 @@ private:
 
     QTimer mDelayedPopup;
     QTimer mHideTimer;
+    QTimer mSearchTimer;
     QString mMenuFile;
 
 protected slots:
@@ -121,7 +122,7 @@ protected slots:
 private slots:
     void showMenu();
     void showHideMenu();
-    void searchTextChanged(QString const & text);
+    void searchMenu();
     void setSearchFocus(QAction *action);
 };
 


### PR DESCRIPTION
While the user is typing in the search field, LXQt Panel does lots of computations (searching for the string that's typed at the moment in lots of desktop entries and updating the menu by considering the found matches), which can result in input blocking and GUI freeze, especially with fast typing. To test that, you could keep the key "A" pressed in the search filed if you have an enough number of menu items in you main menu.

This patch starts searching (filtering) only when the user stops typing. The average typing speed is 200 characters per minute. Here, an interval of 350 ms is used for a smoother filtering.