### PR TITLE
Support optical drives with slot loading and a dedicated eject button

### DIFF
--- a/plugin-mount/CMakeLists.txt
+++ b/plugin-mount/CMakeLists.txt
@@ -10,6 +10,9 @@ set(HEADERS
     actions/deviceaction_info.h
     actions/deviceaction_menu.h
     actions/deviceaction_nothing.h
+    actions/ejectaction.h
+    actions/ejectaction_optical.h
+    actions/ejectaction_nothing.h
 )
 
 set(SOURCES
@@ -22,6 +25,9 @@ set(SOURCES
     actions/deviceaction_info.cpp
     actions/deviceaction_menu.cpp
     actions/deviceaction_nothing.cpp
+    actions/ejectaction.cpp
+    actions/ejectaction_optical.cpp
+    actions/ejectaction_nothing.cpp
 )
 
 set(UIS
@@ -29,6 +35,6 @@ set(UIS
 )
 
 find_package(KF5Solid ${QT_MINIMUM_VERSION} REQUIRED)
-set(LIBRARIES Qt5Xdg KF5::Solid)
+set(LIBRARIES Qt5Xdg lxqt-globalkeys KF5::Solid)
 
 BUILD_LXQT_PLUGIN(${PLUGIN})

--- a/plugin-mount/actions/ejectaction.cpp
+++ b/plugin-mount/actions/ejectaction.cpp
@@ -1,0 +1,86 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2020 LXQt team
+ * Authors:
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "ejectaction.h"
+#include "ejectaction_nothing.h"
+#include "ejectaction_optical.h"
+#include "../lxqtmountplugin.h"
+
+#define ACT_NOTHING       "nothing"
+#define ACT_EJECT_OPTICAL "ejectOpticalDrives"
+
+#define ACT_NOTHING_UPPER       QStringLiteral(ACT_NOTHING).toUpper()
+#define ACT_EJECT_OPTICAL_UPPER QStringLiteral(ACT_EJECT_OPTICAL).toUpper()
+
+EjectAction::EjectAction(LXQtMountPlugin *plugin, QObject *parent)
+    : QObject(parent)
+    , mPlugin(plugin)
+{
+}
+
+EjectAction::~EjectAction()
+{
+}
+
+EjectAction *EjectAction::create(ActionId id, LXQtMountPlugin *plugin, QObject *parent)
+{
+    switch (id)
+    {
+    case ActionNothing:
+        return new EjectActionNothing(plugin, parent);
+
+    case ActionOptical:
+        return new EjectActionOptical(plugin, parent);
+    }
+
+    return nullptr;
+}
+
+QString EjectAction::actionIdToString(EjectAction::ActionId id)
+{
+    switch (id)
+    {
+    case ActionNothing:    return QStringLiteral(ACT_NOTHING);
+    case ActionOptical:    return QStringLiteral(ACT_EJECT_OPTICAL);
+    }
+
+    return QStringLiteral(ACT_NOTHING);
+}
+
+void EjectAction::onEjectPressed(void)
+{
+    doEjectPressed();
+}
+
+EjectAction::ActionId EjectAction::stringToActionId(const QString &string, ActionId defaultValue)
+{
+    QString s = string.toUpper();
+    if (s == ACT_NOTHING_UPPER)          return ActionNothing;
+    if (s == ACT_EJECT_OPTICAL_UPPER)    return ActionOptical;
+
+    return defaultValue;
+}

--- a/plugin-mount/actions/ejectaction.h
+++ b/plugin-mount/actions/ejectaction.h
@@ -4,9 +4,9 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2010-2011 Razor team
+ * Copyright: 2020 LXQt team
  * Authors:
- *   Alexander Sokoloff <sokoloff.a@gmail.com>
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,37 +25,41 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#ifndef LXQT_PLUGIN_MOUNT_CONFIGURATION_H
-#define LXQT_PLUGIN_MOUNT_CONFIGURATION_H
+#ifndef LXQT_PLUGIN_MOUNT_EJECTACTION_H
+#define LXQT_PLUGIN_MOUNT_EJECTACTION_H
 
-#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include <QObject>
+#include <QSettings>
+#include <Solid/Device>
 
-#define CFG_KEY_ACTION    "newDeviceAction"
-#define CFG_EJECT_ACTION  "ejectAction"
-#define ACT_SHOW_MENU     "showMenu"
-#define ACT_SHOW_INFO     "showInfo"
-#define ACT_NOTHING       "nothing"
-#define ACT_EJECT_OPTICAL "ejectOpticalDrives"
+class LXQtMountPlugin;
 
-namespace Ui {
-    class Configuration;
-}
-
-class Configuration : public LXQtPanelPluginConfigDialog
+class EjectAction: public QObject
 {
     Q_OBJECT
 
 public:
-    explicit Configuration(PluginSettings *settings, QWidget *parent = nullptr);
-    ~Configuration();
+    enum ActionId
+    {
+        ActionNothing,
+        ActionOptical
+    };
 
-protected slots:
-    virtual void loadSettings();
-    void devAddedChanged(int index);
-    void ejectPressedChanged(int index);
+    virtual ~EjectAction();
+    virtual ActionId Type() const throw () = 0;
 
-private:
-    Ui::Configuration *ui;
+    static EjectAction *create(ActionId id, LXQtMountPlugin *plugin, QObject *parent = nullptr);
+    static ActionId stringToActionId(const QString &string, ActionId defaultValue);
+    static QString actionIdToString(ActionId id);
+
+public slots:
+    void onEjectPressed(void);
+
+protected:
+    explicit EjectAction(LXQtMountPlugin *plugin, QObject *parent = nullptr);
+    virtual void doEjectPressed() = 0;
+
+    LXQtMountPlugin *mPlugin;
 };
 
-#endif // LXQTMOUNTCONFIGURATION_H
+#endif // EJECTACTION_H

--- a/plugin-mount/actions/ejectaction_nothing.cpp
+++ b/plugin-mount/actions/ejectaction_nothing.cpp
@@ -4,9 +4,9 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2010-2011 Razor team
+ * Copyright: 2020 LXQt team
  * Authors:
- *   Alexander Sokoloff <sokoloff.a@gmail.com>
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,37 +25,13 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#ifndef LXQT_PLUGIN_MOUNT_CONFIGURATION_H
-#define LXQT_PLUGIN_MOUNT_CONFIGURATION_H
+#include "ejectaction_nothing.h"
 
-#include "../panel/lxqtpanelpluginconfigdialog.h"
-
-#define CFG_KEY_ACTION    "newDeviceAction"
-#define CFG_EJECT_ACTION  "ejectAction"
-#define ACT_SHOW_MENU     "showMenu"
-#define ACT_SHOW_INFO     "showInfo"
-#define ACT_NOTHING       "nothing"
-#define ACT_EJECT_OPTICAL "ejectOpticalDrives"
-
-namespace Ui {
-    class Configuration;
+EjectActionNothing::EjectActionNothing(LXQtMountPlugin *plugin, QObject *parent):
+    EjectAction(plugin, parent)
+{
 }
 
-class Configuration : public LXQtPanelPluginConfigDialog
+void EjectActionNothing::doEjectPressed(void)
 {
-    Q_OBJECT
-
-public:
-    explicit Configuration(PluginSettings *settings, QWidget *parent = nullptr);
-    ~Configuration();
-
-protected slots:
-    virtual void loadSettings();
-    void devAddedChanged(int index);
-    void ejectPressedChanged(int index);
-
-private:
-    Ui::Configuration *ui;
-};
-
-#endif // LXQTMOUNTCONFIGURATION_H
+}

--- a/plugin-mount/actions/ejectaction_nothing.h
+++ b/plugin-mount/actions/ejectaction_nothing.h
@@ -4,9 +4,9 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2010-2011 Razor team
+ * Copyright: 2020 LXQt team
  * Authors:
- *   Alexander Sokoloff <sokoloff.a@gmail.com>
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,37 +25,23 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#ifndef LXQT_PLUGIN_MOUNT_CONFIGURATION_H
-#define LXQT_PLUGIN_MOUNT_CONFIGURATION_H
 
-#include "../panel/lxqtpanelpluginconfigdialog.h"
+#ifndef LXQT_PLUGIN_MOUNT_EJECTACTION_NOTHING_H
+#define LXQT_PLUGIN_MOUNT_EJECTACTION_NOTHING_H
 
-#define CFG_KEY_ACTION    "newDeviceAction"
-#define CFG_EJECT_ACTION  "ejectAction"
-#define ACT_SHOW_MENU     "showMenu"
-#define ACT_SHOW_INFO     "showInfo"
-#define ACT_NOTHING       "nothing"
-#define ACT_EJECT_OPTICAL "ejectOpticalDrives"
+#include "ejectaction.h"
+#include <QWidget>
 
-namespace Ui {
-    class Configuration;
-}
-
-class Configuration : public LXQtPanelPluginConfigDialog
+class EjectActionNothing : public EjectAction
 {
     Q_OBJECT
 
 public:
-    explicit Configuration(PluginSettings *settings, QWidget *parent = nullptr);
-    ~Configuration();
+    explicit EjectActionNothing(LXQtMountPlugin *plugin, QObject *parent = nullptr);
+    virtual ActionId Type() const throw () { return ActionNothing; };
 
-protected slots:
-    virtual void loadSettings();
-    void devAddedChanged(int index);
-    void ejectPressedChanged(int index);
-
-private:
-    Ui::Configuration *ui;
+protected:
+    void doEjectPressed(void);
 };
 
-#endif // LXQTMOUNTCONFIGURATION_H
+#endif // EJECTACTION_NOTHING_H

--- a/plugin-mount/actions/ejectaction_optical.cpp
+++ b/plugin-mount/actions/ejectaction_optical.cpp
@@ -1,0 +1,60 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2020 LXQt team
+ * Authors:
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "../lxqtmountplugin.h"
+#include "ejectaction_optical.h"
+
+#include <Solid/StorageAccess>
+#include <Solid/StorageDrive>
+#include <Solid/DeviceNotifier>
+#include <Solid/OpticalDrive>
+
+#include <LXQt/Notification>
+//#include <QDebug>
+
+EjectActionOptical::EjectActionOptical(LXQtMountPlugin *plugin, QObject *parent):
+    EjectAction(plugin, parent)
+{
+}
+
+void EjectActionOptical::doEjectPressed(void)
+{
+    for (const Solid::Device& device : Solid::Device::listFromType(Solid::DeviceInterface::OpticalDrive))
+    {
+        Solid::Device it;
+        if (device.isValid())
+        {
+            it = device;
+            //qDebug() << "device : " << it.udi() << "\n";
+            // search for parent drive
+            for (; !it.udi().isEmpty(); it = it.parent())
+                if (it.is<Solid::OpticalDrive>())
+                    it.as<Solid::OpticalDrive>()->eject();
+        }
+    }
+    LXQt::Notification::notify(tr("Removable media/devices manager"), tr("Ejected all optical drives"), mPlugin->icon().name());
+}

--- a/plugin-mount/actions/ejectaction_optical.h
+++ b/plugin-mount/actions/ejectaction_optical.h
@@ -4,9 +4,9 @@
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org
  *
- * Copyright: 2010-2011 Razor team
+ * Copyright: 2020 LXQt team
  * Authors:
- *   Alexander Sokoloff <sokoloff.a@gmail.com>
+ *   Oleksandr Ostrenko <oleksandr.ostrenko@gmail.com>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,37 +25,22 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#ifndef LXQT_PLUGIN_MOUNT_CONFIGURATION_H
-#define LXQT_PLUGIN_MOUNT_CONFIGURATION_H
+#ifndef LXQT_PLUGIN_MOUNT_EJECTACTION_OPTICAL_H
+#define LXQT_PLUGIN_MOUNT_EJECTACTION_OPTICAL_H
 
-#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include "ejectaction.h"
 
-#define CFG_KEY_ACTION    "newDeviceAction"
-#define CFG_EJECT_ACTION  "ejectAction"
-#define ACT_SHOW_MENU     "showMenu"
-#define ACT_SHOW_INFO     "showInfo"
-#define ACT_NOTHING       "nothing"
-#define ACT_EJECT_OPTICAL "ejectOpticalDrives"
+#include <QWidget>
 
-namespace Ui {
-    class Configuration;
-}
-
-class Configuration : public LXQtPanelPluginConfigDialog
+class EjectActionOptical : public EjectAction
 {
     Q_OBJECT
-
 public:
-    explicit Configuration(PluginSettings *settings, QWidget *parent = nullptr);
-    ~Configuration();
+    explicit EjectActionOptical(LXQtMountPlugin *plugin, QObject *parent = nullptr);
+    virtual ActionId Type() const throw () { return ActionOptical; }
 
-protected slots:
-    virtual void loadSettings();
-    void devAddedChanged(int index);
-    void ejectPressedChanged(int index);
-
-private:
-    Ui::Configuration *ui;
+protected:
+    void doEjectPressed(void);
 };
 
-#endif // LXQTMOUNTCONFIGURATION_H
+#endif // EJECTACTION_OPTICAL_H

--- a/plugin-mount/configuration.cpp
+++ b/plugin-mount/configuration.cpp
@@ -37,13 +37,27 @@ Configuration::Configuration(PluginSettings *settings, QWidget *parent) :
     ui(new Ui::Configuration)
 {
     ui->setupUi(this);
+
+    ui->devAddedLabel->sizePolicy().setHorizontalStretch(1);
+
     ui->devAddedCombo->addItem(tr("Popup menu"), QLatin1String(ACT_SHOW_MENU));
     ui->devAddedCombo->addItem(tr("Show info"),  QLatin1String(ACT_SHOW_INFO));
     ui->devAddedCombo->addItem(tr("Do nothing"), QLatin1String(ACT_NOTHING));
+    ui->devAddedCombo->sizePolicy().setHorizontalStretch(1);
+
+    ui->ejectPressedLabel->sizePolicy().setHorizontalStretch(1);
+
+    ui->ejectPressedCombo->addItem(tr("Do nothing"), QLatin1String(ACT_NOTHING));
+    ui->ejectPressedCombo->addItem(tr("Eject All Optical Drives"), QLatin1String(ACT_EJECT_OPTICAL));
+    ui->ejectPressedCombo->sizePolicy().setHorizontalStretch(1);
+
+    adjustSize();
 
     loadSettings();
     connect(ui->devAddedCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &Configuration::devAddedChanged);
+    connect(ui->ejectPressedCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, &Configuration::ejectPressedChanged);
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &Configuration::dialogButtonsAction);
 }
 
@@ -56,10 +70,19 @@ void Configuration::loadSettings()
 {
     QVariant value = settings().value(QLatin1String(CFG_KEY_ACTION), QLatin1String(ACT_SHOW_INFO));
     setComboboxIndexByData(ui->devAddedCombo, value, 1);
+
+    value = settings().value(QLatin1String(CFG_EJECT_ACTION), QLatin1String(ACT_NOTHING));
+    setComboboxIndexByData(ui->ejectPressedCombo, value, 1);
 }
 
 void Configuration::devAddedChanged(int index)
 {
     QString s = ui->devAddedCombo->itemData(index).toString();
     settings().setValue(QLatin1String(CFG_KEY_ACTION), s);
+}
+
+void Configuration::ejectPressedChanged(int index)
+{
+    QString s = ui->ejectPressedCombo->itemData(index).toString();
+    settings().setValue(QLatin1String(CFG_EJECT_ACTION), s);
 }

--- a/plugin-mount/configuration.ui
+++ b/plugin-mount/configuration.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>407</width>
-    <height>129</height>
+    <width>607</width>
+    <height>170</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,16 +19,35 @@
      <property name="title">
       <string>Behaviour</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <property name="labelAlignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <item row="0" column="0">
        <widget class="QLabel" name="devAddedLabel">
         <property name="text">
          <string>When a device is connected:</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QComboBox" name="devAddedCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ejectPressedLabel">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Trigger the following action eject shortcut is pressed (&lt;span style=&quot; font-weight:600;&quot;&gt;XF86Eject&lt;/span&gt; by default)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>When eject button is pressed:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="ejectPressedCombo"/>
       </item>
      </layout>
     </widget>
@@ -40,8 +59,8 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>41</height>
+       <width>10</width>
+       <height>10</height>
       </size>
      </property>
     </spacer>

--- a/plugin-mount/lxqtmountplugin.h
+++ b/plugin-mount/lxqtmountplugin.h
@@ -33,8 +33,14 @@
 #include "button.h"
 #include "popup.h"
 #include "actions/deviceaction.h"
+#include "actions/ejectaction.h"
 
 #include <QIcon>
+
+namespace GlobalKeyShortcut
+{
+    class Action;
+}
 
 /*!
 \author Petr Vanek <petr@scribus.info>
@@ -61,11 +67,14 @@ public slots:
 
 protected slots:
     virtual void settingsChanged();
+    void shortcutRegistered();
 
 private:
     Button *mButton;
     Popup *mPopup;
     DeviceAction *mDeviceAction;
+    EjectAction *mEjectAction;
+    GlobalKeyShortcut::Action *mKeyEject;
 };
 
 class LXQtMountPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
On some laptops optical drives with slot loading come with a dedicated eject button. This patch allows one to configure the mount plugin to respond to it by ejecting the disk.

Add XF86Eject button action:
 * register a global key shortcut
 * allow one to choose between no action and optical disk ejection
 * notify after disk ejection