### PR TITLE
Workaround an issue with glibc 2.33 on old Docker engines

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -6,6 +6,12 @@ Server = https://repo.archlinuxcn.org/\$arch
 SigLevel = Never
 EOF
 
+# Work-around the issue with glibc 2.33 on old Docker engines
+# Extract files directly as pacman is also affected by the issue
+patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst
+curl -LO https://repo.archlinuxcn.org/x86_64/$patched_glibc
+bsdtar -C / -xvf $patched_glibc
+
 pacman -Syu --noconfirm
 # See *depends in https://github.com/archlinuxcn/repo/blob/master/archlinuxcn/lxqt-panel-git/PKGBUILD
 pacman -S --noconfirm --needed git cmake qt5-tools lxqt-build-tools-git alsa-lib libpulse lm_sensors libstatgrab libsysstat-git solid menu-cache libxcomposite lxmenu-data libdbusmenu-qt5 lxqt-globalkeys-git


### PR DESCRIPTION
Since glibc 2.33, the faccessat() function tries the faccessat2 system
call first and falls back to the faccessat system call on older
kernels [1].  However, the seccomp profile provided by old Docker engines
does not allow faccessat2 (fixed by [2][3]). As a result, the faccessat2
system call returns EPERM, and glibc returns an error in this case. Using
a patched glibc to workaround this issue.

Note that the aforementioned glibc commit does not mean that glibc 2.33
building on new kernels does not work with old kernels. Instead, the
__LINUX_KERNEL_VERSION macro is 0 by default to achieve best-effort
compatibility with various kernel versions.

[1] https://sourceware.org/git/?p=glibc.git;a=patch;h=3d3ab573a5f3071992cbc4f57d50d1d29d55bde2
[2] https://github.com/moby/moby/pull/41353
[3] https://github.com/moby/moby/pull/41381