### PR TITLE
Set window flags of volume popup explicitly

### DIFF
--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -49,6 +49,10 @@ VolumePopup::VolumePopup(QWidget* parent):
     m_anchor(Qt::TopLeftCorner),
     m_device(nullptr)
 {
+    // Under some Wayland compositors, setting window flags in the c-tor of the base class
+    // may not be enough for a correct positioning of the popup.
+    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::Popup | Qt::X11BypassWindowManagerHint);
+
     m_mixerButton = new QPushButton(this);
     m_mixerButton->setObjectName(QStringLiteral("MixerLink"));
     m_mixerButton->setMinimumWidth(1);


### PR DESCRIPTION
It may make a difference under Wayland, with no change under X11.

Closes https://github.com/lxqt/lxqt-panel/issues/1815