### PR TITLE
Make plugin-mount pop-up and LXQtGroupPopup's spacing and margins 0

### DIFF
--- a/plugin-backlight/sliderdialog.cpp
+++ b/plugin-backlight/sliderdialog.cpp
@@ -38,7 +38,7 @@ SliderDialog::SliderDialog(QWidget *parent) : QDialog(parent, Qt::Dialog | Qt::W
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setSpacing(0);
-    layout->setMargin(2);
+    layout->setMargin(0);
 
     m_upButton = new QToolButton();
     m_upButton->setText(QStringLiteral("☀"));

--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -58,7 +58,7 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent):
 
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->setContentsMargins (0, 0, 0, 0);
-    layout->setSpacing (1);
+    layout->setSpacing (0);
     setLayout(layout);
     layout->addWidget (&mButton);
     layout->addWidget (&mLineEdit);

--- a/plugin-mount/popup.cpp
+++ b/plugin-mount/popup.cpp
@@ -61,6 +61,7 @@ Popup::Popup(ILXQtPanelPlugin * plugin, QWidget* parent):
     setObjectName(QStringLiteral("LXQtMountPopup"));
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setLayout(new QVBoxLayout(this));
+    layout()->setSpacing(0);
     layout()->setMargin(0);
 
     setAttribute(Qt::WA_AlwaysShowToolTips);

--- a/plugin-taskbar/lxqtgrouppopup.cpp
+++ b/plugin-taskbar/lxqtgrouppopup.cpp
@@ -54,8 +54,8 @@ LXQtGroupPopup::LXQtGroupPopup(LXQtTaskGroup *group):
     setAttribute(Qt::WA_TranslucentBackground);
 
     setLayout(new QVBoxLayout);
-    layout()->setSpacing(3);
-    layout()->setMargin(3);
+    layout()->setSpacing(0);
+    layout()->setMargin(0);
 
     connect(&mCloseTimer, &QTimer::timeout, this, &LXQtGroupPopup::closeTimerSlot);
     mCloseTimer.setSingleShot(true);

--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -622,7 +622,7 @@ LXQtWorldClockPopup::LXQtWorldClockPopup(QWidget *parent) :
     QDialog(parent, Qt::Window | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::Popup | Qt::X11BypassWindowManagerHint)
 {
     setLayout(new QHBoxLayout(this));
-    layout()->setMargin(1);
+    layout()->setMargin(0);
 }
 
 void LXQtWorldClockPopup::show()


### PR DESCRIPTION
CSS styling in Qt does not allow to change the spacing or margins of layouts. Make them 0 so theme makers can place widgets wherever they want by changing the widgets' paddings/border/margins.