### PR TITLE
Taskbar: Add option to place new windows next to existing windows of same class when ungrouped

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -307,7 +307,7 @@ void LXQtTaskBar::addWindow(WId window)
         });
         mLayout->addWidget(group);
         group->setToolButtonsStyle(mButtonStyle);
-                const QString window_class = QString::fromUtf8(KWindowInfo(window, NET::Properties(), NET::WM2WindowClass).windowClassClass());
+        const QString window_class = QString::fromUtf8(KWindowInfo(window, NET::Properties(), NET::WM2WindowClass).windowClassClass());
         int src_index = mLayout->count() - 1;
         int dst_index = src_index;
         if (mUngroupedNextToExisting)
@@ -318,8 +318,9 @@ void LXQtTaskBar::addWindow(WId window)
                 if (nullptr != group)
                 {
                     const QString current_class = QString::fromUtf8(KWindowInfo((group->groupName()).toUInt(), NET::Properties(), NET::WM2WindowClass).windowClassClass());
-                    if(current_class == window_class){
-                        dst_index = i +1;
+                    if(current_class == window_class)
+                    {
+                        dst_index = i + 1;
                         break;
                     }
                 }

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -307,17 +307,18 @@ void LXQtTaskBar::addWindow(WId window)
         });
         mLayout->addWidget(group);
         group->setToolButtonsStyle(mButtonStyle);
-        const QString window_class = QString::fromUtf8(KWindowInfo(window, NET::Properties(), NET::WM2WindowClass).windowClassClass());
-        int src_index = mLayout->count() - 1;
-        int dst_index = src_index;
+
         if (mUngroupedNextToExisting)
         {
+            const QString window_class = QString::fromUtf8(KWindowInfo(window, NET::Properties(), NET::WM2WindowClass).windowClassClass());
+            int src_index = mLayout->count() - 1;
+            int dst_index = src_index;
             for (int i = mLayout->count() - 2; 0 <= i; --i)
             {
-                LXQtTaskGroup * group = qobject_cast<LXQtTaskGroup*>(mLayout->itemAt(i)->widget());
-                if (nullptr != group)
+                LXQtTaskGroup * current_group = qobject_cast<LXQtTaskGroup*>(mLayout->itemAt(i)->widget());
+                if (nullptr != current_group)
                 {
-                    const QString current_class = QString::fromUtf8(KWindowInfo((group->groupName()).toUInt(), NET::Properties(), NET::WM2WindowClass).windowClassClass());
+                    const QString current_class = QString::fromUtf8(KWindowInfo((current_group->groupName()).toUInt(), NET::Properties(), NET::WM2WindowClass).windowClassClass());
                     if(current_class == window_class)
                     {
                         dst_index = i + 1;

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -136,6 +136,7 @@ private:
     bool mAutoRotate;
     bool mGroupingEnabled;
     bool mShowGroupOnHover;
+    bool mUngroupedNextToExisting;
     bool mIconByClass;
     int mWheelEventsAction;
     int mWheelDeltaThreshold;

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -58,6 +58,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     for (int i = 1; desk_cnt >= i; ++i)
         ui->showDesktopNumCB->addItem(QString(QStringLiteral("%1 - %2")).arg(i).arg(KWindowSystem::desktopName(i)), i);
 
+    ui->ungroupedNextToExistingCB->setEnabled(!(ui->groupingGB->isChecked()));
     loadSettings();
 
     /* We use clicked() and activated(int) because these signals aren't emitting after programmaticaly
@@ -73,7 +74,10 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     connect(ui->buttonHeightSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->autoRotateCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->middleClickCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
-    connect(ui->groupingGB, &QGroupBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->groupingGB, &QGroupBox::clicked, this, [this] {
+        saveSettings();
+        ui->ungroupedNextToExistingCB->setEnabled(!(ui->groupingGB->isChecked()));
+    });
     connect(ui->showGroupOnHoverCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->ungroupedNextToExistingCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->iconByClassCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -58,9 +58,8 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     for (int i = 1; desk_cnt >= i; ++i)
         ui->showDesktopNumCB->addItem(QString(QStringLiteral("%1 - %2")).arg(i).arg(KWindowSystem::desktopName(i)), i);
 
-    ui->ungroupedNextToExistingCB->setEnabled(!(ui->groupingGB->isChecked()));
     loadSettings();
-
+    ui->ungroupedNextToExistingCB->setEnabled(!(ui->groupingGB->isChecked()));
     /* We use clicked() and activated(int) because these signals aren't emitting after programmaticaly
         change of state */
     connect(ui->limitByDesktopCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -75,6 +75,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     connect(ui->middleClickCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->groupingGB, &QGroupBox::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->showGroupOnHoverCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->ungroupedNextToExistingCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->iconByClassCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->wheelEventsActionCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->wheelDeltaThresholdSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
@@ -102,6 +103,7 @@ void LXQtTaskbarConfiguration::loadSettings()
     ui->buttonHeightSB->setValue(settings().value(QStringLiteral("buttonHeight"), 100).toInt());
     ui->groupingGB->setChecked(settings().value(QStringLiteral("groupingEnabled"),true).toBool());
     ui->showGroupOnHoverCB->setChecked(settings().value(QStringLiteral("showGroupOnHover"),true).toBool());
+    ui->ungroupedNextToExistingCB->setChecked(settings().value(QStringLiteral("ungroupedNextToExisting"),false).toBool());
     ui->iconByClassCB->setChecked(settings().value(QStringLiteral("iconByClass"), false).toBool());
     ui->wheelEventsActionCB->setCurrentIndex(ui->wheelEventsActionCB->findData(settings().value(QStringLiteral("wheelEventsAction"), 0).toInt()));
     ui->wheelDeltaThresholdSB->setValue(settings().value(QStringLiteral("wheelDeltaThreshold"), 300).toInt());
@@ -121,6 +123,7 @@ void LXQtTaskbarConfiguration::saveSettings()
     settings().setValue(QStringLiteral("raiseOnCurrentDesktop"), ui->raiseOnCurrentDesktopCB->isChecked());
     settings().setValue(QStringLiteral("groupingEnabled"),ui->groupingGB->isChecked());
     settings().setValue(QStringLiteral("showGroupOnHover"),ui->showGroupOnHoverCB->isChecked());
+    settings().setValue(QStringLiteral("ungroupedNextToExisting"),ui->ungroupedNextToExistingCB->isChecked());
     settings().setValue(QStringLiteral("iconByClass"),ui->iconByClassCB->isChecked());
     settings().setValue(QStringLiteral("wheelEventsAction"),ui->wheelEventsActionCB->itemData(ui->wheelEventsActionCB->currentIndex()));
     settings().setValue(QStringLiteral("wheelDeltaThreshold"),ui->wheelDeltaThresholdSB->value());

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -159,7 +159,7 @@
    <item>
     <widget class="QCheckBox" name="ungroupedNextToExistingCB">
      <property name="text">
-      <string>Ungrouped windows added next to existing window of same class</string>
+      <string>Put buttons of the same class next to each other</string>
      </property>
     </widget>
    </item>

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -114,23 +114,23 @@
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="wheelDeltaThresholdSB">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>300</number>
-          </property>
-         </widget>
+        <widget class="QSpinBox" name="wheelDeltaThresholdSB">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="suffix">
+          <string> px</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>300</number>
+         </property>
+        </widget>
         </item>
        </layout>
       </item>

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>401</width>
-    <height>512</height>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,23 +114,23 @@
          </widget>
         </item>
         <item>
-        <widget class="QSpinBox" name="wheelDeltaThresholdSB">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="suffix">
-          <string> px</string>
-         </property>
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>300</number>
-         </property>
-        </widget>
+         <widget class="QSpinBox" name="wheelDeltaThresholdSB">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>300</number>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -154,6 +154,13 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="ungroupedNextToExistingCB">
+     <property name="text">
+      <string>Ungrouped windows added next to existing window of same class</string>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
This option places new windows right after existing windows of the same class, when ungrouped. I think it's a very useful feature for those who use ungrouped windows.

instead of for example:
`terminal | pcman | firefox | pcman | terminal`
if reorders as:
`terminal | terminal | pcman | pcman | firefox`
and next terminal is placed between terminal and pcman, it just moves the new window to the right of last window of the same class.

Not sure about the config ui, couldn't come up with a better description and placement for the checkbox.
The code could be improved, maybe adding class name to `LXQtTaskGroup` for easier searching.

![sort-taskbar](https://user-images.githubusercontent.com/33790211/85941575-2167b180-b8fa-11ea-8508-cdc04611678f.png)