### PR TITLE
By default, clear the menu text search whenever the menu is closed

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -253,7 +253,7 @@ void LXQtMainMenu::settingsChanged()
     mSearchEdit->setText(QString{});
     mFilterMenu = settings()->value(QStringLiteral("filterMenu"), true).toBool();
     mFilterShow = settings()->value(QStringLiteral("filterShow"), true).toBool();
-    mFilterClear = settings()->value(QStringLiteral("filterClear"), false).toBool();
+    mFilterClear = settings()->value(QStringLiteral("filterClear"), true).toBool();
     mFilterShowHideMenu = settings()->value(QStringLiteral("filterShowHideMenu"), true).toBool();
     if (mMenu)
     {

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -143,7 +143,7 @@ void LXQtMainMenuConfiguration::loadSettings()
     ui->filterShowMaxWidthSB->setValue(settings().value(QStringLiteral("filterShowMaxWidth"), 300).toInt());
     ui->filterShowHideMenuCB->setEnabled(filter_show);
     ui->filterShowHideMenuCB->setChecked(settings().value(QStringLiteral("filterShowHideMenu"), true).toBool());
-    ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), false).toBool());
+    ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), true).toBool());
     ui->filterClearCB->setEnabled(filter_menu || filter_show);
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt/issues/1492

When the user does a search and then closes the menu, it's because one of two things happened:

1. They didn't find what they were looking for, and gave up

2. They did find what they were looking for, and the menu closed automatically

In either case, it's safe to assume that the user is probably not going to repeat the same search the next time the menu is opened. So, in the spirit of making things easy for the most common use cases, let's change the default here. (And in the spirit of making uncommon things possible there is still a setting for changing the behavior back.)