### PR TITLE
Optionally auto-hide panel only when it overlaps a window

### DIFF
--- a/panel/config/configpanelwidget.cpp
+++ b/panel/config/configpanelwidget.cpp
@@ -78,6 +78,8 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
 
     mOldVisibleMargin = mPanel->visibleMargin();
 
+    mOldHideOnOverlap = mPanel->hideOnOverlap();
+
     mOldAnimation = mPanel->animationTime();
     mOldShowDelay = mPanel->showDelay();
 
@@ -106,6 +108,7 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
     connect(ui->comboBox_position,          SIGNAL(activated(int)),         this, SLOT(positionChanged()));
     connect(ui->checkBox_hidable,           SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
     connect(ui->checkBox_visibleMargin,     SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
+    connect(ui->checkBox_overlap,           &QAbstractButton::toggled,      this, &ConfigPanelWidget::editChanged);
     connect(ui->spinBox_animation,          SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
     connect(ui->spinBox_delay,              SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
 
@@ -139,6 +142,8 @@ void ConfigPanelWidget::reset()
     ui->checkBox_hidable->setChecked(mOldHidable);
 
     ui->checkBox_visibleMargin->setChecked(mOldVisibleMargin);
+
+    ui->checkBox_overlap->setChecked(mOldHideOnOverlap);
 
     ui->spinBox_animation->setValue(mOldAnimation);
     ui->spinBox_delay->setValue(mOldShowDelay);
@@ -330,6 +335,7 @@ void ConfigPanelWidget::editChanged()
     mPanel->setPosition(mScreenNum, mPosition, true);
     mPanel->setHidable(ui->checkBox_hidable->isChecked(), true);
     mPanel->setVisibleMargin(ui->checkBox_visibleMargin->isChecked(), true);
+    mPanel->setHideOnOverlap(ui->checkBox_overlap->isChecked(), true);
     mPanel->setAnimationTime(ui->spinBox_animation->value(), true);
     mPanel->setShowDelay(ui->spinBox_delay->value(), true);
 

--- a/panel/config/configpanelwidget.h
+++ b/panel/config/configpanelwidget.h
@@ -92,6 +92,7 @@ private:
     ILXQtPanel::Position mOldPosition;
     bool mOldHidable;
     bool mOldVisibleMargin;
+    bool mOldHideOnOverlap;
     int mOldAnimation;
     int mOldShowDelay;
     int mOldScreenNum;

--- a/panel/config/configpanelwidget.ui
+++ b/panel/config/configpanelwidget.ui
@@ -328,6 +328,13 @@
            </property>
           </widget>
          </item>
+         <item row="3" column="0" colspan="3">
+          <widget class="QCheckBox" name="checkBox_overlap">
+           <property name="text">
+            <string>Hide only on overlapping a window</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -223,6 +223,7 @@ public:
     int reserveSpace() const { return mReserveSpace; }
     bool hidable() const { return mHidable; }
     bool visibleMargin() const { return mVisibleMargin; }
+    bool hideOnOverlap() const { return mHideOnOverlap; }
     int animationTime() const { return mAnimationTime; }
     int showDelay() const { return mShowDelayTimer.interval(); }
     QString iconTheme() const;
@@ -307,6 +308,7 @@ public slots:
     void setReserveSpace(bool reserveSpace, bool save); //!< \sa setPanelSize()
     void setHidable(bool hidable, bool save); //!< \sa setPanelSize()
     void setVisibleMargin(bool visibleMargin, bool save); //!< \sa setPanelSize()
+    void setHideOnOverlap(bool hideOnOverlap, bool save);
     void setAnimationTime(int animationTime, bool save); //!< \sa setPanelSize()
     void setShowDelay(int showDelay, bool save); //!< \sa setPanelSize()
     void setIconTheme(const QString& iconTheme);
@@ -625,6 +627,12 @@ private:
      */
     bool mVisibleMargin;
     /**
+     * @brief Stores if the panel should hide on overlapping a window.
+     *
+     * \sa mHidable, mHidden, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
+     */
+    bool mHideOnOverlap;
+    /**
      * @brief Stores if the panel is currently hidden.
      *
      * \sa mHidable, mVisibleMargin, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
@@ -691,6 +699,11 @@ private:
      * QWidget::setStyleSheet().
      */
     void updateStyleSheet();
+
+    /**
+     * @brief Checks if the panel overlaps a window.
+     */
+    bool isPanelOverlapped() const;
 
     // settings should be kept private for security
     LXQt::Settings *settings() const { return mSettings; }


### PR DESCRIPTION
With the new option checked (it's not checked by default), an auto-hiding panel gets hidden when it overlaps a window and is shown when there's no overlap.

Closes https://github.com/lxqt/lxqt-panel/issues/1515