### PR TITLE
mainmenu: Remove shortcut popup delay

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -77,9 +77,6 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
     mMenuCacheNotify = nullptr;
 #endif
 
-    mDelayedPopup.setSingleShot(true);
-    mDelayedPopup.setInterval(200);
-    connect(&mDelayedPopup, &QTimer::timeout, this, &LXQtMainMenu::showHideMenu);
     mHideTimer.setSingleShot(true);
     mHideTimer.setInterval(250);
 
@@ -132,14 +129,7 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
             else
                 mShortcutSeq = mShortcut->shortcut();
         });
-        connect(mShortcut, &GlobalKeyShortcut::Action::activated, this, [this] {
-            if (!mHideTimer.isActive())
-                // Delay this a little -- if we don't do this, search field
-                // won't be able to capture focus
-                // See <https://github.com/lxqt/lxqt-panel/pull/131> and
-                // <https://github.com/lxqt/lxqt-panel/pull/312>
-                mDelayedPopup.start();
-        });
+        connect(mShortcut, &GlobalKeyShortcut::Action::activated, this, &LXQtMainMenu::showHideMenu);
     }
 }
 

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -110,7 +110,6 @@ private:
     XdgMenu mXdgMenu;
 #endif
 
-    QTimer mDelayedPopup;
     QTimer mHideTimer;
     QTimer mSearchTimer;
     QString mShortcutSeq;


### PR DESCRIPTION
This was introduced as workaround for "menu not in focus after shortcut
activation". But the root cause of the problem was probably in
lxqt-globalkeys, where the signal was triggered on KeyPress instead of
KeyRelease <- this was fixed recently. Now the delay is pointless.

Closes #1770 