### PR TITLE
ColorPicker, Backlight, KbIndicator, and StatusNotifier styling fixes

### DIFF
--- a/plugin-backlight/backlight.cpp
+++ b/plugin-backlight/backlight.cpp
@@ -32,6 +32,8 @@ LXQtBacklight::LXQtBacklight(const ILXQtPanelPluginStartupInfo &startupInfo):
         ILXQtPanelPlugin(startupInfo)
 {
     m_backlightButton = new QToolButton();
+
+    m_backlightButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     // use our own icon
     m_backlightButton->setIcon(QIcon::fromTheme(QStringLiteral("brightnesssettings")));
 

--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -77,8 +77,6 @@ void ColorPicker::realign()
 
 ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent)
 {
-    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-
     mSeparator = new QFrame();
     mSeparator->setFrameShape(QFrame::VLine);
     mSeparator->setFrameShadow(QFrame::Sunken);
@@ -89,12 +87,14 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent)
     mPickerButton->setObjectName(QStringLiteral("ColorPickerPickerButton"));
     mPickerButton->setAccessibleName(mPickerButton->objectName());
     mPickerButton->setAutoRaise(true);
+    mPickerButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mPickerButton->setIcon(QIcon::fromTheme(QLatin1String("color-picker"), QIcon::fromTheme(QLatin1String("color-select-symbolic"))));
 
     mColorButton = new ColorButton();
     mColorButton->setObjectName(QStringLiteral("ColorPickerColorButton"));
     mColorButton->setAccessibleName(mColorButton->objectName());
     mColorButton->setAutoRaise(true);
+    mColorButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mColorButton->setStyleSheet(QStringLiteral("::menu-indicator{ image: none; }"));
 
     QBoxLayout *layout = new QBoxLayout(QBoxLayout::LeftToRight);

--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -67,6 +67,7 @@ Content::Content(bool layoutEnabled):
     m_layout = new QToolButton;
     m_layout->setObjectName(QStringLiteral("LayoutLabel"));
     m_layout->setAutoRaise(true);
+
     connect(m_layout, &QAbstractButton::released, this, [this] { emit controlClicked(Controls::Layout); });
     box->addWidget(m_layout, 0, Qt::AlignCenter);
 }

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -63,6 +63,7 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoRaise(true);
+    setObjectName(QLatin1String("StatusNotifierButton"));
     interface = new SniAsync(service, objectPath, QDBusConnection::sessionBus(), this);
 
     connect(interface, &SniAsync::NewIcon, this, &StatusNotifierButton::newIcon);


### PR DESCRIPTION
I was unsure how to set KbIndicator's #Layout to a fixed 2 characters.

Closes #1845 .