### PR TITLE
Task button: Option to move window with mouse wheel

### DIFF
--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -49,6 +49,8 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     ui->wheelEventsActionCB->addItem(tr("Cycle windows on wheel scrolling"), 1);
     ui->wheelEventsActionCB->addItem(tr("Scroll up to raise, down to minimize"), 2);
     ui->wheelEventsActionCB->addItem(tr("Scroll up to minimize, down to raise"), 3);
+    ui->wheelEventsActionCB->addItem(tr("Scroll up to move to next desktop, down to previous"), 4);
+    ui->wheelEventsActionCB->addItem(tr("Scroll up to move to previous desktop, down to next"), 5);
 
     ui->showDesktopNumCB->addItem(tr("Current"), 0);
     //Note: in KWindowSystem desktops are numbered from 1..N

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -122,6 +122,8 @@ protected:
     inline ILXQtPanelPlugin * plugin() const { return mPlugin; }
 
 private:
+    void moveApplicationToPrevNextDesktop(bool next);
+
     WId mWindow;
     bool mUrgencyHint;
     QPoint mDragStartPosition;
@@ -129,10 +131,14 @@ private:
     LXQtTaskBar * mParentTaskBar;
     ILXQtPanelPlugin * mPlugin;
     int mIconSize;
+    int mWheelDelta;
 
     // Timer for when draggind something into a button (the button's window
     // must be activated so that the use can continue dragging to the window
     QTimer * mDNDTimer;
+
+    // Timer for distinguishing between separate mouse wheel rotations
+    QTimer * mWheelTimer;
 
 private slots:
     void activateWithDraggable();

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -597,6 +597,22 @@ void LXQtTaskGroup::mouseReleaseEvent(QMouseEvent* event)
 /************************************************
 
  ************************************************/
+
+void LXQtTaskGroup::wheelEvent(QWheelEvent* event)
+{
+    if (mSingleButton)
+    {
+        LXQtTaskButton::wheelEvent(event);
+        return;
+    }
+    // if there are multiple buttons, just show the popup
+    setPopupVisible(true);
+    QToolButton::wheelEvent(event);
+}
+
+/************************************************
+
+ ************************************************/
 bool LXQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2)
 { // returns true if the class is preserved
     bool needsRefreshVisibility{false};

--- a/plugin-taskbar/lxqttaskgroup.h
+++ b/plugin-taskbar/lxqttaskgroup.h
@@ -83,6 +83,7 @@ protected:
     void contextMenuEvent(QContextMenuEvent * event);
     void mouseMoveEvent(QMouseEvent * event);
     void mouseReleaseEvent(QMouseEvent *event);
+    void wheelEvent(QWheelEvent* event);
     int recalculateFrameHeight() const;
     int recalculateFrameWidth() const;
 


### PR DESCRIPTION
This patch adds two options to move window to next/previous desktop by scrolling up/down and conversely. It also corrects two flaws:

 1. It considers two mouse wheel rotations separate from each other if there is a minimum interval of 250ms between them. Without this, delta threshold won't make sense because delta could have increased 2 minutes ago, for example. Moreover, wheel movement will be impractical without it.

 2. It shows the group popup for grouped buttons on wheel rotation, instead of applying the wheel event (to raise, minimize, move…). The reason is that, otherwise, the user couldn't predict what will happen to which window inside the group.

Closes https://github.com/lxqt/lxqt-panel/issues/1356