### PR TITLE
panel/plugin: Fix settings storing/restoring

### DIFF
--- a/panel/lxqtpanelpluginconfigdialog.cpp
+++ b/panel/lxqtpanelpluginconfigdialog.cpp
@@ -58,6 +58,15 @@ PluginSettings& LXQtPanelPluginConfigDialog::settings() const
 }
 
 
+/************************************************
+
+ ************************************************/
+void LXQtPanelPluginConfigDialog::closeEvent(QCloseEvent *event)
+{
+    mSettings.storeToCache();
+    return QDialog::closeEvent(event);
+}
+
 
 /************************************************
 

--- a/panel/lxqtpanelpluginconfigdialog.h
+++ b/panel/lxqtpanelpluginconfigdialog.h
@@ -35,6 +35,7 @@
 #include "pluginsettings.h"
 
 class QComboBox;
+class QCloseEvent;
 
 class LXQT_PANEL_API LXQtPanelPluginConfigDialog : public QDialog
 {
@@ -45,6 +46,9 @@ public:
     virtual ~LXQtPanelPluginConfigDialog();
 
     PluginSettings &settings() const;
+
+protected:
+    virtual void closeEvent(QCloseEvent *event) override;
 
 protected slots:
     /*

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -188,6 +188,8 @@ Plugin::Plugin(const LXQt::PluginInfo &desktopFile, LXQt::Settings *settings, co
  ************************************************/
 Plugin::~Plugin()
 {
+    if (mConfigDialog)
+        delete mConfigDialog.data();
     delete mPlugin;
     delete mPluginLoader;
     delete mSettings;
@@ -515,7 +517,6 @@ void Plugin::showConfigureDialog()
     if (!mConfigDialog)
         return;
 
-    connect(this, &Plugin::destroyed, mConfigDialog.data(), &QWidget::close);
     mPanel->willShowWindow(mConfigDialog);
     mConfigDialog->show();
     mConfigDialog->raise();

--- a/panel/pluginsettings.cpp
+++ b/panel/pluginsettings.cpp
@@ -28,15 +28,18 @@
 #include "pluginsettings.h"
 #include "pluginsettings_p.h"
 #include <LXQt/Settings>
+#include <memory>
 
 class PluginSettingsPrivate
 {
 public:
     PluginSettingsPrivate(LXQt::Settings* settings, const QString &group)
         : mSettings(settings)
-        , mOldSettings(settings)
         , mGroup(group)
     {
+        mSettings->beginGroup(mGroup);
+        mOldSettings = std::make_unique<LXQt::SettingsCache>(mSettings);
+        mSettings->endGroup();
     }
 
     QString prefix() const;
@@ -46,7 +49,7 @@ public:
     }
 
     LXQt::Settings *mSettings;
-    LXQt::SettingsCache mOldSettings;
+    std::unique_ptr<LXQt::SettingsCache> mOldSettings;
     QString mGroup;
     QStringList mSubGroups;
 };
@@ -163,10 +166,8 @@ void PluginSettings::clear()
 void PluginSettings::sync()
 {
     Q_D(PluginSettings);
-    d->mSettings->beginGroup(d->mGroup);
     d->mSettings->sync();
-    d->mOldSettings.loadFromSettings();
-    d->mSettings->endGroup();
+    storeToCache();
     emit settingsChanged();
 }
 
@@ -205,7 +206,8 @@ void PluginSettings::loadFromCache()
 {
     Q_D(PluginSettings);
     d->mSettings->beginGroup(d->mGroup);
-    d->mOldSettings.loadToSettings();
+    d->mSettings->remove(QString{});
+    d->mOldSettings->loadToSettings();
     d->mSettings->endGroup();
     emit settingsChanged();
 }
@@ -214,7 +216,7 @@ void PluginSettings::storeToCache()
 {
     Q_D(PluginSettings);
     d->mSettings->beginGroup(d->mGroup);
-    d->mOldSettings.loadFromSettings();
+    d->mOldSettings = std::make_unique<LXQt::SettingsCache>(d->mSettings);
     d->mSettings->endGroup();
 }
 

--- a/panel/pluginsettings.cpp
+++ b/panel/pluginsettings.cpp
@@ -207,6 +207,15 @@ void PluginSettings::loadFromCache()
     d->mSettings->beginGroup(d->mGroup);
     d->mOldSettings.loadToSettings();
     d->mSettings->endGroup();
+    emit settingsChanged();
+}
+
+void PluginSettings::storeToCache()
+{
+    Q_D(PluginSettings);
+    d->mSettings->beginGroup(d->mGroup);
+    d->mOldSettings.loadFromSettings();
+    d->mSettings->endGroup();
 }
 
 PluginSettings* PluginSettingsFactory::create(LXQt::Settings *settings, const QString &group, QObject *parent/* = nullptr*/)

--- a/panel/pluginsettings.h
+++ b/panel/pluginsettings.h
@@ -81,6 +81,7 @@ public:
     void endGroup();
 
     void loadFromCache();
+    void storeToCache();
 
 signals:
     void settingsChanged();

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -485,10 +485,10 @@ void LXQtTaskBar::settingsChanged()
     else
         setButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-    mShowOnlyOneDesktopTasks = mPlugin->settings()->value(QStringLiteral("showOnlyOneDesktopTasks"), mShowOnlyOneDesktopTasks).toBool();
-    mShowDesktopNum = mPlugin->settings()->value(QStringLiteral("showDesktopNum"), mShowDesktopNum).toInt();
-    mShowOnlyCurrentScreenTasks = mPlugin->settings()->value(QStringLiteral("showOnlyCurrentScreenTasks"), mShowOnlyCurrentScreenTasks).toBool();
-    mShowOnlyMinimizedTasks = mPlugin->settings()->value(QStringLiteral("showOnlyMinimizedTasks"), mShowOnlyMinimizedTasks).toBool();
+    mShowOnlyOneDesktopTasks = mPlugin->settings()->value(QStringLiteral("showOnlyOneDesktopTasks"), false).toBool();
+    mShowDesktopNum = mPlugin->settings()->value(QStringLiteral("showDesktopNum"), 0).toInt();
+    mShowOnlyCurrentScreenTasks = mPlugin->settings()->value(QStringLiteral("showOnlyCurrentScreenTasks"), false).toBool();
+    mShowOnlyMinimizedTasks = mPlugin->settings()->value(QStringLiteral("showOnlyMinimizedTasks"), false).toBool();
     mAutoRotate = mPlugin->settings()->value(QStringLiteral("autoRotate"), true).toBool();
     mCloseOnMiddleClick = mPlugin->settings()->value(QStringLiteral("closeOnMiddleClick"), true).toBool();
     mRaiseOnCurrentDesktop = mPlugin->settings()->value(QStringLiteral("raiseOnCurrentDesktop"), false).toBool();


### PR DESCRIPTION
- Add emitting settingsChanged() into PluginSettings::loadFromCache() to
  notify plugin/users, that settings were updated. Previously the signal
  was probably emitted by the underlying object detecting the settings
  file changed, but this is not the case any more (probably enhancement
  in the underlying Qt's QSettings optimization).

- Add PlutingSettings::storeToCache() for the plugin configure dialog to
  be able to store to cache on closing the dialog -> after re-showing or
  showing freshly created one, we expect to be able to reset to the
  values shown initialy in this dialog.

- Delete plugin's config dialog before deleting the plugin object
  itself, as the config dialog can rely/use other plugin objects and
  deleting/closing the dialog late after plugin object destroyed can
  cause problems (invalid memory access).

closes #1741