### PR TITLE
Fixed window cycling with wheel and focus stealing prevention

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -107,7 +107,7 @@ LXQtTaskButton::LXQtTaskButton(const WId window, LXQtTaskBar * taskbar, QWidget 
 
     mDNDTimer->setSingleShot(true);
     mDNDTimer->setInterval(700);
-    connect(mDNDTimer, &QTimer::timeout, this, &LXQtTaskButton::activateWithDraggable);
+    connect(mDNDTimer, &QTimer::timeout, this, &LXQtTaskButton::raiseApplication);
 
     mWheelTimer->setSingleShot(true);
     mWheelTimer->setInterval(250);
@@ -413,17 +413,6 @@ bool LXQtTaskButton::isApplicationActive() const
 /************************************************
 
  ************************************************/
-void LXQtTaskButton::activateWithDraggable()
-{
-    // raise app in any time when there is a drag
-    // in progress to allow drop it into an app
-    raiseApplication();
-    KX11Extras::forceActiveWindow(mWindow);
-}
-
-/************************************************
-
- ************************************************/
 void LXQtTaskButton::raiseApplication()
 {
     KWindowInfo info(mWindow, NET::WMDesktop | NET::WMState | NET::XAWMState);
@@ -437,7 +426,8 @@ void LXQtTaskButton::raiseApplication()
         if (KX11Extras::currentDesktop() != winDesktop)
             KX11Extras::setCurrentDesktop(winDesktop);
     }
-    KX11Extras::activateWindow(mWindow);
+    // bypass focus stealing prevention
+    KX11Extras::forceActiveWindow(mWindow);
 
     setUrgencyHint(false);
 }

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -93,7 +93,7 @@ public slots:
     void shadeApplication();
     void unShadeApplication();
     void closeApplication();
-    void moveApplicationToDesktop();    
+    void moveApplicationToDesktop();
     void moveApplication();
     void resizeApplication();
     void setApplicationLayer();
@@ -139,9 +139,6 @@ private:
 
     // Timer for distinguishing between separate mouse wheel rotations
     QTimer * mWheelTimer;
-
-private slots:
-    void activateWithDraggable();
 
 signals:
     void dropped(QObject * dragSource, QPoint const & pos);


### PR DESCRIPTION
When focus stealing prevention exists, the only way of having a consistent window cycling with mouse wheel is forcing window activation. Since this is a taskbar, it is allowed to do so.

Fixes https://github.com/lxqt/lxqt-panel/issues/1904