### PR TITLE
panel: avoid covering fullscreen windows

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -146,9 +146,7 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
     //Qt documentation or at https://doc.qt.io/qt-5/qt.html
     //Qt::FramelessWindowHint = Produces a borderless window. The user cannot
     //move or resize a borderless window via the window system. On X11, ...
-    //Qt::WindowStaysOnTopHint = Informs the window system that the window
-    //should stay on top of all other windows. Note that on ...
-    Qt::WindowFlags flags = Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint;
+    Qt::WindowFlags flags = Qt::FramelessWindowHint;
 
     // NOTE: by PCMan:
     // In Qt 4, the window is not activated if it has Qt::WA_X11NetWmWindowTypeDock.


### PR DESCRIPTION
Since xfwm4 4.18 [1], windows with `_NET_WM_STATE_ABOVE` cover fullscreen windows. Qt's XCB plugin sets `_NET_WM_STATE_ABOVE` for windows with the flag `Qt::WindowStaysOnTopHint` [2], so panels cover fullscreen windows.

On the other hand, panels have the window type dock [3], which still covers normal windows per the spec [4] and in xfwm4.

The xfwm4 change [1] mentions it follows GNOME, so the issue may be present on Mutter as well.

[1] https://gitlab.xfce.org/xfce/xfwm4/-/commit/cdcce73653d430d9cbddba3873e4e98ddae0a6a8
[2] https://github.com/qt/qtbase/blob/v5.15.7-lts-lgpl/src/plugins/platforms/xcb/qxcbwindow.cpp#L1060
[3] https://github.com/lxqt/lxqt-panel/blob/dbd15d48e0cd8a0b92c769fb9ca875f94154ad74/panel/lxqtpanel.cpp#L167
[4] https://specifications.freedesktop.org/wm-spec/latest/ar01s09.html#STACKINGORDER