### PR TITLE
Make menus more consistent and intuitive

### DIFF
--- a/menu/lxqt-applications-compact.menu
+++ b/menu/lxqt-applications-compact.menu
@@ -229,13 +229,13 @@
 	</Menu> <!-- End Screensaver -->
 
 	<Layout>
-		<Menuname show_empty="false" inline="true">LXQt-About</Menuname>
-		<Separator/>
 		<Merge type="files"/>
 		<Merge type="menus"/>
 		<Separator/>
 		<Menuname>DesktopSettings</Menuname>
 		<Menuname>LXQtSettings</Menuname>
+		<Separator/>
+		<Menuname show_empty="false" inline="true">LXQt-About</Menuname>
 		<Separator/>
 		<Menuname show_empty="false" inline="true">X-Leave</Menuname>
 		<Menuname show_empty="false" inline="true">Screensaver</Menuname>

--- a/menu/lxqt-applications-simple.menu
+++ b/menu/lxqt-applications-simple.menu
@@ -209,12 +209,13 @@
 		</Include>
 	</Menu> <!-- End Screensaver -->
 
-	<Layout><Menuname show_empty="false" inline="true">LXQt-About</Menuname>
-		<Separator/>
+	<Layout>
 		<Merge type="files"/>
 		<Merge type="menus"/>
 		<Separator/>
 		<Menuname show_empty="false" inline="true">Configuration Center</Menuname>
+		<Separator/>
+		<Menuname show_empty="false" inline="true">LXQt-About</Menuname>
 		<Separator/>
 		<Menuname show_empty="false">X-Leave</Menuname>
 		<Menuname show_empty="false" inline="true">Screensaver</Menuname>

--- a/menu/lxqt-applications.menu
+++ b/menu/lxqt-applications.menu
@@ -226,6 +226,7 @@
 		<Merge type="menus"/>
 		<Separator/>
 		<Menuname>DesktopSettings</Menuname>
+		<Separator/>
 		<Menuname show_empty="false" inline="true">LXQt-About</Menuname>
 		<Separator/>
 		<Menuname show_empty="false">X-Leave</Menuname>


### PR DESCRIPTION
Before all: very first pull request ever, so sorry for everything.

This pull request changes the following things:

1. I noticed an ugliness in the formatting.

2. The about dialog has moved to the bottom.
This is more consistent and intuitive in my opinion, as it is a rather unimportant item.
An application menu should probably have the applications at the top.

3. Made separators consistent.

Opinions are welcome.