### PR TITLE
Use our own brightness icon for the new backlight plugin

### DIFF
--- a/plugin-backlight/backlight.cpp
+++ b/plugin-backlight/backlight.cpp
@@ -32,11 +32,11 @@ LXQtBacklight::LXQtBacklight(const ILXQtPanelPluginStartupInfo &startupInfo):
         ILXQtPanelPlugin(startupInfo)
 {
     m_backlightButton = new QToolButton();
-    //m_backlightButton->setIcon(QIcon::fromTheme(QStringLiteral("video-display")));
-    m_backlightButton->setIcon(QIcon::fromTheme(QStringLiteral("display-brightness-symbolic")));
-    
+    // use our own icon
+    m_backlightButton->setIcon(QIcon::fromTheme(QStringLiteral("brightnesssettings")));
+
     connect(m_backlightButton, SIGNAL(clicked(bool)), this, SLOT(showSlider(bool)));
-    
+
     m_backlightSlider = nullptr;
 }
 

--- a/plugin-backlight/resources/backlight.desktop.in
+++ b/plugin-backlight/resources/backlight.desktop.in
@@ -3,6 +3,6 @@ Type=Service
 ServiceTypes=LXQtPanel/Plugin
 Name=Backlight
 Comment=Sets display backlight
-Icon=display-brightness-symbolic
+Icon=brightnesssettings
 
 #TRANSLATIONS_DIR=../translations


### PR DESCRIPTION
And not a gnome-specific icon.