### PR TITLE
Added context items to Quick Launch for reloading desktop entries

### DIFF
--- a/plugin-quicklaunch/quicklaunchaction.h
+++ b/plugin-quicklaunch/quicklaunchaction.h
@@ -44,6 +44,7 @@ class QuickLaunchAction : public QAction
     Q_OBJECT
 
 public:
+    enum ActionType { ActionLegacy, ActionXdg, ActionFile };
     /*! Constructor for "legacy" launchers.
         \warning The XDG way is preferred this is only for older or non-standard apps
         \param name a name to display in tooltip
@@ -62,7 +63,10 @@ public:
     QuickLaunchAction(const QString & fileName, QWidget * parent);
 
     //! Returns true if the action is valid (contains all required properties).
-    bool isValid() { return m_valid; }
+    bool isValid() const { return m_valid; }
+
+    //! Returns the action type (legacy, Xdg, file).
+    int type() const { return m_type; }
 
     QHash<QString, QString> settingsMap() { return m_settingsMap; }
 
@@ -72,11 +76,15 @@ public:
      */
     QList<QAction *> addtitionalActions() const { return m_addtitionalActions; }
 
+    /*! Updates the Xdg action by reloading its desktop file.
+     * Does nothing if the desktop file is not loadable or suitable.
+     */
+    void updateXdgAction();
+
 public slots:
     void execAction(QString additionalAction = QString{});
 
 private:
-    enum ActionType { ActionLegacy, ActionXdg, ActionFile };
     ActionType m_type;
     QString m_data;
     bool m_valid;

--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -66,7 +66,31 @@ QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, ILXQtPanelPlugin *
     mMenu = new QMenu(this);
     mMenu->addAction(mAct);
     mMenu->addActions(mAct->addtitionalActions());
-    mMenu->addSeparator();
+    mFirstSep = mMenu->addSeparator();
+    if (mAct->type() == QuickLaunchAction::ActionType::ActionXdg)
+    {
+        auto updateAct = new QAction(XdgIcon::fromTheme(QStringLiteral("view-refresh")), tr("Refresh"), this);
+        connect(updateAct, &QAction::triggered, this, [this]
+        {
+            const auto actions = mMenu->actions();
+            for (const auto &action : actions)
+            {
+                if (action->isSeparator()) // mFirstSep
+                {
+                    break;
+                }
+                mMenu->removeAction(action);
+            }
+            mAct->updateXdgAction();
+            mMenu->insertAction(mFirstSep, mAct);
+            const auto extraActions = mAct->addtitionalActions();
+            for (const auto &action : extraActions)
+            {
+                mMenu->insertAction(mFirstSep, action);
+            }
+        });
+        mMenu->addAction(updateAct);
+    }
     mMenu->addAction(mMoveLeftAct);
     mMenu->addAction(mMoveRightAct);
     mMenu->addSeparator();

--- a/plugin-quicklaunch/quicklaunchbutton.h
+++ b/plugin-quicklaunch/quicklaunchbutton.h
@@ -61,6 +61,7 @@ protected:
 private:
     QuickLaunchAction *mAct;
     ILXQtPanelPlugin * mPlugin;
+    QAction *mFirstSep;
     QAction *mDeleteAct;
     QAction *mMoveLeftAct;
     QAction *mMoveRightAct;


### PR DESCRIPTION
The reloading happens if the (edited) desktop entry is valid/applicable; otherwise, the previous data will be remembered and used.

Closes https://github.com/lxqt/lxqt-panel/issues/1795