### PR TITLE
Added an option to toggle volume notifications with keyboard

### DIFF
--- a/plugin-volume/lxqtvolume.cpp
+++ b/plugin-volume/lxqtvolume.cpp
@@ -54,7 +54,8 @@ LXQtVolume::LXQtVolume(const ILXQtPanelPluginStartupInfo &startupInfo):
         m_engine(0),
         m_defaultSinkIndex(0),
         m_defaultSink(0),
-        m_allwaysShowNotifications(SETTINGS_DEFAULT_ALLWAYS_SHOW_NOTIFICATIONS)
+        m_allwaysShowNotifications(SETTINGS_DEFAULT_ALLWAYS_SHOW_NOTIFICATIONS),
+        m_showKeyboardNotifications(SETTINGS_DEFAULT_SHOW_KEYBOARD_NOTIFICATIONS)
 {
     m_volumeButton = new VolumeButton(this);
 
@@ -201,6 +202,9 @@ void LXQtVolume::settingsChanged()
     m_volumeButton->setMixerCommand(settings()->value(QStringLiteral(SETTINGS_MIXER_COMMAND), QStringLiteral(SETTINGS_DEFAULT_MIXER_COMMAND)).toString());
     m_volumeButton->volumePopup()->setSliderStep(settings()->value(QStringLiteral(SETTINGS_STEP), SETTINGS_DEFAULT_STEP).toInt());
     m_allwaysShowNotifications = settings()->value(QStringLiteral(SETTINGS_ALLWAYS_SHOW_NOTIFICATIONS), SETTINGS_DEFAULT_ALLWAYS_SHOW_NOTIFICATIONS).toBool();
+    m_showKeyboardNotifications = settings()->value(QStringLiteral(SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS), SETTINGS_DEFAULT_SHOW_KEYBOARD_NOTIFICATIONS).toBool()
+                                  // in case the config file was edited manually (see LXQtVolumeConfiguration)
+                                  || m_allwaysShowNotifications;
 
     if (!new_engine)
         handleSinkListChanged();
@@ -279,7 +283,8 @@ QDialog *LXQtVolume::configureDialog()
 
 void LXQtVolume::showNotification(bool forceShow) const
 {
-    if (forceShow || m_allwaysShowNotifications)
+    if ((forceShow && m_showKeyboardNotifications)  // force only if volume change should be notified with keyboard
+        || m_allwaysShowNotifications)
     {
         if (Q_LIKELY(m_defaultSink))
         {

--- a/plugin-volume/lxqtvolume.h
+++ b/plugin-volume/lxqtvolume.h
@@ -80,6 +80,7 @@ private:
     LXQt::Notification *m_notification;
     QPointer<LXQtVolumeConfiguration> m_configDialog;
     bool m_allwaysShowNotifications;
+    bool m_showKeyboardNotifications;
 };
 
 

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -48,6 +48,7 @@ LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool 
     connect(ui->stepSpinBox, SIGNAL(valueChanged(int)), this, SLOT(stepSpinBoxChanged(int)));
     connect(ui->ignoreMaxVolumeCheckBox, SIGNAL(toggled(bool)), this, SLOT(ignoreMaxVolumeCheckBoxChanged(bool)));
     connect(ui->allwaysShowNotificationsCheckBox, &QAbstractButton::toggled, this, &LXQtVolumeConfiguration::allwaysShowNotificationsCheckBoxChanged);
+    connect(ui->showKeyboardNotificationsCheckBox, &QAbstractButton::toggled, this, &LXQtVolumeConfiguration::showKeyboardNotificationsCheckBoxChanged);
 
 
     // currently, this option is only supported by the pulse audio backend
@@ -143,7 +144,20 @@ void LXQtVolumeConfiguration::ignoreMaxVolumeCheckBoxChanged(bool state)
 void LXQtVolumeConfiguration::allwaysShowNotificationsCheckBoxChanged(bool state)
 {
     settings().setValue(QStringLiteral(SETTINGS_ALLWAYS_SHOW_NOTIFICATIONS), state);
+    // since always showing notifications is the sufficient condition for showing them with keyboard,
+    // self-consistency requires setting the latter to true whenever the former is toggled by the user
+    ui->showKeyboardNotificationsCheckBox->setEnabled(!state);
+    if (!ui->showKeyboardNotificationsCheckBox->isChecked())
+        ui->showKeyboardNotificationsCheckBox->setChecked(true);
+    else
+        settings().setValue(QStringLiteral(SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS), true);
 }
+
+void LXQtVolumeConfiguration::showKeyboardNotificationsCheckBoxChanged(bool state)
+{
+    settings().setValue(QStringLiteral(SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS), state);
+}
+
 
 void LXQtVolumeConfiguration::loadSettings()
 {
@@ -162,5 +176,15 @@ void LXQtVolumeConfiguration::loadSettings()
     ui->stepSpinBox->setValue(settings().value(QStringLiteral(SETTINGS_STEP), SETTINGS_DEFAULT_STEP).toInt());
     ui->ignoreMaxVolumeCheckBox->setChecked(settings().value(QStringLiteral(SETTINGS_IGNORE_MAX_VOLUME), SETTINGS_DEFAULT_IGNORE_MAX_VOLUME).toBool());
     ui->allwaysShowNotificationsCheckBox->setChecked(settings().value(QStringLiteral(SETTINGS_ALLWAYS_SHOW_NOTIFICATIONS), SETTINGS_DEFAULT_ALLWAYS_SHOW_NOTIFICATIONS).toBool());
+    // always showing notifications is the sufficient condition for showing them with keyboard
+    if (ui->allwaysShowNotificationsCheckBox->isChecked())
+    {
+        ui->showKeyboardNotificationsCheckBox->setChecked(true);
+        ui->showKeyboardNotificationsCheckBox->setEnabled(false);
+    }
+    else
+    {
+        ui->showKeyboardNotificationsCheckBox->setChecked(settings().value(QStringLiteral(SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS), SETTINGS_DEFAULT_SHOW_KEYBOARD_NOTIFICATIONS).toBool());
+    }
 }
 

--- a/plugin-volume/lxqtvolumeconfiguration.h
+++ b/plugin-volume/lxqtvolumeconfiguration.h
@@ -41,6 +41,7 @@
 #define SETTINGS_IGNORE_MAX_VOLUME      "ignoreMaxVolume"
 #define SETTINGS_AUDIO_ENGINE           "audioEngine"
 #define SETTINGS_ALLWAYS_SHOW_NOTIFICATIONS "allwaysShowNotifications"
+#define SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS "showKeyboardNotifications"
 
 #define SETTINGS_DEFAULT_SHOW_ON_LEFTCLICK      true
 #define SETTINGS_DEFAULT_MUTE_ON_MIDDLECLICK    true
@@ -59,6 +60,7 @@
 #define SETTINGS_DEFAULT_IGNORE_MAX_VOLUME      false
 #define SETTINGS_DEFAULT_IGNORE_MAX_VOLUME      false
 #define SETTINGS_DEFAULT_ALLWAYS_SHOW_NOTIFICATIONS false
+#define SETTINGS_DEFAULT_SHOW_KEYBOARD_NOTIFICATIONS true
 
 class AudioDevice;
 
@@ -84,6 +86,7 @@ public slots:
     void stepSpinBoxChanged(int step);
     void ignoreMaxVolumeCheckBoxChanged(bool state);
     void allwaysShowNotificationsCheckBoxChanged(bool state);
+    void showKeyboardNotificationsCheckBoxChanged(bool state);
 
 protected slots:
     virtual void loadSettings();

--- a/plugin-volume/lxqtvolumeconfiguration.ui
+++ b/plugin-volume/lxqtvolumeconfiguration.ui
@@ -86,6 +86,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="showKeyboardNotificationsCheckBox">
+        <property name="text">
+         <string>Notify about volume changes with keyboard</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label">


### PR DESCRIPTION
If "Always notify about…" is checked, the new box "Notify about volume changes with keyboard" will be disabled and checked. If the user unchecks the former, the latter will be enabled. Finally, if the user unchecks the second box, all notifications will be disabled.

The change is backward-compatible because the default value of the new key is "true".

Closes https://github.com/lxqt/lxqt-panel/issues/1171