### PR TITLE
Fixed volume change with hi-res mice and touchpad scrolling

### DIFF
--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -30,6 +30,7 @@
 
 #include <QDialog>
 
+class QTimer;
 class QSlider;
 class QPushButton;
 class AudioDevice;
@@ -81,6 +82,7 @@ private:
     QPoint m_pos;
     Qt::Corner m_anchor;
     AudioDevice *m_device;
+    QTimer *mWheelTimer; // for showing tooltip with high-resolution mice
 };
 
 #endif // VOLUMEPOPUP_H


### PR DESCRIPTION
Fixed volume change with hi-res mice and touchpad scrolling

An angle of 15° is required for changing the volume — as with ordinary mice.

Also,

 * Changing the volume by touchpad scrolling is fixed; and
 * Tooltip flickering on wheel rotation is prevented.
