### PR TITLE
remove empty translations

### DIFF
--- a/plugin-colorpicker/translations/colorpicker.ts
+++ b/plugin-colorpicker/translations/colorpicker.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_arn.ts
+++ b/plugin-colorpicker/translations/colorpicker_arn.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="arn">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_ast.ts
+++ b/plugin-colorpicker/translations/colorpicker_ast.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="ast">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_ca.ts
+++ b/plugin-colorpicker/translations/colorpicker_ca.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="ca">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_cs.ts
+++ b/plugin-colorpicker/translations/colorpicker_cs.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="cs">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_cy.ts
+++ b/plugin-colorpicker/translations/colorpicker_cy.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="cy">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_da.ts
+++ b/plugin-colorpicker/translations/colorpicker_da.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="da">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_de.ts
+++ b/plugin-colorpicker/translations/colorpicker_de.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="de">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_gl.ts
+++ b/plugin-colorpicker/translations/colorpicker_gl.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="gl">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_hu.ts
+++ b/plugin-colorpicker/translations/colorpicker_hu.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="hu">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_it.ts
+++ b/plugin-colorpicker/translations/colorpicker_it.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="it">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_ja.ts
+++ b/plugin-colorpicker/translations/colorpicker_ja.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="ja">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_nb_NO.ts
+++ b/plugin-colorpicker/translations/colorpicker_nb_NO.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="nb_NO">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_nl.ts
+++ b/plugin-colorpicker/translations/colorpicker_nl.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="nl">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_pl.ts
+++ b/plugin-colorpicker/translations/colorpicker_pl.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pl">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_pt_BR.ts
+++ b/plugin-colorpicker/translations/colorpicker_pt_BR.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_BR">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_ru.ts
+++ b/plugin-colorpicker/translations/colorpicker_ru.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="ru">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_sk_SK.ts
+++ b/plugin-colorpicker/translations/colorpicker_sk_SK.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="sk_SK">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_sv.ts
+++ b/plugin-colorpicker/translations/colorpicker_sv.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="sv">
-</TS>

--- a/plugin-colorpicker/translations/colorpicker_tr.ts
+++ b/plugin-colorpicker/translations/colorpicker_tr.ts
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="tr">
-</TS>


### PR DESCRIPTION
No idea where those come from originally, I imported them time ago in weblate without realizing that there are 0 words, colorpicker has no settings.