### PR TITLE
Fixed a regression in volume popup

### DIFF
--- a/plugin-volume/lxqtvolume.cpp
+++ b/plugin-volume/lxqtvolume.cpp
@@ -197,7 +197,6 @@ void LXQtVolume::settingsChanged()
 #endif
     }
 
-    m_volumeButton->setShowOnClicked(settings()->value(QStringLiteral(SETTINGS_SHOW_ON_LEFTCLICK), SETTINGS_DEFAULT_SHOW_ON_LEFTCLICK).toBool());
     m_volumeButton->setMuteOnMiddleClick(settings()->value(QStringLiteral(SETTINGS_MUTE_ON_MIDDLECLICK), SETTINGS_DEFAULT_MUTE_ON_MIDDLECLICK).toBool());
     m_volumeButton->setMixerCommand(settings()->value(QStringLiteral(SETTINGS_MIXER_COMMAND), QStringLiteral(SETTINGS_DEFAULT_MIXER_COMMAND)).toString());
     m_volumeButton->volumePopup()->setSliderStep(settings()->value(QStringLiteral(SETTINGS_STEP), SETTINGS_DEFAULT_STEP).toInt());

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -43,7 +43,6 @@ LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool 
     loadSettings();
     connect(ui->devAddedCombo,                     QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtVolumeConfiguration::sinkSelectionChanged);
     connect(ui->buttons,                           &QDialogButtonBox::clicked,                          this, &LXQtVolumeConfiguration::dialogButtonsAction);
-    connect(ui->showOnClickCheckBox,               &QCheckBox::toggled,                                 this, &LXQtVolumeConfiguration::showOnClickedChanged);
     connect(ui->muteOnMiddleClickCheckBox,         &QCheckBox::toggled,                                 this, &LXQtVolumeConfiguration::muteOnMiddleClickChanged);
     connect(ui->mixerLineEdit,                     &QLineEdit::textChanged,                             this, &LXQtVolumeConfiguration::mixerLineEditChanged);
     connect(ui->stepSpinBox,                       QOverload<int>::of(&QSpinBox::valueChanged),         this, &LXQtVolumeConfiguration::stepSpinBoxChanged);
@@ -117,12 +116,6 @@ void LXQtVolumeConfiguration::sinkSelectionChanged(int index)
         settings().setValue(QStringLiteral(SETTINGS_DEVICE), index >= 0 ? index : 0);
 }
 
-void LXQtVolumeConfiguration::showOnClickedChanged(bool state)
-{
-    if (!mLockSettingChanges)
-        settings().setValue(QStringLiteral(SETTINGS_SHOW_ON_LEFTCLICK), state);
-}
-
 void LXQtVolumeConfiguration::muteOnMiddleClickChanged(bool state)
 {
     if (!mLockSettingChanges)
@@ -184,7 +177,6 @@ void LXQtVolumeConfiguration::loadSettings()
         ui->ignoreMaxVolumeCheckBox->setEnabled(false);
 
     setComboboxIndexByData(ui->devAddedCombo, settings().value(QStringLiteral(SETTINGS_DEVICE), SETTINGS_DEFAULT_DEVICE), 1);
-    ui->showOnClickCheckBox->setChecked(settings().value(QStringLiteral(SETTINGS_SHOW_ON_LEFTCLICK), SETTINGS_DEFAULT_SHOW_ON_LEFTCLICK).toBool());
     ui->muteOnMiddleClickCheckBox->setChecked(settings().value(QStringLiteral(SETTINGS_MUTE_ON_MIDDLECLICK), SETTINGS_DEFAULT_MUTE_ON_MIDDLECLICK).toBool());
     ui->mixerLineEdit->setText(settings().value(QStringLiteral(SETTINGS_MIXER_COMMAND), QStringLiteral(SETTINGS_DEFAULT_MIXER_COMMAND)).toString());
     ui->stepSpinBox->setValue(settings().value(QStringLiteral(SETTINGS_STEP), SETTINGS_DEFAULT_STEP).toInt());

--- a/plugin-volume/lxqtvolumeconfiguration.h
+++ b/plugin-volume/lxqtvolumeconfiguration.h
@@ -34,7 +34,6 @@
 #include <QList>
 
 #define SETTINGS_MIXER_COMMAND          "mixerCommand"
-#define SETTINGS_SHOW_ON_LEFTCLICK      "showOnLeftClick"
 #define SETTINGS_MUTE_ON_MIDDLECLICK    "showOnMiddleClick"
 #define SETTINGS_DEVICE                 "device"
 #define SETTINGS_STEP                   "volumeAdjustStep"
@@ -43,7 +42,6 @@
 #define SETTINGS_ALLWAYS_SHOW_NOTIFICATIONS "allwaysShowNotifications"
 #define SETTINGS_SHOW_KEYBOARD_NOTIFICATIONS "showKeyboardNotifications"
 
-#define SETTINGS_DEFAULT_SHOW_ON_LEFTCLICK      true
 #define SETTINGS_DEFAULT_MUTE_ON_MIDDLECLICK    true
 #define SETTINGS_DEFAULT_DEVICE                 0
 #define SETTINGS_DEFAULT_STEP                   3
@@ -80,7 +78,6 @@ public slots:
     void setSinkList(const QList<AudioDevice*> sinks);
     void audioEngineChanged(bool checked);
     void sinkSelectionChanged(int index);
-    void showOnClickedChanged(bool state);
     void muteOnMiddleClickChanged(bool state);
     void mixerLineEditChanged(const QString &command);
     void stepSpinBoxChanged(int step);

--- a/plugin-volume/lxqtvolumeconfiguration.ui
+++ b/plugin-volume/lxqtvolumeconfiguration.ui
@@ -65,13 +65,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="showOnClickCheckBox">
-        <property name="text">
-         <string>Show on mouse click</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="ignoreMaxVolumeCheckBox">
         <property name="text">
          <string>Allow volume beyond 100% (0dB)</string>

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -43,7 +43,6 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         QToolButton(parent),
         mPlugin(plugin),
         m_panel(plugin->panel()),
-        m_showOnClick(true),
         m_muteOnMiddleClick(true)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -68,14 +67,6 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
 
 VolumeButton::~VolumeButton() = default;
 
-void VolumeButton::setShowOnClicked(bool state)
-{
-    if (m_showOnClick == state)
-        return;
-
-    m_showOnClick = state;
-}
-
 void VolumeButton::setMuteOnMiddleClick(bool state)
 {
     m_muteOnMiddleClick = state;
@@ -88,11 +79,6 @@ void VolumeButton::setMixerCommand(const QString &command)
 
 void VolumeButton::enterEvent(QEvent *event)
 {
-    if (!m_showOnClick)
-        showVolumeSlider();
-
-    m_popupHideTimer.stop();
-
     // show tooltip immediately on entering widget
     QToolTip::showText(static_cast<QEnterEvent*>(event)->globalPos(), toolTip());
 }
@@ -103,11 +89,6 @@ void VolumeButton::mouseMoveEvent(QMouseEvent *event)
     // show tooltip immediately on moving the mouse
     if (!QToolTip::isVisible()) // prevent sliding of tooltip
         QToolTip::showText(event->globalPos(), toolTip());
-}
-
-void VolumeButton::leaveEvent(QEvent * /*event*/)
-{
-    m_popupHideTimer.start();
 }
 
 void VolumeButton::wheelEvent(QWheelEvent *event)

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -43,7 +43,6 @@ public:
     VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent = nullptr);
     ~VolumeButton();
 
-    void setShowOnClicked(bool state);
     void setMuteOnMiddleClick(bool state);
     void setMixerCommand(const QString &command);
 
@@ -55,7 +54,6 @@ public slots:
 
 protected:
     void enterEvent(QEvent *event) override;
-    void leaveEvent(QEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -70,7 +68,6 @@ private:
     ILXQtPanelPlugin *mPlugin;
     ILXQtPanel *m_panel;
     QTimer m_popupHideTimer;
-    bool m_showOnClick;
     bool m_muteOnMiddleClick;
     QString m_mixerCommand;
 };


### PR DESCRIPTION
The code shouldn't try to show or hide the popup based on the enter and leave events of its button because those events aren't (or shouldn't be) emitted when the popup is visible.

Also, the option for showing the popup on button mouseover has been removed, because the popup couldn't be hidden when the cursor left the button.

Previously, the code made use of a Qt issue to do the above-mentioned actions, but the issue was avoided for another purpose in V1.2.0.

Fixes https://github.com/lxqt/lxqt-panel/issues/1839