### PR TITLE
Removed QDesktopWidget from panel

### DIFF
--- a/panel/config/configpanelwidget.cpp
+++ b/panel/config/configpanelwidget.cpp
@@ -33,7 +33,7 @@
 #include <KWindowSystem/KWindowSystem>
 #include <QDebug>
 #include <QListView>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QWindow>
 #include <QColorDialog>
 #include <QFileDialog>
@@ -171,7 +171,7 @@ void ConfigPanelWidget::reset()
  ************************************************/
 void ConfigPanelWidget::fillComboBox_position()
 {
-    int screenCount = QApplication::desktop()->screenCount();
+    int screenCount = QApplication::screens().size();
     if (screenCount == 1)
     {
         addPosition(tr("Top of desktop"), 0, LXQtPanel::PositionTop);
@@ -384,13 +384,16 @@ void ConfigPanelWidget::widthTypeChanged()
  ************************************************/
 int ConfigPanelWidget::getMaxLength()
 {
-    QDesktopWidget* dw = QApplication::desktop();
-
-    if (mPosition == ILXQtPanel::PositionTop ||
-        mPosition == ILXQtPanel::PositionBottom)
-        return dw->screenGeometry(mScreenNum).width();
-    else
-        return dw->screenGeometry(mScreenNum).height();
+    auto screens = QApplication::screens();
+    if (screens.size() > mScreenNum)
+    {
+        if (mPosition == ILXQtPanel::PositionTop ||
+            mPosition == ILXQtPanel::PositionBottom)
+            return screens.at(mScreenNum)->geometry().width();
+        else
+            return screens.at(mScreenNum)->geometry().height();
+    }
+    return 0;
 }
 
 

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -674,7 +674,7 @@ void LXQtPanel::updateWmStrut()
 
 
 /************************************************
-  The panel can't be placed on boundary of two displays.
+  The panel can be placed only at the edges of the virtual screen.
   This function checks if the panel can be placed on the display
   @screenNum on @position.
  ************************************************/
@@ -683,12 +683,13 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
     const auto screens = QApplication::screens();
     if (screens.size() > screenNum)
     {
+        const QRect screenGeometry = screens.at(screenNum)->geometry();
         switch (position)
         {
         case LXQtPanel::PositionTop:
             for (const auto& screen : screens)
             {
-                if (screen->geometry().bottom() < screens.at(screenNum)->geometry().top())
+                if (screen->geometry().top() < screenGeometry.top())
                     return false;
             }
             return true;
@@ -696,7 +697,7 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
         case LXQtPanel::PositionBottom:
             for (const auto& screen : screens)
             {
-                if (screen->geometry().top() > screens.at(screenNum)->geometry().bottom())
+                if (screen->geometry().bottom() > screenGeometry.bottom())
                     return false;
             }
             return true;
@@ -704,7 +705,7 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
         case LXQtPanel::PositionLeft:
             for (const auto& screen : screens)
             {
-                if (screen->geometry().right() < screens.at(screenNum)->geometry().left())
+                if (screen->geometry().left() < screenGeometry.left())
                     return false;
             }
             return true;
@@ -712,7 +713,7 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
         case LXQtPanel::PositionRight:
             for (const auto& screen : screens)
             {
-                if (screen->geometry().left() > screens.at(screenNum)->geometry().right())
+                if (screen->geometry().right() > screenGeometry.right())
                     return false;
             }
             return true;

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -229,6 +229,9 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
 
     loadPlugins();
 
+    // NOTE: Some (X11) WMs may need the geometry to be set before QWidget::show().
+    setPanelGeometry();
+
     show();
 
     // show it the first time, despite setting


### PR DESCRIPTION
Qt → `src/widgets/kernel/qdesktopwidget.cpp` was consulted.

NOTE: Although the patch passed my tests with two monitors (by changing their alignment and resolutions and also repositioning the panel), it needs more tests.