### PR TITLE
Made quicklaunch respect Panel's lock state.

### DIFF
--- a/panel/ilxqtpanel.h
+++ b/panel/ilxqtpanel.h
@@ -122,6 +122,11 @@ public:
      * \sa ILXQtPanelPlugin::isSeparate(), ILXQtPanelPlugin::isExpandable
      */
     virtual void pluginFlagsChanged(const ILXQtPanelPlugin * plugin) = 0;
+
+    /*!
+     * \brief Checks if the panel is locked.
+     */
+    virtual bool isLocked() const = 0;
 };
 
 #endif // ILXQTPANEL_H

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -147,6 +147,7 @@ public:
     QRect calculatePopupWindowPos(const ILXQtPanelPlugin *plugin, const QSize &windowSize) const override;
     void willShowWindow(QWidget * w) override;
     void pluginFlagsChanged(const ILXQtPanelPlugin * plugin) override;
+    bool isLocked() const override { return mLockPanel; }
     // ........ end of ILXQtPanel overrides
 
     /**

--- a/plugin-quicklaunch/lxqtquicklaunch.cpp
+++ b/plugin-quicklaunch/lxqtquicklaunch.cpp
@@ -172,6 +172,12 @@ void LXQtQuickLaunch::addButton(QuickLaunchAction* action)
 
 void LXQtQuickLaunch::dragEnterEvent(QDragEnterEvent *e)
 {
+    if (mPlugin->panel()->isLocked())
+    {
+        e->ignore();
+        return;
+    }
+
     // Getting URL from mainmenu...
     if (e->mimeData()->hasUrls())
     {
@@ -188,6 +194,12 @@ void LXQtQuickLaunch::dragEnterEvent(QDragEnterEvent *e)
 
 void LXQtQuickLaunch::dropEvent(QDropEvent *e)
 {
+    if (mPlugin->panel()->isLocked())
+    {
+        e->ignore();
+        return;
+    }
+
     const auto urls = e->mimeData()->urls().toSet();
     for (const QUrl &url : urls)
     {

--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -95,8 +95,9 @@ void QuickLaunchButton::this_customContextMenuRequested(const QPoint & /*pos*/)
 {
     LXQtQuickLaunch *panel = qobject_cast<LXQtQuickLaunch*>(parent());
 
-    mMoveLeftAct->setEnabled( panel && panel->indexOfButton(this) > 0);
-    mMoveRightAct->setEnabled(panel && panel->indexOfButton(this) < panel->countOfButtons() - 1);
+    mMoveLeftAct->setEnabled(!mPlugin->panel()->isLocked() && panel && panel->indexOfButton(this) > 0);
+    mMoveRightAct->setEnabled(!mPlugin->panel()->isLocked() && panel && panel->indexOfButton(this) < panel->countOfButtons() - 1);
+    mDeleteAct->setEnabled(!mPlugin->panel()->isLocked());
     mPlugin->willShowWindow(mMenu);
     mMenu->popup(mPlugin->panel()->calculatePopupWindowPos(mapToGlobal({0, 0}), mMenu->sizeHint()).topLeft());
 }
@@ -133,7 +134,7 @@ void QuickLaunchButton::mousePressEvent(QMouseEvent *e)
 
 void QuickLaunchButton::mouseMoveEvent(QMouseEvent *e)
 {
-    if (!(e->buttons() & Qt::LeftButton))
+    if (mPlugin->panel()->isLocked() || !(e->buttons() & Qt::LeftButton))
     {
         return;
     }
@@ -165,7 +166,7 @@ void QuickLaunchButton::mouseMoveEvent(QMouseEvent *e)
 
 void QuickLaunchButton::dragMoveEvent(QDragMoveEvent * e)
 {
-    if (e->mimeData()->hasFormat(QStringLiteral(MIMETYPE)))
+    if (!mPlugin->panel()->isLocked() && e->mimeData()->hasFormat(QStringLiteral(MIMETYPE)))
         e->acceptProposedAction();
     else
         e->ignore();
@@ -174,9 +175,11 @@ void QuickLaunchButton::dragMoveEvent(QDragMoveEvent * e)
 
 void QuickLaunchButton::dragEnterEvent(QDragEnterEvent *e)
 {
-    const ButtonMimeData *mimeData = qobject_cast<const ButtonMimeData*>(e->mimeData());
-    if (mimeData && mimeData->button())
-    {
-        emit switchButtons(mimeData->button(), this);
+    if (!mPlugin->panel()->isLocked()) {
+        const ButtonMimeData *mimeData = qobject_cast<const ButtonMimeData*>(e->mimeData());
+        if (mimeData && mimeData->button())
+        {
+            emit switchButtons(mimeData->button(), this);
+        }
     }
 }


### PR DESCRIPTION
DND is also considerd (dropping of main menu items and moving icons while pressing `Ctrl`).

Closes https://github.com/lxqt/lxqt/issues/1746