### PR TITLE
Added right-click menu to main menu items

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -83,6 +83,7 @@ protected:
 private:
     void setMenuFontSize();
     void setButtonIcon();
+    void addContextMenu(QMenu *menu);
 
 private:
     QToolButton mButton;
@@ -124,6 +125,7 @@ private slots:
     void showHideMenu();
     void searchMenu();
     void setSearchFocus(QAction *action);
+    void onRequestingCustomMenu(const QPoint& p);
 };
 
 class LXQtMainMenuPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
Each right-click menu has two items for adding to desktop and copying to clipboard.

Closes https://github.com/lxqt/lxqt/issues/383