### PR TITLE
fix for menu overlap

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -529,6 +529,7 @@ void LXQtPanel::setPanelGeometry(bool animate)
                 rect.moveRight(currentScreen.right());
         }
     }
+    if (!mHidden || !mGeometry.isValid()) mGeometry = rect;
     if (rect != geometry())
     {
         setFixedSize(rect.size());
@@ -1217,19 +1218,19 @@ QRect LXQtPanel::calculatePopupWindowPos(QPoint const & absolutePos, QSize const
     switch (position())
     {
     case ILXQtPanel::PositionTop:
-        y = globalGeometry().bottom();
+        y = mGeometry.bottom();
         break;
 
     case ILXQtPanel::PositionBottom:
-        y = globalGeometry().top() - windowSize.height();
+        y = mGeometry.top() - windowSize.height();
         break;
 
     case ILXQtPanel::PositionLeft:
-        x = globalGeometry().right();
+        x = mGeometry.right();
         break;
 
     case ILXQtPanel::PositionRight:
-        x = globalGeometry().left() - windowSize.width();
+        x = mGeometry.left() - windowSize.width();
         break;
     }
 
@@ -1275,7 +1276,7 @@ QRect LXQtPanel::calculatePopupWindowPos(const ILXQtPanelPlugin *plugin, const Q
     }
 
     // Note: assuming there are not contentMargins around the "BackgroundWidget" (LXQtPanelWidget)
-    return calculatePopupWindowPos(globalGeometry().topLeft() + panel_plugin->geometry().topLeft(), windowSize);
+    return calculatePopupWindowPos(mGeometry.topLeft() + panel_plugin->geometry().topLeft(), windowSize);
 }
 
 

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -525,7 +525,11 @@ private:
      * @return The height/width of the panel.
      */
     int getReserveDimension();
-
+    /**
+     * @brief Stores the geometry of the non-hidden panel, for use in
+     * calculatePopupWindowPos()
+     */
+    QRect mGeometry;
     /**
      * @brief Stores the size of the panel, i.e. the height of a horizontal
      * panel or the width of a vertical panel in pixels. If the panel is


### PR DESCRIPTION
fix for #1483
at first i wanted to emit a signal from panel to let the menu recalculate its position, but thought this one would be better since it's a more generic fix (although i don't know if there's another popup u can open with key shortcut)