### PR TITLE
plugin-mainmenu - add contextmenu and drag/drop to search results

### DIFF
--- a/plugin-mainmenu/actionview.cpp
+++ b/plugin-mainmenu/actionview.cpp
@@ -44,6 +44,7 @@
 #include <QMouseEvent>
 #include <QMimeData>
 #include <QUrl>
+#include <QPointer>
 
 //==============================
 #ifdef HAVE_MENU_CACHE
@@ -307,10 +308,12 @@ void ActionView::mouseMoveEvent(QMouseEvent *event)
     QMimeData *mimeData = new QMimeData();
     mimeData->setUrls(urls);
 
-    QDrag *drag = new QDrag(this);
+    QPointer<QDrag> drag = new QDrag(this);
     drag->setMimeData(mimeData);
     drag->exec(Qt::CopyAction | Qt::LinkAction);
     emit requestShowHideMenu();
+    event->accept();
+    drag->deleteLater();
 }
 
 void ActionView::onActivated(QModelIndex const & index)

--- a/plugin-mainmenu/actionview.cpp
+++ b/plugin-mainmenu/actionview.cpp
@@ -44,7 +44,6 @@
 #include <QMouseEvent>
 #include <QMimeData>
 #include <QUrl>
-#include <QPointer>
 
 //==============================
 #ifdef HAVE_MENU_CACHE
@@ -308,12 +307,10 @@ void ActionView::mouseMoveEvent(QMouseEvent *event)
     QMimeData *mimeData = new QMimeData();
     mimeData->setUrls(urls);
 
-    QPointer<QDrag> drag = new QDrag(this);
+    QDrag *drag = new QDrag(this);
     drag->setMimeData(mimeData);
     drag->exec(Qt::CopyAction | Qt::LinkAction);
     emit requestShowHideMenu();
-    event->accept();
-    drag->deleteLater();
 }
 
 void ActionView::onActivated(QModelIndex const & index)

--- a/plugin-mainmenu/actionview.h
+++ b/plugin-mainmenu/actionview.h
@@ -29,6 +29,7 @@
 #define ACTION_VIEW_H
 
 #include <QListView>
+#include <QPoint>
 
 class QStandardItemModel;
 
@@ -102,6 +103,11 @@ public slots:
 protected:
     virtual QSize viewportSizeHint() const override;
     virtual QSize minimumSizeHint() const override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+
+signals:
+    void requestShowHideMenu();
 
 private slots:
     void onActivated(QModelIndex const & index);
@@ -112,6 +118,7 @@ private:
 
 private:
     QStandardItemModel * mModel;
+    QPoint mDragStartPosition;
 #ifdef HAVE_MENU_CACHE
     QSortFilterProxyModel * mProxy;
 #else

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -40,7 +40,6 @@
 #include <QLineEdit>
 #include <lxqt-globalkeys.h>
 #include <algorithm> // for find_if()
-#include <KWindowSystem/KWindowSystem>
 #include <QApplication>
 
 #include <XdgMenuWidget>
@@ -471,8 +470,8 @@ void LXQtMainMenu::onRequestingCustomMenu(const QPoint& p)
     Q_UNUSED(p)
     return;
 #else
-    QMenu *parentMenu = static_cast<QMenu*>(QObject::sender());
-    ActionView *parentView = static_cast<ActionView*>(QObject::sender());
+    QMenu *parentMenu = qobject_cast<QMenu*>(QObject::sender());
+    ActionView *parentView = qobject_cast<ActionView*>(QObject::sender());
     QAction *action;
     QPoint globalPos;
     if (parentView != nullptr) {

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -102,7 +102,10 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
 
     mSearchView = new ActionView;
     mSearchView->setVisible(false);
+    mSearchView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mSearchView, &QAbstractItemView::activated, this, &LXQtMainMenu::showHideMenu);
+    connect(mSearchView, &ActionView::requestShowHideMenu, this, &LXQtMainMenu::showHideMenu);
+    connect(mSearchView, &QWidget::customContextMenuRequested, this, &LXQtMainMenu::onRequestingCustomMenu);
     mSearchViewAction->setDefaultWidget(mSearchView);
     mSearchEdit = new QLineEdit;
     mSearchEdit->setClearButtonEnabled(true);
@@ -469,11 +472,24 @@ void LXQtMainMenu::onRequestingCustomMenu(const QPoint& p)
     return;
 #else
     QMenu *parentMenu = static_cast<QMenu*>(QObject::sender());
-    if (parentMenu == nullptr)
+    ActionView *parentView = static_cast<ActionView*>(QObject::sender());
+    QAction *action;
+    QPoint globalPos;
+    if (parentView != nullptr) {
+        action = mSearchView->indexAt(p).data(ActionView::ActionRole).value<QAction*>();
+        if (action == nullptr)
+            return;
+        globalPos = parentView->mapToGlobal(p);
+    }
+    else if (parentMenu != nullptr) {
+        action = parentMenu->actionAt(p);
+        if (action == nullptr || action->menu() != nullptr || action->isSeparator())
+            return;
+        globalPos = parentMenu->mapToGlobal(p);
+    }
+    else {
         return;
-    QAction *action = parentMenu->actionAt(p);
-    if (action == nullptr || action->menu() != nullptr || action->isSeparator())
-        return;
+    }
     XdgAction *xdgAction = qobject_cast<XdgAction *>(action);
     if (xdgAction == nullptr)
         return;
@@ -487,10 +503,10 @@ void LXQtMainMenu::onRequestingCustomMenu(const QPoint& p)
     {
         for (int i = 0; i < df.actions().count(); ++i)
         {
-            QString action(df.actions().at(i));
-            a = menu.addAction(df.actionIcon(action), df.actionName(action));
-            connect(a, &QAction::triggered, this, [this, df, action] {
-                df.actionActivate(action, QStringList());
+            QString actionString(df.actions().at(i));
+            a = menu.addAction(df.actionIcon(actionString), df.actionName(actionString));
+            connect(a, &QAction::triggered, this, [this, df, actionString] {
+                df.actionActivate(actionString, QStringList());
                 mMenu->hide();
             });
         }
@@ -527,7 +543,7 @@ void LXQtMainMenu::onRequestingCustomMenu(const QPoint& p)
                                                        + QByteArray("\r\n"));
         clipboard->setMimeData(data);
     });
-    menu.exec(parentMenu->mapToGlobal(p));
+    menu.exec(globalPos);
 #endif
 }
 

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -476,7 +476,7 @@ void LXQtMainMenu::onRequestingCustomMenu(const QPoint& p)
     QAction *action;
     QPoint globalPos;
     if (parentView != nullptr) {
-        action = mSearchView->indexAt(p).data(ActionView::ActionRole).value<QAction*>();
+        action = parentView->indexAt(p).data(ActionView::ActionRole).value<QAction*>();
         if (action == nullptr)
             return;
         globalPos = parentView->mapToGlobal(p);


### PR DESCRIPTION
To make search results behave the same as regular menu actions. 
- Added drag and drop to search results
- Added context menu to search results

plus a small change:
- Changed variable name `QString action` to `actionString` to avoid conflict with `QAction *action` declared earlier.