### PR TITLE
Fixed the sizes and alignments of some plugins at startup

### DIFF
--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -412,8 +412,12 @@ void Plugin::mouseDoubleClickEvent(QMouseEvent*)
  ************************************************/
 void Plugin::showEvent(QShowEvent *)
 {
+    // ensure that plugin widgets have correct sizes at startup
     if (mPluginWidget)
+    {
+        mPluginWidget->updateGeometry(); // needed for widgets with style sizes (like buttons)
         mPluginWidget->adjustSize();
+    }
 }
 
 


### PR DESCRIPTION
Plugins whose widgets are (tool) buttons need both a geometry update and a size adjustment when they are shown; otherwise, their style sizes will be used and their alignments will be incorrect. Doing so for all plugins guarantees correct sizes everywhere.

Fixes https://github.com/lxqt/lxqt-panel/issues/1425