### PR TITLE
Prevent possible C++11 range loop container detachment

### DIFF
--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -227,7 +227,8 @@ void DesktopSwitch::onCurrentDesktopChanged(int current)
     if (mShowOnlyActive)
     {
         int i = 1;
-        for (auto button : m_buttons->buttons())
+        const auto buttons = m_buttons->buttons();
+        for (const auto button : buttons)
         {
             if (current == i)
             {


### PR DESCRIPTION
Just make the container const.