### PR TITLE
taskbar: Fix checking/clearing of urgency

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -834,12 +834,6 @@ void LXQtTaskButton::setUrgencyHint(bool set)
     if (mUrgencyHint == set)
         return;
 
-    if (!set) {
-        // TODO: Test using QWindow::alert()
-        NETWinInfo info(QX11Info::connection(), mWindow, QX11Info::appRootWindow(), NET::WMState, NET::Properties2());
-        info.setState(set ? NET::DemandsAttention : NET::States(), NET::DemandsAttention);
-    }
-
     mUrgencyHint = set;
     setProperty("urgent", set);
     style()->unpolish(this);


### PR DESCRIPTION
We need to test the real urgency hint, not just the flag about urgency hint changed.
In the previous commit 44c46c163b7282fd521b3cf361e6f87c88a48a9f, bug for clearing of the urgency widget hint was introduced also.

I was too hurry in the previous PR #1901, it was working just by a chance and resetting the urgency style was buggy also. This should fix both shortcomings.