### PR TITLE
[WIP] kbindicator: Add basic support for country flags

### DIFF
--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -126,10 +126,9 @@ bool Content::eventFilter(QObject *object, QEvent *event)
         else if(object == m_layout){
             emit controlClicked(Controls::Layout);
         }
-        return true;
     }
 
-    return QObject::eventFilter(object, event);
+    return QWidget::eventFilter(object, event);
 }
 
 void Content::showHorizontal()

--- a/plugin-kbindicator/src/content.h
+++ b/plugin-kbindicator/src/content.h
@@ -31,6 +31,7 @@
 #include "controls.h"
 
 class QLabel;
+class QToolButton;
 
 class Content : public QWidget
 {
@@ -55,10 +56,11 @@ signals:
     void controlClicked(Controls cnt);
 private:
     bool        m_layoutEnabled;
+    QString     m_layoutFlagPattern;
     QLabel     *m_capsLock;
     QLabel     *m_numLock;
     QLabel     *m_scrollLock;
-    QLabel     *m_layout;
+    QToolButton *m_layout;
 };
 
 #endif

--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -44,6 +44,7 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
     connect(m_ui->showNum,    &QCheckBox::clicked, this, &KbdStateConfig::save);
     connect(m_ui->showScroll, &QCheckBox::clicked, this, &KbdStateConfig::save);
     connect(m_ui->showLayout, &QGroupBox::clicked, this, &KbdStateConfig::save);
+    connect(m_ui->layoutFlagPattern, &QLineEdit::textEdited, this, &KbdStateConfig::save);
 
     connect(m_ui->modes, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
         [this](int){
@@ -76,6 +77,7 @@ void KbdStateConfig::load()
     m_ui->showNum->setChecked(sets.showNumLock());
     m_ui->showScroll->setChecked(sets.showScrollLock());
     m_ui->showLayout->setChecked(sets.showLayout());
+    m_ui->layoutFlagPattern->setText(sets.layoutFlagPattern());
 
     switch(sets.keeperType()){
     case KeeperType::Global:
@@ -98,6 +100,7 @@ void KbdStateConfig::save()
     sets.setShowNumLock(m_ui->showNum->isChecked());
     sets.setShowScrollLock(m_ui->showScroll->isChecked());
     sets.setShowLayout(m_ui->showLayout->isChecked());
+    sets.setLayoutFlagPattern(m_ui->layoutFlagPattern->text());
 
     if (m_ui->switchGlobal->isChecked())
         sets.setKeeperType(KeeperType::Global);

--- a/plugin-kbindicator/src/kbdstateconfig.ui
+++ b/plugin-kbindicator/src/kbdstateconfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>249</width>
-    <height>354</height>
+    <width>384</width>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,15 +55,15 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="policyLabel">
         <property name="text">
          <string>Switching policy</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0" colspan="2">
        <widget class="QRadioButton" name="switchGlobal">
         <property name="text">
          <string>Global</string>
@@ -73,7 +73,7 @@
         </attribute>
        </widget>
       </item>
-      <item>
+      <item row="2" column="0" colspan="2">
        <widget class="QRadioButton" name="switchWindow">
         <property name="text">
          <string>Window</string>
@@ -83,7 +83,7 @@
         </attribute>
        </widget>
       </item>
-      <item>
+      <item row="3" column="0" colspan="2">
        <widget class="QRadioButton" name="switchApplication">
         <property name="text">
          <string>Application</string>
@@ -91,6 +91,21 @@
         <attribute name="buttonGroup">
          <string notr="true">modes</string>
         </attribute>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Flags path pattern:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="layoutFlagPattern">
+        <property name="toolTip">
+         <string>File path pattern for country flags. Must contain &lt;strong&gt;%1&lt;/strong&gt; which is replaced by the two letter ISO country code (lower case).&lt;br/&gt;
+Example: /usr/share/iso-flags-svg/country-squared/%1.svg</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/plugin-kbindicator/src/kbdwatcher.cpp
+++ b/plugin-kbindicator/src/kbdwatcher.cpp
@@ -41,6 +41,8 @@ void KbdWatcher::setup()
 
     if (!m_keeper || m_keeper->type() != Settings::instance().keeperType()){
         createKeeper(Settings::instance().keeperType());
+    } else {
+        keeperChanged();
     }
 }
 

--- a/plugin-kbindicator/src/settings.cpp
+++ b/plugin-kbindicator/src/settings.cpp
@@ -53,6 +53,9 @@ bool Settings::showScrollLock() const
 bool Settings::showLayout() const
 { return m_settings->value(QStringLiteral("show_layout"), true).toBool(); }
 
+QString Settings::layoutFlagPattern() const
+{ return m_settings->value(QStringLiteral("layout_flag_pattern"), true).toString(); }
+
 void Settings::setShowCapLock(bool show)
 { m_settings->setValue(QStringLiteral("show_caps_lock"), show); }
 
@@ -64,6 +67,9 @@ void Settings::setShowScrollLock(bool show)
 
 void Settings::setShowLayout(bool show)
 { m_settings->setValue(QStringLiteral("show_layout"), show); }
+
+void Settings::setLayoutFlagPattern(const QString & layoutFlagPattern)
+{ m_settings->setValue(QStringLiteral("layout_flag_pattern"), layoutFlagPattern); }
 
 KeeperType Settings::keeperType() const
 {

--- a/plugin-kbindicator/src/settings.h
+++ b/plugin-kbindicator/src/settings.h
@@ -50,6 +50,7 @@ public:
     bool showNumLock() const;
     bool showScrollLock() const;
     bool showLayout() const;
+    QString layoutFlagPattern() const;
     KeeperType keeperType() const;
     void restore();
 
@@ -58,6 +59,7 @@ public:
     void setShowNumLock(bool show);
     void setShowScrollLock(bool show);
     void setShowLayout(bool show);
+    void setLayoutFlagPattern(const QString & layoutFlagPattern);
     void setKeeperType(KeeperType type) const;
 
 private:


### PR DESCRIPTION
ref. lxqt/lxqt#1162

This is some kind of basic support for displaying country flags instead of letters. We don't provide any flag images by our self, instead the user can set a pattern for constructing the path for flag. In case of empty/wrong configuration or file with flag does not exist (or is not an image easily shown by `QIcon`) the indicator falls back to the letter country code.

I tested it with the debian's [iso-flags-svg](https://tracker.debian.org/pkg/iso-flags-svg).

Is something like that acceptable?