### PR TITLE
Implemented auto-hiding for Status Notifier

### DIFF
--- a/plugin-statusnotifier/CMakeLists.txt
+++ b/plugin-statusnotifier/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Concurrent)
 
 set(HEADERS
     statusnotifier.h
+    statusnotifierconfiguration.h
     dbustypes.h
     statusnotifierbutton.h
     statusnotifieriteminterface.h
@@ -16,12 +17,17 @@ set(HEADERS
 
 set(SOURCES
     statusnotifier.cpp
+    statusnotifierconfiguration.cpp
     dbustypes.cpp
     statusnotifierbutton.cpp
     statusnotifieriteminterface.cpp
     statusnotifierwatcher.cpp
     statusnotifierwidget.cpp
     sniasync.cpp
+)
+
+set(UIS
+    statusnotifierconfiguration.ui
 )
 
 qt5_add_dbus_adaptor(DBUS_SOURCES

--- a/plugin-statusnotifier/statusnotifier.h
+++ b/plugin-statusnotifier/statusnotifier.h
@@ -31,6 +31,7 @@
 
 #include "../panel/ilxqtpanelplugin.h"
 #include "statusnotifierwidget.h"
+#include "statusnotifierconfiguration.h"
 
 class StatusNotifier : public QObject, public ILXQtPanelPlugin
 {
@@ -41,8 +42,12 @@ public:
     bool isSeparate() const { return true; }
     void realign();
     QString themeId() const { return QStringLiteral("StatusNotifier"); }
-    virtual Flags flags() const { return SingleInstance | NeedsHandle; }
+    virtual Flags flags() const { return SingleInstance | HaveConfigDialog | NeedsHandle; }
     QWidget *widget() { return m_widget; }
+
+    QDialog *configureDialog();
+
+    void settingsChanged() { m_widget->settingsChanged(); }
 
 private:
     StatusNotifierWidget *m_widget;

--- a/plugin-statusnotifier/statusnotifier.h
+++ b/plugin-statusnotifier/statusnotifier.h
@@ -45,7 +45,7 @@ public:
     virtual Flags flags() const { return SingleInstance | HaveConfigDialog | NeedsHandle; }
     QWidget *widget() { return m_widget; }
 
-    QDialog *configureDialog();
+    QDialog *configureDialog() override;
 
     void settingsChanged() { m_widget->settingsChanged(); }
 

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -101,7 +101,10 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     // The timer that hides an auto-hiding button after it gets attention:
     mHideTimer.setSingleShot(true);
     mHideTimer.setInterval(300000);
-    connect(&mHideTimer, &QTimer::timeout, this, [this] { hide(); });
+    connect(&mHideTimer, &QTimer::timeout, this, [this] {
+        hide();
+        emit attentionChanged();
+    });
 }
 
 StatusNotifierButton::~StatusNotifierButton()
@@ -344,6 +347,7 @@ void StatusNotifierButton::onNeedingAttention()
     {
         show();
         mHideTimer.start();
+        emit attentionChanged();
     }
 }
 

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -58,7 +58,8 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     mMenu(nullptr),
     mStatus(Passive),
     mFallbackIcon(QIcon::fromTheme(QLatin1String("application-x-executable"))),
-    mPlugin(plugin)
+    mPlugin(plugin),
+    mAutoHide(false)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoRaise(true);
@@ -69,6 +70,12 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     connect(interface, &SniAsync::NewAttentionIcon, this, &StatusNotifierButton::newAttentionIcon);
     connect(interface, &SniAsync::NewToolTip, this, &StatusNotifierButton::newToolTip);
     connect(interface, &SniAsync::NewStatus, this, &StatusNotifierButton::newStatus);
+
+    // get the title only at the start
+    interface->propertyGetAsync(QLatin1String("Title"), [this] (QString value) {
+        mTitle = value;
+        emit titleFound(value);
+    });
 
     interface->propertyGetAsync(QLatin1String("Menu"), [this] (QDBusObjectPath path) {
         if (!path.path().isEmpty())
@@ -90,6 +97,11 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     });
 
     newToolTip();
+
+    // The timer that hides an auto-hiding button after it gets attention:
+    mHideTimer.setSingleShot(true);
+    mHideTimer.setInterval(300000);
+    connect(&mHideTimer, &QTimer::timeout, this, [this] { hide(); });
 }
 
 StatusNotifierButton::~StatusNotifierButton()
@@ -99,6 +111,9 @@ StatusNotifierButton::~StatusNotifierButton()
 
 void StatusNotifierButton::newIcon()
 {
+    if (!icon().isNull() && icon().name() != QLatin1String("application-x-executable"))
+        onNeedingAttention();
+
     interface->propertyGetAsync(QLatin1String("IconThemePath"), [this] (QString value) {
         refetchIcon(Passive, value);
     });
@@ -106,6 +121,8 @@ void StatusNotifierButton::newIcon()
 
 void StatusNotifierButton::newOverlayIcon()
 {
+    onNeedingAttention();
+
     interface->propertyGetAsync(QLatin1String("IconThemePath"), [this] (QString value) {
         refetchIcon(Active, value);
     });
@@ -113,6 +130,8 @@ void StatusNotifierButton::newOverlayIcon()
 
 void StatusNotifierButton::newAttentionIcon()
 {
+    onNeedingAttention();
+
     interface->propertyGetAsync(QLatin1String("IconThemePath"), [this] (QString value) {
         refetchIcon(NeedsAttention, value);
     });
@@ -255,6 +274,8 @@ void StatusNotifierButton::newStatus(QString status)
         return;
 
     mStatus = newStatus;
+    if (mStatus == NeedsAttention)
+        onNeedingAttention();
     resetIcon();
 }
 
@@ -302,4 +323,31 @@ void StatusNotifierButton::resetIcon()
         setIcon(mAttentionIcon);
     else
         setIcon(mFallbackIcon);
+}
+
+void StatusNotifierButton::setAutoHide(bool autoHide, int minutes, bool forcedVisible)
+{
+    if (autoHide)
+        mHideTimer.setInterval(qBound(1, minutes, 60) * 60000);
+    if (mAutoHide != autoHide)
+    {
+        mAutoHide = autoHide;
+        setVisible(!mAutoHide || forcedVisible);
+        if (!mAutoHide)
+            mHideTimer.stop();
+    }
+}
+
+void StatusNotifierButton::onNeedingAttention()
+{
+    if (mAutoHide)
+    {
+        show();
+        mHideTimer.start();
+    }
+}
+
+bool StatusNotifierButton::hasAttention() const
+{
+    return mHideTimer.isActive();
 }

--- a/plugin-statusnotifier/statusnotifierbutton.h
+++ b/plugin-statusnotifier/statusnotifierbutton.h
@@ -72,6 +72,7 @@ public:
 
 signals:
     void titleFound(const QString &title);
+    void attentionChanged();
 
 public slots:
     void newIcon();

--- a/plugin-statusnotifier/statusnotifierbutton.h
+++ b/plugin-statusnotifier/statusnotifierbutton.h
@@ -36,6 +36,7 @@
 #include <QToolButton>
 #include <QWheelEvent>
 #include <QMenu>
+#include <QTimer>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
 template <typename T> inline T qFromUnaligned(const uchar *src)
@@ -63,6 +64,15 @@ public:
         Passive, Active, NeedsAttention
     };
 
+    QString title() const {
+        return mTitle;
+    }
+    bool hasAttention() const;
+    void setAutoHide(bool autoHide, int minutes = 5, bool forcedVisible = false);
+
+signals:
+    void titleFound(const QString &title);
+
 public slots:
     void newIcon();
     void newAttentionIcon();
@@ -71,6 +81,8 @@ public slots:
     void newStatus(QString status);
 
 private:
+    void onNeedingAttention();
+
     SniAsync *interface;
     QMenu *mMenu;
     Status mStatus;
@@ -78,6 +90,10 @@ private:
     QIcon mIcon, mOverlayIcon, mAttentionIcon, mFallbackIcon;
 
     ILXQtPanelPlugin* mPlugin;
+
+    QString mTitle;
+    bool mAutoHide;
+    QTimer mHideTimer;
 
 protected:
     void contextMenuEvent(QContextMenuEvent * event);

--- a/plugin-statusnotifier/statusnotifierconfiguration.cpp
+++ b/plugin-statusnotifier/statusnotifierconfiguration.cpp
@@ -1,0 +1,115 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2020 LXQt team
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "statusnotifierconfiguration.h"
+#include "ui_statusnotifierconfiguration.h"
+#include <QPushButton>
+#include <QComboBox>
+
+StatusNotifierConfiguration::StatusNotifierConfiguration(PluginSettings *settings, QWidget *parent):
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::StatusNotifierConfiguration)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setObjectName(QStringLiteral("StatusNotifierConfigurationWindow"));
+    ui->setupUi(this);
+
+    if (QPushButton *closeBtn = ui->buttons->button(QDialogButtonBox::Close))
+        closeBtn->setDefault(true);
+    connect(ui->buttons, &QDialogButtonBox::clicked, this, &StatusNotifierConfiguration::dialogButtonsAction);
+
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    ui->tableWidget->horizontalHeader()->setSectionsClickable(false);
+    ui->tableWidget->sortByColumn(0, Qt::AscendingOrder);
+
+    loadSettings();
+
+    connect(ui->attentionSB, &QAbstractSpinBox::editingFinished, this, &StatusNotifierConfiguration::saveSettings);
+}
+
+StatusNotifierConfiguration::~StatusNotifierConfiguration()
+{
+    delete ui;
+}
+
+void StatusNotifierConfiguration::loadSettings()
+{
+    ui->attentionSB->setValue(settings().value(QStringLiteral("attentionPeriod"), 5).toInt());
+    mAutoHideList = settings().value(QStringLiteral("autoHideList")).toStringList();
+    mHideList = settings().value(QStringLiteral("hideList")).toStringList();
+}
+
+void StatusNotifierConfiguration::saveSettings()
+{
+    settings().setValue(QStringLiteral("attentionPeriod"), ui->attentionSB->value());
+    settings().setValue(QStringLiteral("autoHideList"), mAutoHideList);
+    settings().setValue(QStringLiteral("hideList"), mHideList);
+}
+
+void StatusNotifierConfiguration::addItems(const QStringList &items)
+{
+    ui->tableWidget->setRowCount(items.size());
+    ui->tableWidget->setSortingEnabled(false);
+    int index = 0;
+    for (const auto &item : items)
+    {
+        // first column
+        QTableWidgetItem *widgetItem = new QTableWidgetItem(item);
+        widgetItem->setFlags(widgetItem->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsSelectable);
+        ui->tableWidget->setItem(index, 0, widgetItem);
+        // second column
+        QComboBox *cb = new QComboBox();
+        cb->addItems(QStringList() << tr("Always show") << tr("Auto-hide") << tr("Always hide"));
+        if (mAutoHideList.contains(item))
+            cb->setCurrentIndex(1);
+        else if (mHideList.contains(item))
+            cb->setCurrentIndex(2);
+        connect(cb, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, item] (int index) {
+            if (index == 0)
+            {
+                mAutoHideList.removeAll(item);
+                mHideList.removeAll(item);
+            }
+            else if (index == 1)
+            {
+                mHideList.removeAll(item);
+                if (!mAutoHideList.contains(item))
+                    mAutoHideList << item;
+            }
+            else if (index == 2)
+            {
+                mAutoHideList.removeAll(item);
+                if (!mHideList.contains(item))
+                    mHideList << item;
+            }
+            saveSettings();
+        });
+        ui->tableWidget->setCellWidget(index, 1, cb);
+        ++ index;
+    }
+    ui->tableWidget->setSortingEnabled(true);
+    ui->tableWidget->horizontalHeader()->setSortIndicatorShown(false);
+    ui->tableWidget->setCurrentCell(0, 1);
+}

--- a/plugin-statusnotifier/statusnotifierconfiguration.cpp
+++ b/plugin-statusnotifier/statusnotifierconfiguration.cpp
@@ -86,19 +86,19 @@ void StatusNotifierConfiguration::addItems(const QStringList &items)
             cb->setCurrentIndex(1);
         else if (mHideList.contains(item))
             cb->setCurrentIndex(2);
-        connect(cb, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, item] (int index) {
-            if (index == 0)
+        connect(cb, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, item] (int indx) {
+            if (indx == 0)
             {
                 mAutoHideList.removeAll(item);
                 mHideList.removeAll(item);
             }
-            else if (index == 1)
+            else if (indx == 1)
             {
                 mHideList.removeAll(item);
                 if (!mAutoHideList.contains(item))
                     mAutoHideList << item;
             }
-            else if (index == 2)
+            else if (indx == 2)
             {
                 mAutoHideList.removeAll(item);
                 if (!mHideList.contains(item))

--- a/plugin-statusnotifier/statusnotifierconfiguration.h
+++ b/plugin-statusnotifier/statusnotifierconfiguration.h
@@ -4,10 +4,7 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2015 LXQt team
- * Authors:
- *  Balázs Béla <balazsbela[at]gmail.com>
- *  Paulo Lieuthier <paulolieuthier@gmail.com>
+ * Copyright: 2020 LXQt team
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -18,7 +15,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+
  * You should have received a copy of the GNU Lesser General
  * Public License along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -26,23 +23,36 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include "statusnotifier.h"
+#ifndef STATUSNOTIFIERCONFIGURATION_H
+#define STATUSNOTIFIERCONFIGURATION_H
 
-StatusNotifier::StatusNotifier(const ILXQtPanelPluginStartupInfo &startupInfo) :
-    QObject(),
-    ILXQtPanelPlugin(startupInfo)
-{
-    m_widget = new StatusNotifierWidget(this);
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include "../panel/pluginsettings.h"
+
+namespace Ui {
+    class StatusNotifierConfiguration;
 }
 
-QDialog *StatusNotifier::configureDialog()
+class StatusNotifierConfiguration : public LXQtPanelPluginConfigDialog
 {
-    auto dialog = new StatusNotifierConfiguration(settings());
-    dialog->addItems(m_widget->itemTitles());
-    return dialog;
-}
+    Q_OBJECT
 
-void StatusNotifier::realign()
-{
-    m_widget->realign();
-}
+public:
+    explicit StatusNotifierConfiguration(PluginSettings *settings, QWidget *parent = nullptr);
+    ~StatusNotifierConfiguration();
+
+    void addItems(const QStringList &items);
+
+private:
+    Ui::StatusNotifierConfiguration *ui;
+
+    QStringList mAutoHideList;
+    QStringList mHideList;
+
+    void loadSettings();
+
+private slots:
+    void saveSettings();
+};
+
+#endif // STATUSNOTIFIERCONFIGURATION_H

--- a/plugin-statusnotifier/statusnotifierconfiguration.ui
+++ b/plugin-statusnotifier/statusnotifierconfiguration.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StatusNotifierConfiguration</class>
+ <widget class="QDialog" name="StatusNotifierConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Status Notifier Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="toolTip">
+        <string>An auto-hiding item will remain visible for this period if it needs attention.</string>
+       </property>
+       <property name="text">
+        <string>Attention period:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="attentionSB">
+       <property name="toolTip">
+        <string>An auto-hiding item will remain visible for this period if it needs attention.</string>
+       </property>
+       <property name="suffix">
+        <string> minute(s)</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Change visibility of items</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QTableWidget" name="tableWidget">
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Item</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Visibility</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttons</sender>
+   <signal>accepted()</signal>
+   <receiver>StatusNotifierConfiguration</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>262</x>
+     <y>496</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttons</sender>
+   <signal>rejected()</signal>
+   <receiver>StatusNotifierConfiguration</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>330</x>
+     <y>496</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -32,13 +32,57 @@
 #include <QFutureWatcher>
 #include <QtConcurrent>
 #include <QDBusConnectionInterface>
+#include "../panel/pluginsettings.h"
 #include "../panel/ilxqtpanelplugin.h"
 
 StatusNotifierWidget::StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *parent) :
     QWidget(parent),
-    mPlugin(plugin)
+    mPlugin(plugin),
+    mAttentionPeriod(5),
+    mForceVisible(false)
 {
     setLayout(new LXQt::GridLayout(this));
+
+    // The button that shows all hidden items:
+    mShowBtn = new QToolButton(this);
+    mShowBtn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    mShowBtn->setAutoRaise(true);
+    mShowBtn->setToolButtonStyle(Qt::ToolButtonIconOnly);
+    mShowBtn->setIcon(QIcon::fromTheme(QLatin1String("dialog-information")));
+    layout()->addWidget(mShowBtn);
+    mShowBtn->hide();
+    connect(mShowBtn, &QAbstractButton::released, [this] {
+        mHideTimer.stop();
+        const auto allButtons = findChildren<StatusNotifierButton *>(QString(), Qt::FindDirectChildrenOnly);
+        for (const auto &btn : allButtons)
+        {
+            if (!btn->isVisible())
+            {
+                mForceVisible = true;
+                btn->show();
+            }
+        }
+    });
+
+    settingsChanged();
+
+    // The timer that hides (auto-)hidden items after 2 seconds:
+    mHideTimer.setSingleShot(true);
+    mHideTimer.setInterval(2000);
+    connect(&mHideTimer, &QTimer::timeout, this, [this] {
+        mForceVisible = false;
+        const auto allButtons = findChildren<StatusNotifierButton *>(QString(), Qt::FindDirectChildrenOnly);
+        for (const auto &btn : allButtons)
+        {
+            if (btn->hasAttention()
+                || (!mAutoHideList.contains(btn->title())
+                     && !mHideList.contains(btn->title())))
+            {
+                continue;
+            }
+            btn->hide();
+        }
+    });
 
     QFutureWatcher<StatusNotifierWatcher *> * future_watcher = new QFutureWatcher<StatusNotifierWatcher *>;
     connect(future_watcher, &QFutureWatcher<StatusNotifierWatcher *>::finished, this, [this, future_watcher]
@@ -70,12 +114,22 @@ StatusNotifierWidget::StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *pa
     future_watcher->setFuture(future);
 
     realign();
-
 }
 
 StatusNotifierWidget::~StatusNotifierWidget()
 {
     delete mWatcher;
+}
+
+void StatusNotifierWidget::leaveEvent(QEvent * /*event*/)
+{
+    if (mForceVisible)
+        mHideTimer.start();
+}
+
+void StatusNotifierWidget::enterEvent(QEvent * /*event*/)
+{
+    mHideTimer.stop();
 }
 
 void StatusNotifierWidget::itemAdded(QString serviceAndPath)
@@ -88,6 +142,22 @@ void StatusNotifierWidget::itemAdded(QString serviceAndPath)
     mServices.insert(serviceAndPath, button);
     layout()->addWidget(button);
     button->show();
+
+    connect(button, &StatusNotifierButton::titleFound, button, [this, button] (const QString &title) {
+        mItemTitles << title;
+        if (mAutoHideList.contains(title))
+        {
+            mShowBtn->show();
+            button->setAutoHide(true, mAttentionPeriod, mHideTimer.isActive());
+        }
+        else if (mHideList.contains(title))
+        {
+            mShowBtn->show();
+            button->setAutoHide(false);
+            if (!mHideTimer.isActive())
+                button->hide();
+        }
+    });
 }
 
 void StatusNotifierWidget::itemRemoved(const QString &serviceAndPath)
@@ -95,8 +165,64 @@ void StatusNotifierWidget::itemRemoved(const QString &serviceAndPath)
     StatusNotifierButton *button = mServices.value(serviceAndPath, nullptr);
     if (button)
     {
+        mItemTitles.removeOne(button->title());
+        if (mShowBtn->isVisible())
+        { // hide mShowBtn if no (auto-)hidden item remains
+            bool showBtn = false;
+            for (const auto &name : qAsConst(mItemTitles))
+            {
+                if (mAutoHideList.contains(name) || mHideList.contains(name))
+                {
+                    showBtn = true;
+                    break;
+                }
+            }
+            if (!showBtn)
+            {
+                mHideTimer.stop();
+                mForceVisible = false;
+                mShowBtn->hide();
+            }
+        }
         button->deleteLater();
         layout()->removeWidget(button);
+        mServices.remove(serviceAndPath);
+    }
+}
+
+void StatusNotifierWidget::settingsChanged()
+{
+    mAttentionPeriod = mPlugin->settings()->value(QStringLiteral("attentionPeriod"), 5).toInt();
+    mAutoHideList = mPlugin->settings()->value(QStringLiteral("autoHideList")).toStringList();
+    mHideList = mPlugin->settings()->value(QStringLiteral("hideList")).toStringList();
+
+    // show/hide items as well as showBtn appropriately
+    const auto allButtons = findChildren<StatusNotifierButton *>(QString(), Qt::FindDirectChildrenOnly);
+    bool showBtn = false;
+    for (const auto &btn : allButtons)
+    {
+        if (mAutoHideList.contains(btn->title()))
+        {
+            showBtn = true;
+            btn->setAutoHide(true, mAttentionPeriod);
+        }
+        else if (mHideList.contains(btn->title()))
+        {
+            showBtn = true;
+            btn->setAutoHide(false);
+            btn->hide();
+        }
+        else
+        {
+            btn->setAutoHide(false);
+            btn->show(); // may have been in mHideList before
+        }
+    }
+    mShowBtn->setVisible(showBtn);
+    if (!showBtn)
+    {
+        mHideTimer.stop();
+        mForceVisible = false;
     }
 }
 
@@ -118,4 +244,11 @@ void StatusNotifierWidget::realign()
     }
 
     layout->setEnabled(true);
+}
+
+QStringList StatusNotifierWidget::itemTitles() const
+{
+    QStringList names = mItemTitles;
+    names.removeDuplicates();
+    return names;
 }

--- a/plugin-statusnotifier/statusnotifierwidget.h
+++ b/plugin-statusnotifier/statusnotifierwidget.h
@@ -45,6 +45,7 @@ public:
     StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *parent = nullptr);
     ~StatusNotifierWidget();
 
+    void settingsChanged();
     QStringList itemTitles() const;
 
 signals:
@@ -52,7 +53,7 @@ signals:
 public slots:
     void itemAdded(QString serviceAndPath);
     void itemRemoved(const QString &serviceAndPath);
-    void settingsChanged();
+
     void realign();
 
 protected:

--- a/plugin-statusnotifier/statusnotifierwidget.h
+++ b/plugin-statusnotifier/statusnotifierwidget.h
@@ -30,6 +30,7 @@
 #define STATUSNOTIFIERWIDGET_H
 
 #include <QDir>
+#include <QTimer>
 
 #include <LXQt/GridLayout>
 
@@ -44,19 +45,34 @@ public:
     StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *parent = nullptr);
     ~StatusNotifierWidget();
 
+    QStringList itemTitles() const;
+
 signals:
 
 public slots:
     void itemAdded(QString serviceAndPath);
     void itemRemoved(const QString &serviceAndPath);
-
+    void settingsChanged();
     void realign();
+
+protected:
+    void leaveEvent(QEvent *event) override;
+    void enterEvent(QEvent *event) override;
 
 private:
     ILXQtPanelPlugin *mPlugin;
     StatusNotifierWatcher *mWatcher;
 
+    QTimer mHideTimer;
+
     QHash<QString, StatusNotifierButton*> mServices;
+
+    QStringList mItemTitles;
+    QStringList mAutoHideList;
+    QStringList mHideList;
+    QToolButton *mShowBtn;
+    int mAttentionPeriod;
+    bool mForceVisible;
 };
 
 #endif // STATUSNOTIFIERWIDGET_H


### PR DESCRIPTION
The items can be auto-hidden or always shown/hidden. The default is "Always show".

If there are (auto-)hidden items, an extra button will appear, which shows all items when clicked; then (auto-)hidden items will be made hidden again after 2 seconds if the the mouse cursor leaves Status Notifier.

The auto-hidden items that need attention are shown for 5 minutes (the interval is configurable). Apart from explicit attention requests, an icon change is also interpreted as an attention request with auto-hiding. That's useful, for example, when a battery or WiFi icon changes.

Closes https://github.com/lxqt/lxqt/issues/1012