### PR TITLE
Prevent flickering of desktop switcher when only active button is shown

### DIFF
--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -228,6 +228,7 @@ void DesktopSwitch::onCurrentDesktopChanged(int current)
 {
     if (mShowOnlyActive)
     {
+        mLayout->setEnabled(false);
         int i = 1;
         const auto buttons = m_buttons->buttons();
         for (const auto button : buttons)
@@ -242,6 +243,7 @@ void DesktopSwitch::onCurrentDesktopChanged(int current)
             }
             ++i;
         }
+        mLayout->setEnabled(true);
     } else
     {
         QAbstractButton *button = m_buttons->button(current - 1);


### PR DESCRIPTION
If only the active button is shown, the layout of desktop switcher might grow and shrink on switching desktop because, in a very short interval, the number of visible buttons will change. That may cause a flickering under rare and random circumstances. When it happens, it can be quite visible because it may shake nearby plugins.

The flickering is prevented here by disabling the layout before changing visibilities of buttons and re-enabling it afterward.