### PR TITLE
Fix delayed window activation during drag.

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -421,6 +421,7 @@ void LXQtTaskButton::activateWithDraggable()
     // in progress to allow drop it into an app
     raiseApplication();
     KWindowSystem::forceActiveWindow(mWindow);
+    xcb_flush(QX11Info::connection());
 }
 
 /************************************************


### PR DESCRIPTION
The timer-activated forceActiveWindow() call was not flushed to the
X server. As a result, the window was not activated until the timer
expired *and* the mouse was moved again. After adding the explicit
flush, the window is properly activated when the timer fires.