### PR TITLE
Add missing override specifiers

### DIFF
--- a/plugin-statusnotifier/statusnotifier.h
+++ b/plugin-statusnotifier/statusnotifier.h
@@ -39,15 +39,15 @@ class StatusNotifier : public QObject, public ILXQtPanelPlugin
 public:
     StatusNotifier(const ILXQtPanelPluginStartupInfo &startupInfo);
 
-    bool isSeparate() const { return true; }
-    void realign();
-    QString themeId() const { return QStringLiteral("StatusNotifier"); }
-    virtual Flags flags() const { return SingleInstance | HaveConfigDialog | NeedsHandle; }
-    QWidget *widget() { return m_widget; }
+    bool isSeparate() const override { return true; }
+    void realign() override;
+    QString themeId() const override { return QStringLiteral("StatusNotifier"); }
+    Flags flags() const override { return SingleInstance | HaveConfigDialog | NeedsHandle; }
+    QWidget *widget() override { return m_widget; }
 
     QDialog *configureDialog() override;
 
-    void settingsChanged() { m_widget->settingsChanged(); }
+    void settingsChanged() override { m_widget->settingsChanged(); }
 
 private:
     StatusNotifierWidget *m_widget;


### PR DESCRIPTION
It helps in maintenance and the compiler stops issuing warnings.