### PR TITLE
Corrected context menu position of Fancy Menu

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -125,6 +125,10 @@ protected:
 LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     : QWidget{parent, Qt::Popup}
 {
+    // Under some Wayland compositors, setting window flags in the c-tor of the base class
+    // may not be enough for a correct positioning of the popup.
+    setWindowFlags(Qt::Popup);
+
     SingleActivateStyle *s = new SingleActivateStyle;
     s->setParent(this);
     setStyle(s);
@@ -350,8 +354,7 @@ void LXQtFancyMenuWindow::onAppViewCustomMenu(const QPoint& p)
         });
     }
 
-    QPoint globalPos = mAppView->mapToGlobal(p);
-    menu.exec(globalPos);
+    menu.exec(mAppView->viewport()->mapToGlobal(p));
 }
 
 void LXQtFancyMenuWindow::setCurrentCategory(int cat)


### PR DESCRIPTION
`QWidget::mapToGlobal` should have been used with the viewport, not with the view itself.

Also, set the window flag explicitly because, although there seems to be no problem under Wayland, we had seen a problem in another plugin when the flags weren't set explicitly.