### PR TITLE
Check pressed mouse buttons before closing grouped task popup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ lxqt-panel-0.17.0 / 2021-04-15
   * Optionally auto-hide panel only when it overlaps a window.
   * Workaround for an issue with glibc 2.33 on old Docker engines.
   * Completely move to Qt5 signal/slot syntax.
+  * Check pressed mouse buttons before closing grouped task popup.
 
 lxqt-panel-0.16.1 / 2020-11-04
 ==============================

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -576,7 +576,8 @@ void LXQtTaskGroup::dragLeaveEvent(QDragLeaveEvent *event)
 void LXQtTaskGroup::mouseMoveEvent(QMouseEvent* event)
 {
     // if dragging the taskgroup, do not show the popup
-    setPopupVisible(false, true);
+    if (event->buttons() & Qt::LeftButton)
+        setPopupVisible(false, true);
     LXQtTaskButton::mouseMoveEvent(event);
 }
 


### PR DESCRIPTION
The lack of checking didn't have an effect with the official Qt releases but it causes a bug with the latest official patches. Logically, the pressed mouse buttons should have always been checked.

Closes https://github.com/lxqt/lxqt-panel/issues/1600