### PR TITLE
Check if panel is under mouse on auto-hiding

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1332,7 +1332,7 @@ void LXQtPanel::hidePanel()
 
 void LXQtPanel::hidePanelWork()
 {
-    if (!geometry().contains(QCursor::pos()))
+    if (!testAttribute(Qt::WA_UnderMouse))
     {
         if (!mStandaloneWindows->isAnyWindowShown())
         {


### PR DESCRIPTION
…Instead of checking if its rectangle contains the cursor.

Fixes https://github.com/lxqt/lxqt-panel/issues/1266