### PR TITLE
Fixed changing of world clock's time zone with mouse wheel

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -59,8 +59,6 @@ LXQtWorldClock::LXQtWorldClock(const ILXQtPanelPluginStartupInfo &startupInfo):
     mContent = new ActiveLabel();
     mRotatedWidget = new LXQt::RotatedWidget(*mContent, mMainWidget);
 
-    mRotatedWidget->setTransferWheelEvent(true);
-
     QVBoxLayout *borderLayout = new QVBoxLayout(mMainWidget);
     borderLayout->setContentsMargins(0, 0, 0, 0);
     borderLayout->setSpacing(0);


### PR DESCRIPTION
Using of liblxqt's `RotatedWidget::setTransferWheelEvent()` caused the mouse wheel event to be sent twice to the clock's label and interfere with the correct changing of the time zone. The label already received the wheel event and the above-mentioned method doubled it.

Fixes https://github.com/lxqt/lxqt-panel/issues/1512