### PR TITLE
Keyboard State Indicator: do not toggle on right click

### DIFF
--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -130,15 +130,18 @@ QWidget* Content::widget(Controls cnt) const
 
 bool Content::eventFilter(QObject *object, QEvent *event)
 {
-    if (event->type() == QEvent::QEvent::MouseButtonRelease
-        && static_cast<QMouseEvent*>(event)->button() == Qt::LeftButton)
+    if (event->type() == QEvent::QEvent::MouseButtonRelease)
     {
-        if (object == m_capsLock)
-            emit controlClicked(Controls::Caps);
-        else if (object == m_numLock)
-            emit controlClicked(Controls::Num);
-        else if (object == m_scrollLock)
-            emit controlClicked(Controls::Scroll);
+        Qt::MouseButton btn = static_cast<QMouseEvent*>(event)->button();
+        if (btn == Qt::LeftButton || btn == Qt::MiddleButton)
+        {
+	    if (object == m_capsLock)
+	        emit controlClicked(Controls::Caps);
+	    else if (object == m_numLock)
+	        emit controlClicked(Controls::Num);
+            else if (object == m_scrollLock)
+                emit controlClicked(Controls::Scroll);
+        }
     }
 
     return QWidget::eventFilter(object, event);

--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -28,6 +28,7 @@
 #include <QLabel>
 #include <QDebug>
 #include <QEvent>
+#include <QMouseEvent>
 #include <QIcon>
 #include <QToolButton>
 #include <QFileInfo>
@@ -129,7 +130,8 @@ QWidget* Content::widget(Controls cnt) const
 
 bool Content::eventFilter(QObject *object, QEvent *event)
 {
-    if (event->type() == QEvent::QEvent::MouseButtonRelease)
+    if (event->type() == QEvent::QEvent::MouseButtonRelease
+        && static_cast<QMouseEvent*>(event)->button() == Qt::LeftButton)
     {
         if (object == m_capsLock)
             emit controlClicked(Controls::Caps);


### PR DESCRIPTION
This suppresses toggling states when trying to access the context menu