### PR TITLE
Improved styling of views of Fancy Menu a little

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -35,7 +35,7 @@
 #include <QLineEdit>
 #include <QToolButton>
 #include <QListView>
-
+#include <QPainter>
 #include <QMenu>
 #include <QStandardPaths>
 #include <QDir>
@@ -150,19 +150,21 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     connect(mPowerButton, &QToolButton::clicked, this, &LXQtFancyMenuWindow::runPowerDialog);
 
     mAppView = new QListView;
+    mAppView->setObjectName(QStringLiteral("AppView"));
     mAppView->setSelectionMode(QListView::SingleSelection);
     mAppView->setDragEnabled(true);
     mAppView->setContextMenuPolicy(Qt::CustomContextMenu);
     mAppView->setItemDelegate(new SeparatorDelegate(this));
 
     mCategoryView = new QListView;
+    mCategoryView->setObjectName(QStringLiteral("CategoryView"));
     mCategoryView->setSelectionMode(QListView::SingleSelection);
     mCategoryView->setItemDelegate(new SeparatorDelegate(this));
 
     // Meld category view with whole popup window
-    // So remove the frame and set same background as the window
+    // So remove its frame and do not auto-fill its background
     mCategoryView->setFrameShape(QFrame::NoFrame);
-    mCategoryView->viewport()->setBackgroundRole(QPalette::Window);
+    mCategoryView->viewport()->setAutoFillBackground(false);
 
     mAppMap = new LXQtFancyMenuAppMap;
 
@@ -518,4 +520,13 @@ void LXQtFancyMenuWindow::setFavorites(const QStringList &newFavorites)
     mAppModel->reloadAppMap(false);
     mAppMap->setFavorites(mFavorites);
     mAppModel->reloadAppMap(true);
+}
+
+void LXQtFancyMenuWindow::paintEvent(QPaintEvent *)
+{
+    // enforce the stylesheet background color (if any) on all widget styles
+    QPainter p(this);
+    QStyleOption opt;
+    opt.initFrom(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -89,6 +89,7 @@ public slots:
 protected:
     void hideEvent(QHideEvent *e);
     void keyPressEvent(QKeyEvent *e);
+    void paintEvent(QPaintEvent *e);
 
 private slots:
     void activateCategory(const QModelIndex& idx);


### PR DESCRIPTION
 * `CategoryView` and `AppView` can be styled independently.
 * If you don't add a background for `CategoryView`, it'll have the background of `LXQtFancyMenuWindow` (previously it did only *without* stylesheets).
 * The patch also enforces the stylesheet background color of `LXQtFancyMenuWindow` (if any) on widget styles that try to override it (like Kvantum).