### PR TITLE
Fixed the seconds shown by clock

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -83,7 +83,7 @@ LXQtWorldClock::~LXQtWorldClock()
 
 void LXQtWorldClock::timeout()
 {
-    if (QDateTime{}.time().msec() > 500)
+    if (QTime::currentTime().msec() > 500)
         restartTimer();
     updateTimeText();
 }


### PR DESCRIPTION
Found the problem only after comparing the seconds shown by Panel's clock with the seconds hand of a Qt analog clock I'd made.

Fixes https://github.com/lxqt/lxqt-panel/issues/1880