### PR TITLE
Cleanups for Custom Command

### DIFF
--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -102,7 +102,7 @@ void LXQtCustomCommand::settingsChanged()
     int oldMaxWidth = mMaxWidth;
 
     mAutoRotate = settings()->value(QStringLiteral("autoRotate"), true).toBool();
-    mFont = settings()->value(QStringLiteral("font"), mButton->font().toString()).toString();
+    mFont = settings()->value(QStringLiteral("font"), QString()).toString(); // the default font should be empty
     mCommand = settings()->value(QStringLiteral("command"), QStringLiteral("echo Configure...")).toString();
     mRunWithBash = settings()->value(QStringLiteral("runWithBash"), true).toBool();
     mRepeat = settings()->value(QStringLiteral("repeat"), true).toBool();

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.h
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.h
@@ -41,26 +41,9 @@ public:
     explicit LXQtCustomCommandConfiguration(PluginSettings *settings, QWidget *parent = nullptr);
     ~LXQtCustomCommandConfiguration();
 
-private:
-    bool mAutoRotate;
-    QString mFont;
-    QString mCommand;
-    bool mRunWithBash;
-    bool mRepeat;
-    int mRepeatTimer;
-    QString mIcon;
-    QString mText;
-    int mMaxWidth;
-    QString mClick;
-    QString mWheelUp;
-    QString mWheelDown;
-
 private slots:
-    void buttonBoxClicked(QAbstractButton *btn);
-    void setUiValues();
     void autoRotateChanged(bool autoRotate);
     void fontButtonClicked();
-    void fontChanged(QString fontString);
     void commandPlainTextEditChanged();
     void runWithBashCheckBoxChanged(bool runWithBash);
     void repeatCheckBoxChanged(bool repeat);
@@ -78,6 +61,7 @@ protected slots:
 
 private:
     Ui::LXQtCustomCommandConfiguration *ui;
+    bool mLockSettingChanges;
 };
 
 #endif // LXQTCUSTOMCOMMANDCONFIGURATION_H


### PR DESCRIPTION
Removed redundant variables/methods and prevented redundant saving in config dialog.

Also, fixed the default font of the button. It should be empty for the button to inherit it from the app; otherwise, the font could never be reset.