### PR TITLE
Sligtly increase of default panel size

### DIFF
--- a/panel/resources/panel.conf
+++ b/panel/resources/panel.conf
@@ -4,6 +4,8 @@ panels=panel1
 plugins=mainmenu,desktopswitch,quicklaunch,taskbar,statusnotifier,tray,mount,volume,worldclock,showdesktop
 position=Bottom
 desktop=0
+iconSize=26
+panelSize=35
 
 [mainmenu]
 type=mainmenu


### PR DESCRIPTION
Default was 32/22px and quicklaunch placeholder text looked  squashed.