### PR TITLE
quicklaunch: Remove press-and-hold popup menu from launchers.

### DIFF
--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -63,7 +63,7 @@ QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, ILXQtPanelPlugin *
 
     mDeleteAct = new QAction(XdgIcon::fromTheme(QStringLiteral("dialog-close")), tr("Remove from quicklaunch"), this);
     connect(mDeleteAct, SIGNAL(triggered()), this, SLOT(selfRemove()));
-    addAction(mDeleteAct);
+
     mMenu = new QMenu(this);
     mMenu->addAction(mAct);
     mMenu->addActions(mAct->addtitionalActions());
@@ -72,7 +72,6 @@ QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, ILXQtPanelPlugin *
     mMenu->addAction(mMoveRightAct);
     mMenu->addSeparator();
     mMenu->addAction(mDeleteAct);
-
 
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(const QPoint&)),
@@ -108,17 +107,6 @@ void QuickLaunchButton::this_customContextMenuRequested(const QPoint & /*pos*/)
 void QuickLaunchButton::selfRemove()
 {
     emit buttonDeleted();
-}
-
-
-void QuickLaunchButton::paintEvent(QPaintEvent *)
-{
-    // Do not paint that ugly "has menu" arrow
-    QStylePainter p(this);
-    QStyleOptionToolButton opt;
-    initStyleOption(&opt);
-    opt.features &= (~ QStyleOptionToolButton::HasMenu);
-    p.drawComplexControl(QStyle::CC_ToolButton, opt);
 }
 
 

--- a/plugin-quicklaunch/quicklaunchbutton.h
+++ b/plugin-quicklaunch/quicklaunchbutton.h
@@ -53,8 +53,6 @@ signals:
     void movedRight();
 
 protected:
-    //! Disable that annoying small arrow when there is a menu
-    virtual void paintEvent(QPaintEvent *);
     void mousePressEvent(QMouseEvent *e);
     void mouseMoveEvent(QMouseEvent *e);
     void dragEnterEvent(QDragEnterEvent *e);


### PR DESCRIPTION
It's unnecessary because we already have the right-click context
menu which provides the same options (and then some).

This fixes the issue of the launcher buttons being too wide (#1223)
because Qt no longer allocates space for the little arrow that
indicates the presence of a popup menu.  (The arrow was previously
hidden by overriding paintEvent(), but space was still allocated.)