### PR TITLE
CustomCommand: Allow plugin to expand to all rows in the panel + fixes

### DIFF
--- a/plugin-customcommand/custombutton.h
+++ b/plugin-customcommand/custombutton.h
@@ -40,9 +40,9 @@ public:
     ~CustomButton();
 
 public slots:
-    void setAutoRotation(bool value);
     void setMaxWidth(int maxWidth);
-    void updateWidth();
+    void setAutoRotation(bool rotate);
+    void updateButton();
 
 protected:
     void wheelEvent(QWheelEvent *event) override;
@@ -54,8 +54,11 @@ private slots:
 private:
     ILXQtPanelPlugin *mPlugin;
     ILXQtPanel *mPanel;
+    ILXQtPanel::Position mPanelPosition;
+    bool mAutoRotate;
     Qt::Corner mOrigin;
     int mMaxWidth;
+    QSize mSizeHint;
 
 signals:
     void wheelScrolled(int);

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -141,11 +141,9 @@ void LXQtCustomCommand::settingsChanged()
     if (oldMaxWidth != mMaxWidth)
         mButton->setMaxWidth(mMaxWidth);
 
-    if (oldExpandToRows != mExpandToRows) {
+    if (oldExpandToRows != mExpandToRows)
         pluginFlagsChanged();
-        // Need to call setAutoRotation twice to change instantly
-        mButton->setAutoRotation(!mAutoRotate);
-    }
+
     mButton->setAutoRotation(mAutoRotate);
 
     if (mFirstRun) {

--- a/plugin-customcommand/lxqtcustomcommand.h
+++ b/plugin-customcommand/lxqtcustomcommand.h
@@ -49,6 +49,7 @@ public:
     virtual ILXQtPanelPlugin::Flags flags() const { return PreferRightAlignment | HaveConfigDialog ; }
     void realign();
     QDialog *configureDialog();
+    bool isSeparate() const { return mExpandToRows; }
 
 protected slots:
     virtual void settingsChanged();
@@ -74,6 +75,7 @@ private:
     QString mOutput;
 
     bool mAutoRotate;
+    bool mExpandToRows;
     QString mFont;
     QString mCommand;
     bool mRunWithBash;

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -42,6 +42,7 @@ LXQtCustomCommandConfiguration::LXQtCustomCommandConfiguration(PluginSettings *s
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &LXQtCustomCommandConfiguration::buttonBoxClicked);
     connect(ui->autoRotateCheckBox, &QCheckBox::toggled, this, &LXQtCustomCommandConfiguration::autoRotateChanged);
+    connect(ui->expandToRowsCheckBox, &QCheckBox::toggled, this, &LXQtCustomCommandConfiguration::expandToRowsChanged);
     connect(ui->fontButton, &QPushButton::clicked, this, &LXQtCustomCommandConfiguration::fontButtonClicked);
     connect(ui->commandPlainTextEdit, &QPlainTextEdit::textChanged, this, &LXQtCustomCommandConfiguration::commandPlainTextEditChanged);
     connect(ui->runWithBashCheckBox, &QCheckBox::toggled, this, &LXQtCustomCommandConfiguration::runWithBashCheckBoxChanged);
@@ -75,6 +76,7 @@ void LXQtCustomCommandConfiguration::buttonBoxClicked(QAbstractButton *btn)
 void LXQtCustomCommandConfiguration::loadSettings()
 {
     mAutoRotate = settings().value(QStringLiteral("autoRotate"), true).toBool();
+    mExpandToRows = settings().value(QStringLiteral("expandToRows"), false).toBool();
     mFont = settings().value(QStringLiteral("font"), font().toString()).toString();
     mCommand = settings().value(QStringLiteral("command"), QStringLiteral("echo Configure...")).toString();
     mRunWithBash = settings().value(QStringLiteral("runWithBash"), true).toBool();
@@ -91,6 +93,7 @@ void LXQtCustomCommandConfiguration::loadSettings()
 void LXQtCustomCommandConfiguration::setUiValues()
 {
     ui->autoRotateCheckBox->setChecked(mAutoRotate);
+    ui->expandToRowsCheckBox->setChecked(mExpandToRows);
     ui->fontButton->setText(mFont);
     ui->commandPlainTextEdit->setPlainText(mCommand);
     ui->runWithBashCheckBox->setChecked(mRunWithBash);
@@ -108,6 +111,11 @@ void LXQtCustomCommandConfiguration::setUiValues()
 void LXQtCustomCommandConfiguration::autoRotateChanged(bool autoRotate)
 {
     settings().setValue(QStringLiteral("autoRotate"), autoRotate);
+}
+
+void LXQtCustomCommandConfiguration::expandToRowsChanged(bool expand)
+{
+    settings().setValue(QStringLiteral("expandToRows"), expand);
 }
 
 void LXQtCustomCommandConfiguration::fontButtonClicked()

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.h
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.h
@@ -43,6 +43,7 @@ public:
 
 private:
     bool mAutoRotate;
+    bool mExpandToRows;
     QString mFont;
     QString mCommand;
     bool mRunWithBash;
@@ -59,6 +60,7 @@ private slots:
     void buttonBoxClicked(QAbstractButton *btn);
     void setUiValues();
     void autoRotateChanged(bool autoRotate);
+    void expandToRowsChanged(bool expand);
     void fontButtonClicked();
     void fontChanged(QString fontString);
     void commandPlainTextEditChanged();

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.ui
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>500</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,149 +22,7 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="7" column="1">
-         <widget class="QLineEdit" name="iconLineEdit">
-          <property name="placeholderText">
-           <string>Use icon from theme or browse file</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1" colspan="2">
-         <widget class="QCheckBox" name="runWithBashCheckBox">
-          <property name="text">
-           <string>Run with &quot;bash -c&quot;</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QPushButton" name="fontButton">
-          <property name="text">
-           <string>Select Font</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="textLabel">
-          <property name="text">
-           <string>Text</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" rowspan="5">
-         <widget class="QLabel" name="commandLabel">
-          <property name="text">
-           <string>Command</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="fontLabel">
-          <property name="text">
-           <string>Font</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="1" colspan="2">
-         <widget class="QSpinBox" name="maxWidthSpinBox">
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="minimum">
-           <number>10</number>
-          </property>
-          <property name="maximum">
-           <number>9999</number>
-          </property>
-          <property name="singleStep">
-           <number>5</number>
-          </property>
-          <property name="value">
-           <number>200</number>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1" colspan="2">
-         <widget class="QLineEdit" name="textLineEdit">
-          <property name="text">
-           <string>%1</string>
-          </property>
-          <property name="placeholderText">
-           <string>Use %1 to display command output</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="iconLabel">
-          <property name="text">
-           <string>Icon</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="QPushButton" name="iconBrowseButton">
-          <property name="text">
-           <string>Browse</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0" colspan="3">
-         <widget class="QCheckBox" name="autoRotateCheckBox">
-          <property name="text">
-           <string>Autorotate when the panel is vertical</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1" colspan="2">
-         <widget class="QPlainTextEdit" name="commandPlainTextEdit">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>52</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="plainText">
-           <string>echo Configure...</string>
-          </property>
-          <property name="placeholderText">
-           <string>Command to run</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="maxWidthLabel">
-          <property name="text">
-           <string>Max Width</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1" colspan="2">
+        <item row="6" column="1" colspan="2">
          <widget class="QFrame" name="frame">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -242,6 +100,155 @@
             </widget>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item row="5" column="1" colspan="2">
+         <widget class="QCheckBox" name="runWithBashCheckBox">
+          <property name="text">
+           <string>Run with &quot;bash -c&quot;</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1" colspan="2">
+         <widget class="QLineEdit" name="textLineEdit">
+          <property name="text">
+           <string>%1</string>
+          </property>
+          <property name="placeholderText">
+           <string>Use %1 to display command output</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" colspan="3">
+         <widget class="QCheckBox" name="autoRotateCheckBox">
+          <property name="text">
+           <string>Autorotate when the panel is vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QLineEdit" name="iconLineEdit">
+          <property name="placeholderText">
+           <string>Use icon from theme or browse file</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1" colspan="2">
+         <widget class="QPushButton" name="fontButton">
+          <property name="text">
+           <string>Select Font</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1" colspan="2">
+         <widget class="QSpinBox" name="maxWidthSpinBox">
+          <property name="suffix">
+           <string> px</string>
+          </property>
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>9999</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>200</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0" rowspan="5">
+         <widget class="QLabel" name="commandLabel">
+          <property name="text">
+           <string>Command</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="iconLabel">
+          <property name="text">
+           <string>Icon</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="2">
+         <widget class="QPlainTextEdit" name="commandPlainTextEdit">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>52</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="plainText">
+           <string>echo Configure...</string>
+          </property>
+          <property name="placeholderText">
+           <string>Command to run</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="textLabel">
+          <property name="text">
+           <string>Text</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="QPushButton" name="iconBrowseButton">
+          <property name="text">
+           <string>Browse</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="fontLabel">
+          <property name="text">
+           <string>Font</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0">
+         <widget class="QLabel" name="maxWidthLabel">
+          <property name="text">
+           <string>Max Width</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="3">
+         <widget class="QCheckBox" name="expandToRowsCheckBox">
+          <property name="text">
+           <string>Expand to all panel rows</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -323,6 +330,7 @@
  </widget>
  <tabstops>
   <tabstop>autoRotateCheckBox</tabstop>
+  <tabstop>expandToRowsCheckBox</tabstop>
   <tabstop>fontButton</tabstop>
   <tabstop>commandPlainTextEdit</tabstop>
   <tabstop>runWithBashCheckBox</tabstop>


### PR DESCRIPTION
- Added option to expand to all panel rows (only has effect when panel has more than 1 row). Default off, same behavior as before.
- Correctly calculate "max width" when panel is vertical and auto rotate is off (text is horizontal and height will be limited by "max width" from config)
- Removed ProxyStyle, was being used for right eliding text, but it is unnecessary and was preventing multi line output. (Could be re-added if the default middle eliding is annoying, or i can change to just clip the extra text instead of right eliding)
- Reduced button updates during plugin creation and settingsChanged() or when command finishes (if text size doesn't change it won't update the dimensions)

Example with vertical panel with 2 rows and some plugins:
![cmd-expand](https://user-images.githubusercontent.com/33790211/152089035-a875e2c0-8adb-4c83-b2be-b248667537ba.png)
