### PR TITLE
Remove not needed allocation

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -481,7 +481,7 @@ void LXQtWorldClock::updatePopupContent()
 bool LXQtWorldClock::formatHasTimeZone(QString format)
 {
     format.replace(QRegExp(QLatin1String("'[^']*'")), QString());
-    return format.toLower().contains(QLatin1String("t"));
+    return format.contains(QLatin1Char('t'), Qt::CaseInsensitive);
 }
 
 QString LXQtWorldClock::preformat(const QString &format, const QTimeZone &timeZone, const QDateTime &dateTime)


### PR DESCRIPTION
When searching for a lowercase in case sensitive mode, there's no need to
convert the string to lowercase.
A QLatin1Char() is enough here.