### PR TITLE
CustomCommand: close QProcess on destructor

### DIFF
--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -64,6 +64,7 @@ LXQtCustomCommand::LXQtCustomCommand(const ILXQtPanelPluginStartupInfo &startupI
 
 LXQtCustomCommand::~LXQtCustomCommand()
 {
+    mProcess->close();
     delete mButton;
 }
 

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -64,6 +64,7 @@ LXQtCustomCommand::LXQtCustomCommand(const ILXQtPanelPluginStartupInfo &startupI
 
 LXQtCustomCommand::~LXQtCustomCommand()
 {
+    // Ensure process is closed before exiting and avoids warning from QProcess.
     mProcess->close();
     delete mButton;
 }


### PR DESCRIPTION
maybe fixes #1710 ?

i also noticed without this commit there's a warning `QProcess: Destroyed while process ("bash") is still running.`