### PR TITLE
Enable DOM plugin by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(DIRECTORYMENU_PLUGIN)
     add_subdirectory(plugin-directorymenu)
 endif()
 
-setByDefault(DOM_PLUGIN No)
+setByDefault(DOM_PLUGIN Yes)
 if(DOM_PLUGIN)
     list(APPEND ENABLED_PLUGINS "DOM")
     add_subdirectory(plugin-dom)


### PR DESCRIPTION
It was disabled in a seemingly unrelated change https://github.com/lxqt/lxqt-panel/commit/2dbbed87d72dcda98494a907207e2a65134bebc4