### PR TITLE
Removed redundant classes from `VolumeButton` in volume plugin

### DIFF
--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -42,7 +42,6 @@
 VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         QToolButton(parent),
         mPlugin(plugin),
-        m_panel(plugin->panel()),
         m_muteOnMiddleClick(true)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -32,8 +32,6 @@
 #include <QTimer>
 
 class VolumePopup;
-class ILXQtPanel;
-class LXQtVolume;
 class ILXQtPanelPlugin;
 
 class VolumeButton : public QToolButton
@@ -66,7 +64,6 @@ private slots:
 private:
     VolumePopup *m_volumePopup;
     ILXQtPanelPlugin *mPlugin;
-    ILXQtPanel *m_panel;
     QTimer m_popupHideTimer;
     bool m_muteOnMiddleClick;
     QString m_mixerCommand;


### PR DESCRIPTION
They were useless under X11, but the existence of `ILXQtPanel` inside `VolumeButton` made the volume popup have an incorrect position under Wayland.

Closes https://github.com/lxqt/lxqt-panel/issues/1815