### PR TITLE
 Reorder XML .ui files to correct tab orders for plugin config dialogs

### DIFF
--- a/plugin-mainmenu/lxqtmainmenuconfiguration.ui
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.ui
@@ -127,6 +127,13 @@
       <string>Keyboard Shortcut</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Click the button to record shortcut:</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="ShortcutSelector" name="shortcutEd">
         <property name="minimumSize">
@@ -140,13 +147,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Click the button to record shortcut:</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -156,10 +156,10 @@
       <string>Search</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="1">
-       <widget class="QLabel" name="filterShowMaxWidthL">
+      <item row="0" column="0" colspan="3">
+       <widget class="QCheckBox" name="filterMenuCB">
         <property name="text">
-         <string>Max. item width:</string>
+         <string>Filter menu entries</string>
         </property>
        </widget>
       </item>
@@ -170,13 +170,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="filterShowMaxItemsSB">
-        <property name="maximum">
-         <number>20</number>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="filterShowMaxItemsL">
         <property name="text">
@@ -184,10 +177,17 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="3">
-       <widget class="QCheckBox" name="filterMenuCB">
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="filterShowMaxItemsSB">
+        <property name="maximum">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="filterShowMaxWidthL">
         <property name="text">
-         <string>Filter menu entries</string>
+         <string>Max. item width:</string>
         </property>
        </widget>
       </item>

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.ui
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.ui
@@ -29,23 +29,10 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QLabel" name="interfaceLabel">
+      <item row="0" column="0">
+       <widget class="QLabel" name="iconLabel">
         <property name="text">
-         <string>Interface</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="interfaceCB">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
+         <string>Icon</string>
         </property>
        </widget>
       </item>
@@ -89,10 +76,23 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="iconLabel">
+      <item row="1" column="0">
+       <widget class="QLabel" name="interfaceLabel">
         <property name="text">
-         <string>Icon</string>
+         <string>Interface</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="interfaceCB">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/plugin-sensors/lxqtsensorsconfiguration.ui
+++ b/plugin-sensors/lxqtsensorsconfiguration.ui
@@ -43,13 +43,6 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="tempBarWidthL">
-         <property name="text">
-          <string>Temperature bar width</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="1">
         <widget class="QSpinBox" name="updateIntervalSB">
          <property name="enabled">
@@ -75,6 +68,13 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="tempBarWidthL">
+         <property name="text">
+          <string>Temperature bar width</string>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="1">
         <widget class="QSpinBox" name="tempBarWidthSB">
          <property name="minimum">
@@ -85,18 +85,24 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="2" column="0" colspan="2">
+        <widget class="QCheckBox" name="warningAboutHighTemperatureChB">
+         <property name="toolTip">
+          <string>Blink status bars when the temperature is too high</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
          </property>
-        </spacer>
+         <property name="text">
+          <string>Warning about high temperature</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="tristate">
+          <bool>false</bool>
+         </property>
+        </widget>
        </item>
        <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="tempScaleGB">
@@ -126,24 +132,18 @@
          <zorder>celsiusTempScaleRB</zorder>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="QCheckBox" name="warningAboutHighTemperatureChB">
-         <property name="toolTip">
-          <string>Blink status bars when the temperature is too high</string>
+       <item row="5" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-         <property name="text">
-          <string>Warning about high temperature</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/plugin-sensors/lxqtsensorsconfiguration.ui
+++ b/plugin-sensors/lxqtsensorsconfiguration.ui
@@ -152,6 +152,13 @@
        <string>Sensors</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="3" column="0">
+        <widget class="QLabel" name="detectedChipsL">
+         <property name="text">
+          <string>Detected chips:</string>
+         </property>
+        </widget>
+       </item>
        <item row="4" column="0">
         <widget class="QComboBox" name="detectedChipsCB">
          <property name="currentIndex">
@@ -159,13 +166,6 @@
          </property>
          <property name="frame">
           <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="detectedChipsL">
-         <property name="text">
-          <string>Detected chips:</string>
          </property>
         </widget>
        </item>

--- a/plugin-spacer/spacerconfiguration.ui
+++ b/plugin-spacer/spacerconfiguration.ui
@@ -34,27 +34,24 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="labelType">
-     <property name="text">
-      <string>Space type:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttons">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QRadioButton" name="sizeFixedRB">
      <property name="text">
       <string>fixed</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QRadioButton" name="sizeExpandRB">
+     <property name="text">
+      <string>expandable</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelType">
+     <property name="text">
+      <string>Space type:</string>
      </property>
     </widget>
    </item>
@@ -65,10 +62,13 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QRadioButton" name="sizeExpandRB">
-     <property name="text">
-      <string>expandable</string>
+   <item row="3" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
      </property>
     </widget>
    </item>

--- a/plugin-spacer/spacerconfiguration.ui
+++ b/plugin-spacer/spacerconfiguration.ui
@@ -21,6 +21,13 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="QRadioButton" name="sizeFixedRB">
+     <property name="text">
+      <string>fixed</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="2">
     <widget class="QSpinBox" name="sizeSB">
      <property name="minimum">
@@ -31,13 +38,6 @@
      </property>
      <property name="value">
       <number>8</number>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QRadioButton" name="sizeFixedRB">
-     <property name="text">
-      <string>fixed</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Some fixes to lxqt-panel plugins config dialogs

Affected files:
plugin-mainmenu/lxqtmainmenuconfiguration.ui
plugin-networkmonitor/lxqtnetworkmonitorconfiguration.ui plugin-sensors/lxqtsensorsconfiguration.ui
plugin-spacer/spacerconfiguration.ui