### PR TITLE
Task Button: Add option to move to next monitor

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -610,12 +610,12 @@ void LXQtTaskButton::moveApplicationToPrevNextMonitor(bool next)
                 QRect targetScreenGeometry = screens[targetScreen]->geometry();
                 int X = windowGeometry.x() - screenGeometry.x() + targetScreenGeometry.x();
                 int Y = windowGeometry.y() - screenGeometry.y() + targetScreenGeometry.y();
-                NET::States state = KWindowInfo(mWindow, NET::WMState).state();
-                //      NW geometry |     x/y      |  from panel
-                const int flags = 1 | (0b011 << 8) | (0b011 << 12);
+                NET::States state = KWindowInfo(mWindow, NET::WMState).state();                
+                //      NW geometry |     y/x      |  from panel
+                const int flags = 1 | (0b011 << 8) | (0b010 << 12);
                 KWindowSystem::clearState(mWindow, NET::MaxHoriz | NET::MaxVert | NET::Max | NET::FullScreen);
                 NETRootInfo(QX11Info::connection(), 0, NET::WM2MoveResizeWindow).moveResizeWindowRequest(mWindow, flags, X, Y, 0, 0);            
-                QTimer::singleShot(200, [=]()
+                QTimer::singleShot(200, this, [this, state]
                 {
                     KWindowSystem::setState(mWindow, state);
                     raiseApplication();
@@ -733,7 +733,8 @@ void LXQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
         connect(a, SIGNAL(triggered(bool)), this, SLOT(moveApplicationToDesktop()));
     }
     /********** Move/Resize **********/
-    if(QGuiApplication::screens().size() > 1){
+    if (QGuiApplication::screens().size() > 1)
+    {
         menu->addSeparator();
         a = menu->addAction(tr("Move To &Next Monitor"));
         connect(a, &QAction::triggered, this, [this] { moveApplicationToPrevNextMonitor(true); });

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -610,7 +610,6 @@ void LXQtTaskButton::moveApplicationToPrevNextMonitor(bool next)
                 QRect targetScreenGeometry = screens[targetScreen]->geometry();
                 int X = windowGeometry.x() - screenGeometry.x() + targetScreenGeometry.x();
                 int Y = windowGeometry.y() - screenGeometry.y() + targetScreenGeometry.y();
-                ;
                 NET::States state = KWindowInfo(mWindow, NET::WMState).state();
                 //      NW geometry |     x/y      |  from panel
                 const int flags = 1 | (0b011 << 8) | (0b011 << 12);

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -606,7 +606,7 @@ void LXQtTaskButton::moveApplicationToNextMonitor()
                 int Y = windowGeometry.y() - screenGeometry.y() + nextScreenGeometry.y();
                 //      NW geometry |     x/y      |  from panel
                 const int flags = 1 | (0b011 << 8) | (0b010 << 12);
-                NETRootInfo(QX11Info::connection(), NET::Properties()).moveResizeWindowRequest(mWindow, flags, X, Y, 0, 0);
+                NETRootInfo(QX11Info::connection(), 0, NET::WM2MoveResizeWindow).moveResizeWindowRequest(mWindow, flags, X, Y, 0, 0);
                 break;
             }
         }
@@ -723,7 +723,6 @@ void LXQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     if(QGuiApplication::screens().size() > 1){
         menu->addSeparator();
         a = menu->addAction(tr("Move To &Next Monitor"));
-        a->setEnabled(info.actionSupported(NET::ActionMove));
         connect(a, &QAction::triggered, this, &LXQtTaskButton::moveApplicationToNextMonitor); 
     }
     menu->addSeparator();

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -93,8 +93,7 @@ public slots:
     void shadeApplication();
     void unShadeApplication();
     void closeApplication();
-    void moveApplicationToDesktop();
-    
+    void moveApplicationToDesktop();    
     void moveApplication();
     void resizeApplication();
     void setApplicationLayer();

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -94,6 +94,7 @@ public slots:
     void unShadeApplication();
     void closeApplication();
     void moveApplicationToDesktop();
+    void moveApplicationToNextMonitor();
     void moveApplication();
     void resizeApplication();
     void setApplicationLayer();

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -94,7 +94,7 @@ public slots:
     void unShadeApplication();
     void closeApplication();
     void moveApplicationToDesktop();
-    void moveApplicationToNextMonitor();
+    
     void moveApplication();
     void resizeApplication();
     void setApplicationLayer();
@@ -124,7 +124,7 @@ protected:
 
 private:
     void moveApplicationToPrevNextDesktop(bool next);
-
+    void moveApplicationToPrevNextMonitor(bool next);
     WId mWindow;
     bool mUrgencyHint;
     QPoint mDragStartPosition;


### PR DESCRIPTION
Implemented this option which i find very useful in other DEs, since my second screen is a TV and it's not always on, i'm a noob in c++, so let me know if something needs fixing... Also since i was digging through kwindowsystem and qt docs for this, i can try to remove QDesktopWidget later since it is being deprecated.
![move](https://user-images.githubusercontent.com/33790211/75746369-d5648180-5cf8-11ea-9040-6c15c286b085.png)
