### PR TITLE
Added .svg format to panel background in translations

### DIFF
--- a/panel/translations/lxqt-panel.ts
+++ b/panel/translations/lxqt-panel.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_ar.ts
+++ b/panel/translations/lxqt-panel_ar.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>الصور (‎*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>الصور (‎*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_arn.ts
+++ b/panel/translations/lxqt-panel_arn.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_ast.ts
+++ b/panel/translations/lxqt-panel_ast.ts
@@ -304,8 +304,8 @@ Pintar los iconos según l&apos;estilu de widgets (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configpanelwidget.cpp" line="470"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imáxenes (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imáxenes (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_bg.ts
+++ b/panel/translations/lxqt-panel_bg.ts
@@ -363,8 +363,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Изображения (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Изображения (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ca.ts
+++ b/panel/translations/lxqt-panel_ca.ts
@@ -369,8 +369,8 @@ Acoloreix les icones en funció de l&apos;estil de l&apos;estri (paleta)</transl
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imatges (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imatges (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_cs.ts
+++ b/panel/translations/lxqt-panel_cs.ts
@@ -369,8 +369,8 @@ Obarvit ikony podle stylu prvku (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Obrázky (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Obrázky (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_cy.ts
+++ b/panel/translations/lxqt-panel_cy.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_da.ts
+++ b/panel/translations/lxqt-panel_da.ts
@@ -369,8 +369,8 @@ Farvelæg ikoner baseret på widgetstil (palet)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Billeder (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Billeder (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_de.ts
+++ b/panel/translations/lxqt-panel_de.ts
@@ -369,8 +369,8 @@ Symbolfarbe folgt Symbolthema (Farben)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Bilder (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Bilder (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_el.ts
+++ b/panel/translations/lxqt-panel_el.ts
@@ -371,8 +371,8 @@ LXQT Διαμόρφωση εμφάνισης→
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Εικόνες (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Εικόνες (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_en_GB.ts
+++ b/panel/translations/lxqt-panel_en_GB.ts
@@ -369,8 +369,8 @@ Colourise icons based on widget style (palette)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Images (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Images (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_eo.ts
+++ b/panel/translations/lxqt-panel_eo.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_es.ts
+++ b/panel/translations/lxqt-panel_es.ts
@@ -370,8 +370,8 @@ Colorear los iconos según la paleta de colores usada en los widgets</translatio
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imágenes (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imágenes (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_es_UY.ts
+++ b/panel/translations/lxqt-panel_es_UY.ts
@@ -362,8 +362,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imágenes (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imágenes (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_es_VE.ts
+++ b/panel/translations/lxqt-panel_es_VE.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_et.ts
+++ b/panel/translations/lxqt-panel_et.ts
@@ -369,8 +369,8 @@ Ikoonide värvimine vidinastiili alusel (värvipalett)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Pildifailid (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Pildifailid (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_eu.ts
+++ b/panel/translations/lxqt-panel_eu.ts
@@ -369,7 +369,7 @@ Koloreztatu ikonoak widget estiloaren arabera (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation>Irudiak (* .png * .gif * .jpg)</translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_fa.ts
+++ b/panel/translations/lxqt-panel_fa.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>تصاویر (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>تصاویر (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_fi.ts
+++ b/panel/translations/lxqt-panel_fi.ts
@@ -369,8 +369,8 @@ Väritä kuvakkeet pienoisohjelmatyylin (paletti) mukaan</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Kuvat (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Kuvat (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_fr.ts
+++ b/panel/translations/lxqt-panel_fr.ts
@@ -369,8 +369,8 @@ Colorier les icônes en fonction du style du widget (palette)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Images (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Images (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_gl.ts
+++ b/panel/translations/lxqt-panel_gl.ts
@@ -369,8 +369,8 @@ Colorar as iconas segundo o estilo dos trebellos (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imaxes (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imaxes (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_he.ts
+++ b/panel/translations/lxqt-panel_he.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>תמונות ‎(*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>תמונות ‎(*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_hr.ts
+++ b/panel/translations/lxqt-panel_hr.ts
@@ -369,8 +369,8 @@ Oboji ikone na osnovi stila programčića (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Slike (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Slike (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_hu.ts
+++ b/panel/translations/lxqt-panel_hu.ts
@@ -369,8 +369,8 @@ Színes ikonok az elemek stílusából (paletta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Képek (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Képek (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ia.ts
+++ b/panel/translations/lxqt-panel_ia.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_id.ts
+++ b/panel/translations/lxqt-panel_id.ts
@@ -369,8 +369,8 @@ Warnai ikon berdasarkan gaya widget (palette)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Gambar (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Gambar (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_it.ts
+++ b/panel/translations/lxqt-panel_it.ts
@@ -369,8 +369,8 @@ Colora le icone in base allo stile del widget (palette)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Immagini (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Immagini (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ja.ts
+++ b/panel/translations/lxqt-panel_ja.ts
@@ -369,8 +369,8 @@ LXQt 設定 - 外観 →
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>画像 (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>画像 (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ko.ts
+++ b/panel/translations/lxqt-panel_ko.ts
@@ -369,8 +369,8 @@ LXQt 모양새 구성 →
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>이미지 (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>이미지 (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_lt.ts
+++ b/panel/translations/lxqt-panel_lt.ts
@@ -370,8 +370,8 @@ Spalvinti piktogramas valdiklių stiliaus
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Paveikslai (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Paveikslai (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_lv.ts
+++ b/panel/translations/lxqt-panel_lv.ts
@@ -369,8 +369,8 @@ Iekrāsot ikonas, balstoties uz logrīku stilu (palete)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Attēli (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Attēli (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_nb_NO.ts
+++ b/panel/translations/lxqt-panel_nb_NO.ts
@@ -369,8 +369,8 @@ Fargelegg symboler basert på widget-stil (pallett)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Bilder (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Bilder (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_nl.ts
+++ b/panel/translations/lxqt-panel_nl.ts
@@ -369,8 +369,8 @@ Pictogrammen inkleuren op basis van elementstijl (palet)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Afbeeldingen (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Afbeeldingen (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_oc.ts
+++ b/panel/translations/lxqt-panel_oc.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_pa.ts
+++ b/panel/translations/lxqt-panel_pa.ts
@@ -362,8 +362,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>ਚਿੱਤਰ (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>ਚਿੱਤਰ (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_pl.ts
+++ b/panel/translations/lxqt-panel_pl.ts
@@ -369,8 +369,8 @@ Koloruj ikony na podstawie stylu (palety)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Obrazki (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Obrazki (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_pt.ts
+++ b/panel/translations/lxqt-panel_pt.ts
@@ -369,8 +369,8 @@ Colorir ícones tendo por base o estilo do widget (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imagens (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imagens (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_pt_BR.ts
+++ b/panel/translations/lxqt-panel_pt_BR.ts
@@ -369,8 +369,8 @@ Colorir ícones baseado no estilo widget (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imagens (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imagens (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ro_RO.ts
+++ b/panel/translations/lxqt-panel_ro_RO.ts
@@ -369,8 +369,8 @@ Colorează pictogramele pe baza stilului widgetului (paletei)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Imagini (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Imagini (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_ru.ts
+++ b/panel/translations/lxqt-panel_ru.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Изображения (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Изображения (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_si.ts
+++ b/panel/translations/lxqt-panel_si.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_sk_SK.ts
+++ b/panel/translations/lxqt-panel_sk_SK.ts
@@ -369,8 +369,8 @@ Farbu ikon na základe štýlu widgetu (palety)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Obrázky (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Obrázky (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_sl.ts
+++ b/panel/translations/lxqt-panel_sl.ts
@@ -369,8 +369,8 @@ Obarvaj ikone glede na stil (paleto) gradnikov</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Slike (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Slike (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_sr@ijekavian.ts
+++ b/panel/translations/lxqt-panel_sr@ijekavian.ts
@@ -369,8 +369,8 @@ LXQt подешавање приказа→
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Слике (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Слике (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_sr@latin.ts
+++ b/panel/translations/lxqt-panel_sr@latin.ts
@@ -369,7 +369,7 @@ Oboji ikone na osnovu stila vidžeta (paleta)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_sr_BA.ts
+++ b/panel/translations/lxqt-panel_sr_BA.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_sr_RS.ts
+++ b/panel/translations/lxqt-panel_sr_RS.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Слике (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Слике (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_sv.ts
+++ b/panel/translations/lxqt-panel_sv.ts
@@ -370,8 +370,8 @@ Färgade ikoner baserad på widgetstil (palett)</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Bilder (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Bilder (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_th_TH.ts
+++ b/panel/translations/lxqt-panel_th_TH.ts
@@ -362,7 +362,7 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panel/translations/lxqt-panel_tr.ts
+++ b/panel/translations/lxqt-panel_tr.ts
@@ -369,8 +369,8 @@ Gereç biçimine (palet) göre simgeleri renklendir</translation>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Resimler (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Resimler (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_uk.ts
+++ b/panel/translations/lxqt-panel_uk.ts
@@ -369,8 +369,8 @@ Colorize icons based on widget style (palette)</source>
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>Зображення (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>Зображення (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_zh_CN.ts
+++ b/panel/translations/lxqt-panel_zh_CN.ts
@@ -369,8 +369,8 @@ LXQt 外观配置→
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>图像 (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>图像 (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/panel/translations/lxqt-panel_zh_TW.ts
+++ b/panel/translations/lxqt-panel_zh_TW.ts
@@ -369,8 +369,8 @@ LXQt外觀配置→
     </message>
     <message>
         <location filename="../config/configstyling.cpp" line="223"/>
-        <source>Images (*.png *.gif *.jpg)</source>
-        <translation>圖片 (*.png *.gif *.jpg)</translation>
+        <source>Images (*.png *.gif *.jpg *.svg)</source>
+        <translation>圖片 (*.png *.gif *.jpg *.svg)</translation>
     </message>
 </context>
 <context>

--- a/plugin-worldclock/translations/worldclock_pa.ts
+++ b/plugin-worldclock/translations/worldclock_pa.ts
@@ -240,7 +240,7 @@
     <message>
         <location filename="../lxqtworldclockconfiguration.cpp" line="106"/>
         <source>&apos;&lt;b&gt;&apos;HH:mm:ss&apos;&lt;/b&gt;&lt;br/&gt;&lt;font size=&quot;-2&quot;&gt;&apos;ddd, d MMM yyyy&apos;&lt;br/&gt;&apos;TT&apos;&lt;/font&gt;&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&apos;&lt;b&gt;&apos;HH:mm:ss&apos;&lt;/b&gt;&lt;br/&gt;&lt;font size=&quot;-2&quot;&gt;&apos;ddd, d MMM yyyy&apos;&lt;br/&gt;&apos;TT&apos;&lt;/font&gt;&apos;</translation>
     </message>
     <message>
         <location filename="../lxqtworldclockconfiguration.cpp" line="584"/>


### PR DESCRIPTION
To avoid removing all existing translations when updating.
 Running `lxqt-transupdate` one translation for worldclock marked as unfinished sneaked in somehow but shoud be harmless.