### PR TITLE
mainmenu: Close menu only on shortcut press

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -113,6 +113,7 @@ private:
     QTimer mDelayedPopup;
     QTimer mHideTimer;
     QTimer mSearchTimer;
+    QString mShortcutSeq;
     QString mMenuFile;
 
 protected slots:


### PR DESCRIPTION
In acc90ef308a4e15a0ab72cb7a7403e41a9988b36 (#255) closing the menu on
any "modifier" press. This workaround was clashing with the expected
behavior in search QLineEdit (#1717).

This commit reintroduces closing the menu just upon releasing the defined
menu shortcut and tries to solve also specific shortcuts (when the
shortcut itself consists only from modifiers).

closes #1717