### PR TITLE
Nullity check for quicklaunch placeholder widget

### DIFF
--- a/plugin-quicklaunch/lxqtquicklaunch.cpp
+++ b/plugin-quicklaunch/lxqtquicklaunch.cpp
@@ -160,9 +160,12 @@ void LXQtQuickLaunch::addButton(QuickLaunchAction* action)
     connect(btn, &QuickLaunchButton::movedLeft,     this, &LXQtQuickLaunch::buttonMoveLeft);
     connect(btn, &QuickLaunchButton::movedRight,    this, &LXQtQuickLaunch::buttonMoveRight);
 
-    mLayout->removeWidget(mPlaceHolder);
-    delete mPlaceHolder;
-    mPlaceHolder = nullptr;
+    if (mPlaceHolder)
+    {
+        mLayout->removeWidget(mPlaceHolder);
+        delete mPlaceHolder;
+        mPlaceHolder = nullptr;
+    }
     mLayout->setEnabled(true);
     realign();
 }


### PR DESCRIPTION
Eliminates error message "QLayout::removeWidget: Cannot remove a null widget." when starting with a populated quicklaunch, or when adding members.