### PR TITLE
Use LXQt menu file by default in Fancy Menu

### DIFF
--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -175,7 +175,7 @@ void LXQtFancyMenu::settingsChanged()
 
     QString menu_file = settings()->value(QStringLiteral("menu_file"), QString()).toString();
     if (menu_file.isEmpty())
-        menu_file = XdgMenu::getMenuFileName();
+        menu_file = XdgMenu::getMenuFileName(LXQtMenuFile);
 
     if (mMenuFile != menu_file)
     {

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -123,7 +123,7 @@ void LXQtFancyMenuConfiguration::loadSettings()
     QString menuFile = settings().value(QStringLiteral("menu_file"), QString()).toString();
     if (menuFile.isEmpty())
     {
-        menuFile = XdgMenu::getMenuFileName();
+        menuFile = XdgMenu::getMenuFileName(LXQtMenuFile);
     }
     ui->menuFilePathLE->setText(menuFile);
     ui->shortcutEd->setText(nullptr != mShortcut ? mShortcut->shortcut() : mDefaultShortcut);

--- a/plugin-fancymenu/lxqtfancymenutypes.h
+++ b/plugin-fancymenu/lxqtfancymenutypes.h
@@ -52,4 +52,6 @@ enum class LXQtFancyMenuItemType
 
 static constexpr const int LXQtFancyMenuItemIsSeparatorRole = Qt::UserRole + 1;
 
+static constexpr const QLatin1String LXQtMenuFile("lxqt-applications.menu");
+
 #endif // LXQTFANCYMENUTYPES_H


### PR DESCRIPTION
Although the base name of the default menu file of `XdgMenu` is `applications.menu` (which may be good for `libqtxdg`), here we should use LXQt menu file by default, not an alien file.