### PR TITLE
WIP: Merge Conflicts - mainmenu: Filter applications more quickly when searching.

### DIFF
--- a/plugin-mainmenu/actionview.h
+++ b/plugin-mainmenu/actionview.h
@@ -33,6 +33,22 @@
 class QStandardItemModel;
 
 //==============================
+class StringFilter
+{
+public:
+    StringFilter() = default;
+    StringFilter(const QString &searchStr, bool startOfWord);
+
+    const QString& searchStr() const { return searchStr_; }
+
+    bool isMatch(const QString& string) const;
+
+private:
+    QString searchStr_;
+    QStringList snippets;
+    bool startOfWord_ = false;
+};
+//==============================
 #ifdef HAVE_MENU_CACHE
 class QSortFilterProxyModel;
 #else
@@ -44,8 +60,8 @@ public:
     explicit FilterProxyModel(QObject* parent = nullptr);
     virtual ~FilterProxyModel();
 
-    void setfilerString(const QString &str) {
-        filterStr_ = str;
+    void setFilter(const StringFilter& filter) {
+        filter_ = filter;
         invalidateFilter();
     }
 
@@ -53,7 +69,7 @@ protected:
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;
 
 private:
-    QString filterStr_;
+    StringFilter filter_;
 };
 #endif
 //==============================
@@ -86,7 +102,7 @@ public:
     void fillActions(QMenu * menu);
     /*! \brief Sets the filter for entries to be presented
      */
-    void setFilter(QString const & filter);
+    void setFilter(const StringFilter& filter);
     /*! \brief Set the maximum number of items/results to show
      */
     void setMaxItemsToShow(int max);

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -97,6 +97,7 @@ private:
     QAction * mMakeDirtyAction;
     bool mFilterMenu; //!< searching should perform hiding nonmatching items in menu
     bool mFilterShow; //!< searching should list matching items in top menu
+    bool mFilterStartOfWord; //!< search should match from start of word only
     bool mFilterClear; //!< search field should be cleared upon showing the menu
     bool mFilterShowHideMenu; //!< while searching all (original) menu entries should be hidden
     bool mHeavyMenuChanges; //!< flag for filtering some mMenu events while heavy changes are performed

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -78,12 +78,16 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
 
     connect(ui->filterMenuCB, &QCheckBox::toggled, [this] (bool enabled)
         {
-            ui->filterClearCB->setEnabled(enabled || ui->filterShowCB->isChecked());
+            bool search_enabled = enabled || ui->filterShowCB->isChecked();
+            ui->filterStartOfWordCB->setEnabled(search_enabled);
+            ui->filterClearCB->setEnabled(search_enabled);
             this->settings().setValue(QStringLiteral("filterMenu"), enabled);
         });
     connect(ui->filterShowCB, &QCheckBox::toggled, [this] (bool enabled)
         {
-            ui->filterClearCB->setEnabled(enabled || ui->filterMenuCB->isChecked());
+            bool search_enabled = enabled || ui->filterMenuCB->isChecked();
+            ui->filterStartOfWordCB->setEnabled(search_enabled);
+            ui->filterClearCB->setEnabled(search_enabled);
             this->settings().setValue(QStringLiteral("filterShow"), enabled);
         });
     connect(ui->filterShowMaxItemsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [this] (int value)
@@ -97,6 +101,10 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
     connect(ui->filterShowHideMenuCB, &QCheckBox::toggled, [this] (bool enabled)
         {
             this->settings().setValue(QStringLiteral("filterShowHideMenu"), enabled);
+        });
+    connect(ui->filterStartOfWordCB, &QCheckBox::toggled, [this] (bool enabled)
+        {
+            this->settings().setValue(QStringLiteral("filterStartOfWord"), enabled);
         });
     connect(ui->filterClearCB, &QCheckBox::toggled, [this] (bool enabled)
         {
@@ -143,6 +151,8 @@ void LXQtMainMenuConfiguration::loadSettings()
     ui->filterShowMaxWidthSB->setValue(settings().value(QStringLiteral("filterShowMaxWidth"), 300).toInt());
     ui->filterShowHideMenuCB->setEnabled(filter_show);
     ui->filterShowHideMenuCB->setChecked(settings().value(QStringLiteral("filterShowHideMenu"), true).toBool());
+    ui->filterStartOfWordCB->setChecked(settings().value(QStringLiteral("filterStartOfWord"), false).toBool());
+    ui->filterStartOfWordCB->setEnabled(filter_menu || filter_show);
     ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), false).toBool());
     ui->filterClearCB->setEnabled(filter_menu || filter_show);
 }

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.ui
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>LXQtMainMenuConfiguration</class>
  <widget class="QDialog" name="LXQtMainMenuConfiguration">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>481</width>
-    <height>501</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Main Menu settings</string>
   </property>
@@ -212,6 +204,13 @@
        </widget>
       </item>
       <item row="4" column="0" colspan="3">
+       <widget class="QCheckBox" name="filterStartOfWordCB">
+        <property name="text">
+         <string>Match start of word only (&quot;ma&quot; matches &quot;make&quot;, not &quot;cmake&quot;)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
        <widget class="QCheckBox" name="filterClearCB">
         <property name="text">
          <string>Clear search upon showing menu</string>


### PR DESCRIPTION
Match only from the start of words.  E.g. if I type "ge", assume I
want "GEany" and not "diffuse merGE tool".  This is similar to the
way that tab-completion works in Bash, and saves typing by reducing
the number of results much more quickly.

This also allows shorthand such as "l c" for "Libreoffice Calc".