### PR TITLE
Don't use hardcoded xkb rules file paths.

### DIFF
--- a/plugin-kbindicator/CMakeLists.txt
+++ b/plugin-kbindicator/CMakeLists.txt
@@ -31,9 +31,22 @@ set(LIBRARIES
 
 find_package(XCB REQUIRED COMPONENTS xcb xcb-xkb)
 find_package(XKBCommon REQUIRED COMPONENTS XKBCommon X11)
+find_package(X11 REQUIRED)
 find_package(Qt5 ${QT_MINIMUM_VERSION} REQUIRED COMPONENTS X11Extras Xml)
 
-include_directories(${XCB_INCLUDE_DIRS})
+find_package(PkgConfig REQUIRED)
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=xkb_base xkeyboard-config
+    OUTPUT_VARIABLE XKB_RULES_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT EXISTS "${XKB_RULES_DIR}")
+    message(FATAL_ERROR "Couldn't find XKB rules location: \"${XKB_RULES_DIR}\".")
+endif()
+
+include_directories(
+    ${XCB_INCLUDE_DIRS}
+    ${X11_xkbfile_INCLUDE_PATH}
+)
 
 set(HEADERS
     ${HEADERS}
@@ -48,11 +61,13 @@ set(SOURCES
 set(LIBRARIES
     ${LIBRARIES}
     ${XCB_LIBRARIES}
+    ${X11_xkbfile_LIB}
     XKBCommon::XKBCommon
     XKBCommon::X11
     Qt5::Xml
 )
 
-add_definitions(-DX11_ENABLED)
+add_definitions(-DX11_ENABLED -DXKB_RULES_DIR=\"${XKB_RULES_DIR}\")
+
 
 BUILD_LXQT_PLUGIN(${PLUGIN})


### PR DESCRIPTION
* Use xkeyboard-config at compile time to find out the xkb base data dir.
* Get the rules in use with XkbRF_GetNamesProp()
