### PR TITLE
tray: Support bigger icon sizes

### DIFF
--- a/plugin-tray/sniproxy.h
+++ b/plugin-tray/sniproxy.h
@@ -31,7 +31,7 @@
 #include <QDBusConnection>
 #include <QDBusObjectPath>
 #include <QObject>
-#include <QPixmap>
+#include <QImage>
 #include <QPoint>
 
 #include <xcb/xcb.h>
@@ -171,7 +171,8 @@ private:
     xcb_window_t m_windowId;
     xcb_window_t m_containerWid;
     static int s_serviceCount;
-    QPixmap m_pixmap;
+    QImage m_windowImage;
+    QImage m_iconImage;
     bool sendingClickEvent;
     InjectMode m_injectMode;
     Xcb::Atoms & m_atoms;


### PR DESCRIPTION
- increase the client (painting) window to 128x128
- detect opaque area (some apps don't honor the size of the window and
  paint small icons in the middle) and use just that for icon image
- present icon images up to 128x128 to SNI (if needed the image is
  scaled up for multiple resolutions)

fixes #1735 