### PR TITLE
Qt Workaround: Reset panel style sheet before updating it

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -764,6 +764,11 @@ void LXQtPanel::showAddPluginDialog()
  ************************************************/
 void LXQtPanel::updateStyleSheet()
 {
+    // NOTE: This is a workaround for Qt >= 5.13, which might not completely
+    // update the style sheet (especially positioned backgrounds of plugins
+    // with NeedsHandle="true") if it is not reset first.
+    setStyleSheet(QString());
+
     QStringList sheet;
     sheet << QStringLiteral("Plugin > QAbstractButton, LXQtTray { qproperty-iconSize: %1px %1px; }").arg(mIconSize);
     sheet << QStringLiteral("Plugin > * > QAbstractButton, TrayIcon { qproperty-iconSize: %1px %1px; }").arg(mIconSize);


### PR DESCRIPTION
Since Qt 5.13, positioned backgrounds of plugins (so-called "handles") aren't updated on changing panel position. This should be a new Qt bug. As a workaround, the stylesheet is reset before being updated.

Closes https://github.com/lxqt/lxqt-panel/issues/1164