### PR TITLE
Remove delayed initialization of tray icons.

### DIFF
--- a/plugin-tray/trayicon.cpp
+++ b/plugin-tray/trayicon.cpp
@@ -88,12 +88,8 @@ TrayIcon::TrayIcon(Window iconId, QSize const & iconSize, QWidget* parent):
 
     setObjectName(QStringLiteral("TrayIcon"));
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    // NOTE:
-    // see https://github.com/lxqt/lxqt/issues/945
-    // workaround: delayed init because of weird behaviour of some icons/windows (claws-mail)
-    // (upon starting the app the window for receiving clicks wasn't correctly sized
-    //  no matter what we've done)
-    QTimer::singleShot(200, [this] { init(); update(); });
+    init();
+    update();
 }
 
 


### PR DESCRIPTION
This workaround causes https://github.com/lxqt/lxqt/issues/1817.
I myself cannot reproduce https://github.com/lxqt/lxqt/issues/945 after this change, so to me it seems safe to remove this workaround.

@renegat since you reported that issue a few years back and in case you're still around and reading this: can you confirm that https://github.com/lxqt/lxqt/issues/945 is no longer happening even with this workaround removed?

In any case, I'm creating this pull request for you to discuss, if you rather want to keep having https://github.com/lxqt/lxqt/issues/1817 or take the risk of reintroducing https://github.com/lxqt/lxqt/issues/945.