### PR TITLE
Reserve space for the panel when it is permanently shown.

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1444,6 +1444,7 @@ void LXQtPanel::showPanel(bool animate)
             mHidden = false;
             setPanelGeometry(mAnimationTime > 0 && animate);
         }
+        mRerveSpace=true;
     }
 }
 


### PR DESCRIPTION
I think this is a self explanatory feature. I don't see any reason the show button would not also reserve space, because the current behavior  makes the bottom of the apps hidden under the panel which is very annoying to troubleshoot when you don't know what settings caused that behavior.