### PR TITLE
Let panel be at virtual screen edges but not between screens

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -677,23 +677,28 @@ void LXQtPanel::updateWmStrut()
 
 
 /************************************************
-  The panel can be placed only at the edges of the virtual screen.
-  This function checks if the panel can be placed on the display
-  @screenNum on @position.
+  This function checks if the panel can be placed on
+  the display @screenNum at @position.
+  NOTE: The panel can be placed only at screen edges
+  but no part of it should be between two screens.
  ************************************************/
 bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
 {
     const auto screens = QApplication::screens();
     if (screens.size() > screenNum)
     {
-        const QRect screenGeometry = screens.at(screenNum)->geometry();
+        QRect screenGeometry = screens.at(screenNum)->geometry();
         switch (position)
         {
         case LXQtPanel::PositionTop:
             for (const auto& screen : screens)
             {
                 if (screen->geometry().top() < screenGeometry.top())
-                    return false;
+                {
+                    screenGeometry.setTop(screen->geometry().top());
+                    if (screen->geometry().intersects(screenGeometry))
+                        return false;
+                }
             }
             return true;
 
@@ -701,7 +706,11 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             for (const auto& screen : screens)
             {
                 if (screen->geometry().bottom() > screenGeometry.bottom())
-                    return false;
+                {
+                    screenGeometry.setBottom(screen->geometry().bottom());
+                    if (screen->geometry().intersects(screenGeometry))
+                        return false;
+                }
             }
             return true;
 
@@ -709,7 +718,11 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             for (const auto& screen : screens)
             {
                 if (screen->geometry().left() < screenGeometry.left())
-                    return false;
+                {
+                    screenGeometry.setLeft(screen->geometry().left());
+                    if (screen->geometry().intersects(screenGeometry))
+                        return false;
+                }
             }
             return true;
 
@@ -717,7 +730,11 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             for (const auto& screen : screens)
             {
                 if (screen->geometry().right() > screenGeometry.right())
-                    return false;
+                {
+                    screenGeometry.setRight(screen->geometry().right());
+                    if (screen->geometry().intersects(screenGeometry))
+                        return false;
+                }
             }
             return true;
         }

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -687,7 +687,7 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
     const auto screens = QApplication::screens();
     if (screens.size() > screenNum)
     {
-        QRect screenGeometry = screens.at(screenNum)->geometry();
+        const QRect screenGeometry = screens.at(screenNum)->geometry();
         switch (position)
         {
         case LXQtPanel::PositionTop:
@@ -695,8 +695,8 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             {
                 if (screen->geometry().top() < screenGeometry.top())
                 {
-                    screenGeometry.setTop(screen->geometry().top());
-                    if (screen->geometry().intersects(screenGeometry))
+                    QRect r = screenGeometry.adjusted(0, screen->geometry().top() - screenGeometry.top(), 0, 0);
+                    if (screen->geometry().intersects(r))
                         return false;
                 }
             }
@@ -707,8 +707,8 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             {
                 if (screen->geometry().bottom() > screenGeometry.bottom())
                 {
-                    screenGeometry.setBottom(screen->geometry().bottom());
-                    if (screen->geometry().intersects(screenGeometry))
+                    QRect r = screenGeometry.adjusted(0, 0, 0, screen->geometry().bottom() - screenGeometry.bottom());
+                    if (screen->geometry().intersects(r))
                         return false;
                 }
             }
@@ -719,8 +719,8 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             {
                 if (screen->geometry().left() < screenGeometry.left())
                 {
-                    screenGeometry.setLeft(screen->geometry().left());
-                    if (screen->geometry().intersects(screenGeometry))
+                    QRect r = screenGeometry.adjusted(screen->geometry().left() - screenGeometry.left(), 0, 0, 0);
+                    if (screen->geometry().intersects(r))
                         return false;
                 }
             }
@@ -731,8 +731,8 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
             {
                 if (screen->geometry().right() > screenGeometry.right())
                 {
-                    screenGeometry.setRight(screen->geometry().right());
-                    if (screen->geometry().intersects(screenGeometry))
+                    QRect r = screenGeometry.adjusted(0, 0, screen->geometry().right() - screenGeometry.right(), 0);
+                    if (screen->geometry().intersects(r))
                         return false;
                 }
             }


### PR DESCRIPTION
This patch allows the panel to be positioned at virtual screen edges and not only at the farthest edges, provided that no part of it can be between 2 screens.

Closes https://github.com/lxqt/lxqt/issues/1787