### PR TITLE
Fixed Quick Launch with multiple config files

### DIFF
--- a/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/plugin-quicklaunch/quicklaunchaction.cpp
@@ -50,6 +50,12 @@ QuickLaunchAction::QuickLaunchAction(const QString & name,
     m_settingsMap[QStringLiteral("exec")] = exec;
     m_settingsMap[QStringLiteral("icon")] = icon;
 
+    // Since the keys "desktop" and "file" have priority over the above keys
+    // (see LXQtQuickLaunch::LXQtQuickLaunch), we prevent their reading
+    // from another config file by setting them to empty strings here.
+    m_settingsMap[QStringLiteral("desktop")] = QString();
+    m_settingsMap[QStringLiteral("file")] = QString();
+
     if (icon == QLatin1String("") || icon.isNull())
         setIcon(XdgIcon::defaultApplicationIcon());
     else
@@ -98,6 +104,8 @@ QuickLaunchAction::QuickLaunchAction(const QString & fileName, QWidget * parent)
     setData(fileName);
 
     m_settingsMap[QStringLiteral("file")] = fileName;
+    // prevent reading of "desktop" from another config file
+    m_settingsMap[QStringLiteral("desktop")] = QString();
 
     QFileInfo fi(fileName);
     if (fi.isDir())


### PR DESCRIPTION
The code checks the keys "desktop", "file" and "name/exec/icon" in this order and ignores the rest if one is found. Because of that, for example, if the user config file contains "name/exec/icon" but another config file contains "desktop" *for the same Quick Launch button*, the former will be ignored and the latter will be used instead.

To fix this problem, the patch sets "desktop" and "file" to empty strings for executable scripts. It also sets "desktop" to an empty string for files.

If the user has encountered the bug before this patch, he should either remake his script/file launcher(s) or temporarily change some setting to get rid of the problem.

Fixes https://github.com/lxqt/lxqt-panel/issues/1822