### PR TITLE
Fixed a new case of high CPU usage with scaling

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -159,35 +159,6 @@ void LXQtTaskButton::updateIcon()
 /************************************************
 
  ************************************************/
-void LXQtTaskButton::refreshIconGeometry(QRect const & geom)
-{
-    xcb_connection_t* x11conn = QX11Info::connection();
-
-    if (!x11conn) {
-        return;
-    }
-
-    NETWinInfo info(x11conn,
-                    windowId(),
-                    (WId) QX11Info::appRootWindow(),
-                    NET::WMIconGeometry,
-                    NET::Properties2());
-    NETRect const curr = info.iconGeometry();
-    if (curr.pos.x != geom.x() || curr.pos.y != geom.y()
-            || curr.size.width != geom.width() || curr.size.height != geom.height())
-    {
-        NETRect nrect;
-        nrect.pos.x = geom.x();
-        nrect.pos.y = geom.y();
-        nrect.size.height = geom.height();
-        nrect.size.width = geom.width();
-        info.setIconGeometry(nrect);
-    }
-}
-
-/************************************************
-
- ************************************************/
 void LXQtTaskButton::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::StyleChange)

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -79,7 +79,6 @@ public:
 
     LXQtTaskBar * parentTaskBar() const {return mParentTaskBar;}
 
-    void refreshIconGeometry(QRect const & geom);
     static QString mimeDataFormat() { return QLatin1String("lxqt/lxqttaskbutton"); }
     /*! \return true if this button received DragEnter event (and no DragLeave event yet)
      * */

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -439,18 +439,8 @@ void LXQtTaskGroup::setPopupVisible(bool visible, bool fast)
  ************************************************/
 void LXQtTaskGroup::refreshIconsGeometry()
 {
-    QRect rect = geometry();
-    rect.moveTo(mapToGlobal(QPoint(0, 0)));
-
-    if (mSingleButton)
-    {
-        refreshIconGeometry(rect);
-        return;
-    }
-
     for(LXQtTaskButton *but : qAsConst(mButtonHash))
     {
-        but->refreshIconGeometry(rect);
         but->setIconSize(QSize(plugin()->panel()->iconSize(), plugin()->panel()->iconSize()));
     }
 }


### PR DESCRIPTION
… by removing `LXQtTaskButton::refreshIconGeometry`, for which I found no use. The high CPU usage was a result of a recent change — or perhaps bug — in `KWindowSystem`.

Fixes https://github.com/lxqt/lxqt-panel/issues/1926

EDIT: As @palinek explained later, `LXQtTaskButton::refreshIconGeometry` is for WM minimizing animations, like KWin's "magic lamp".