### PR TITLE
Fixed the tooltips of volume control under Wayland

### DIFF
--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -80,7 +80,7 @@ void VolumeButton::setMixerCommand(const QString &command)
 void VolumeButton::enterEvent(QEvent *event)
 {
     // show tooltip immediately on entering widget
-    QToolTip::showText(static_cast<QEnterEvent*>(event)->globalPos(), toolTip());
+    QToolTip::showText(static_cast<QEnterEvent*>(event)->globalPos(), toolTip(), this);
 }
 
 void VolumeButton::mouseMoveEvent(QMouseEvent *event)
@@ -88,7 +88,7 @@ void VolumeButton::mouseMoveEvent(QMouseEvent *event)
     QToolButton::mouseMoveEvent(event);
     // show tooltip immediately on moving the mouse
     if (!QToolTip::isVisible()) // prevent sliding of tooltip
-        QToolTip::showText(event->globalPos(), toolTip());
+        QToolTip::showText(event->globalPos(), toolTip(), this);
 }
 
 void VolumeButton::wheelEvent(QWheelEvent *event)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -127,7 +127,7 @@ void VolumePopup::handleSliderValueChanged(int value)
         return;
     // qDebug("VolumePopup::handleSliderValueChanged: %d\n", value);
     m_device->setVolume(value);
-    QTimer::singleShot(0, this, [this] { QToolTip::showText(QCursor::pos(), m_volumeSlider->toolTip()); });
+    QTimer::singleShot(0, this, [this] { QToolTip::showText(QCursor::pos(), m_volumeSlider->toolTip(), this); });
 }
 
 void VolumePopup::handleMuteToggleClicked()


### PR DESCRIPTION
… by setting their parent widgets. X11 sees no change.

Fixes https://github.com/lxqt/lxqt-panel/issues/1927