### PR TITLE
Rename kf5 packages

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -3,7 +3,7 @@ set -ex
 source shared-ci/prepare-archlinux.sh
 
 # See *depends in https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=lxqt-panel-git
-pacman -S --noconfirm --needed git cmake qt5-tools lxqt-build-tools-git alsa-lib libpulse lm_sensors libstatgrab libsysstat-git solid menu-cache libxcomposite lxqt-menu-data-git libdbusmenu-qt5 lxqt-globalkeys-git libxtst
+pacman -S --noconfirm --needed git cmake qt5-tools lxqt-build-tools-git alsa-lib libpulse lm_sensors libstatgrab libsysstat-git solid5 menu-cache libxcomposite lxqt-menu-data-git libdbusmenu-qt5 lxqt-globalkeys-git libxtst
 
 cmake -B build -S .
 make -C build


### PR DESCRIPTION
Most KF5 packages are renamed to have a suffix, and provides= is later droped.

See: https://gitlab.archlinux.org/archlinux/packaging/packages/solid5/-/commit/b04eb194f02b4340aa24aee6d8001b6306ea4ebd
See: https://gitlab.archlinux.org/archlinux/packaging/packages/lxqt-panel/-/commit/f25b78c90774196875308df034a3ab9ae7a7cc35
See: https://aur.archlinux.org/cgit/aur.git/commit/?h=lxqt-panel-git&id=f70ca49e16a5c3a074673462297ae4a58a014240