### PR TITLE
Cleanup and fixes for taksbar code

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -567,13 +567,18 @@ void LXQtTaskBar::wheelEvent(QWheelEvent* event)
         return QFrame::wheelEvent(event);
 
     static int threshold = 0;
-    threshold += abs(event->delta());
+
+    QPoint angleDelta = event->angleDelta();
+    Qt::Orientation orient = (qAbs(angleDelta.x()) > qAbs(angleDelta.y()) ? Qt::Horizontal : Qt::Vertical);
+    int delta = (orient == Qt::Horizontal ? angleDelta.x() : angleDelta.y());
+
+    threshold += abs(delta);
     if (threshold < mWheelDeltaThreshold)
         return QFrame::wheelEvent(event);
     else
         threshold = 0;
 
-    int delta = event->delta() < 0 ? 1 : -1;
+    int D = delta < 0 ? 1 : -1;
 
     // create temporary list of visible groups in the same order like on the layout
     QList<LXQtTaskGroup*> list;
@@ -602,10 +607,10 @@ void LXQtTaskBar::wheelEvent(QWheelEvent* event)
     // switching between groups from temporary list in modulo addressing
     while (!button)
     {
-        button = group->getNextPrevChildButton(delta == 1, !(list.count() - 1));
+        button = group->getNextPrevChildButton(D == 1, !(list.count() - 1));
         if (button)
             button->raiseApplication();
-        int idx = (list.indexOf(group) + delta + list.count()) % list.count();
+        int idx = (list.indexOf(group) + D + list.count()) % list.count();
         group = list.at(idx);
     }
     QFrame::wheelEvent(event);

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -60,22 +60,22 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
 
     /* We use clicked() and activated(int) because these signals aren't emitting after programmaticaly
         change of state */
-    connect(ui->limitByDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->limitByDesktopCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->limitByDesktopCB, &QCheckBox::stateChanged, ui->showDesktopNumCB, &QWidget::setEnabled);
-    connect(ui->showDesktopNumCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(ui->limitByScreenCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->limitByMinimizedCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->raiseOnCurrentDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->buttonStyleCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(ui->buttonWidthSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
-    connect(ui->buttonHeightSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
-    connect(ui->autoRotateCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->middleClickCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->groupingGB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->showGroupOnHoverCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->iconByClassCB, &QCheckBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
-    connect(ui->wheelEventsActionCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(ui->wheelDeltaThresholdSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
+    connect(ui->showDesktopNumCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->limitByScreenCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->limitByMinimizedCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->raiseOnCurrentDesktopCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->buttonStyleCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->buttonWidthSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->buttonHeightSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->autoRotateCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->middleClickCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->groupingGB, &QGroupBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->showGroupOnHoverCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->iconByClassCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->wheelEventsActionCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->wheelDeltaThresholdSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
 }
 
 LXQtTaskbarConfiguration::~LXQtTaskbarConfiguration()

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -284,19 +284,24 @@ void LXQtTaskButton::wheelEvent(QWheelEvent* event)
         return QToolButton::wheelEvent(event);
 
     static int threshold = 0;
-    threshold += abs(event->delta());
+
+    QPoint angleDelta = event->angleDelta();
+    Qt::Orientation orient = (qAbs(angleDelta.x()) > qAbs(angleDelta.y()) ? Qt::Horizontal : Qt::Vertical);
+    int delta = (orient == Qt::Horizontal ? angleDelta.x() : angleDelta.y());
+
+    threshold += abs(delta);
     if (threshold < mParentTaskBar->wheelDeltaThreshold())
         return QToolButton::wheelEvent(event);
     else
         threshold = 0;
 
-    int delta = event->delta() < 0 ? 1 : -1;
+    int D = delta < 0 ? 1 : -1;
     if (mParentTaskBar->wheelEventsAction() == 3)
-        delta *= -1;
+        D *= -1;
 
-    if (delta < 0)
+    if (D < 0)
         raiseApplication();
-    else if (delta > 0)
+    else if (D > 0)
         minimizeApplication();
 
     QToolButton::wheelEvent(event);


### PR DESCRIPTION
(1) The obsolete method `QWheelEvent::delta` is replaced.

(2) The signal-slot connection syntax is updated (only in a relevant source file).

(3) The signal `QSpinBox::valueChanged` is replaced by `QAbstractSpinBox::editingFinished` to prevent redundant writes (that should be done in all similar places, IMHO).

NOTE: This is a fix for https://github.com/lxqt/lxqt-panel/pull/1161