### PR TITLE
mainmenu: Clear search edit on hide, rather than on show.

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -173,10 +173,6 @@ void LXQtMainMenu::showMenu()
     mMenu->popup(calculatePopupWindowPos(mMenu->sizeHint()).topLeft());
     if (mFilterMenu || mFilterShow)
     {
-        if (mFilterClear && !mSearchEdit->text().isEmpty())
-        {
-            mSearchEdit->setText(QString{});
-        }
         //Note: part of the workadound for https://bugreports.qt.io/browse/QTBUG-52021
         mSearchEdit->setReadOnly(false);
         //the setReadOnly also changes the cursor, override it back to normal
@@ -263,6 +259,8 @@ void LXQtMainMenu::settingsChanged()
     {
         mSearchEdit->setVisible(mFilterMenu || mFilterShow);
         mSearchEditAction->setVisible(mFilterMenu || mFilterShow);
+        if (mFilterClear && !mMenu->isVisible())
+            mSearchEdit->clear();
     }
     mSearchView->setMaxItemsToShow(settings()->value(QStringLiteral("filterShowMaxItems"), 10).toInt());
     mSearchView->setMaxItemWidth(settings()->value(QStringLiteral("filterShowMaxWidth"), 300).toInt());
@@ -424,7 +422,11 @@ void LXQtMainMenu::buildMenu()
     //(if the readOnly is not set, the "blink" timer is active also in case the menu is not shown ->
     //QWidgetLineControl::updateNeeded is performed w/o any need)
     //https://bugreports.qt.io/browse/QTBUG-52021
-    connect(mMenu, &QMenu::aboutToHide, [this] { mSearchEdit->setReadOnly(true); });
+    connect(mMenu, &QMenu::aboutToHide, [this] {
+        mSearchEdit->setReadOnly(true);
+        if (mFilterClear)
+            mSearchEdit->clear();
+    });
     mSearchEdit->setVisible(mFilterMenu || mFilterShow);
     mSearchEditAction->setVisible(mFilterMenu || mFilterShow);
     mSearchView->fillActions(mMenu);


### PR DESCRIPTION
This prevents the fade-out animation of the "clear" icon which
would occur when the menu was shown the next time after performing
a search.  IMHO, animations on newly-shown widgets are undesirable.