### PR TITLE
Visible separator for Fancy Menu with all Qt styles

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -95,9 +95,20 @@ protected:
             QRect rect = option.rect;
             if (const QAbstractItemView *view = qobject_cast<const QAbstractItemView*>(option.widget))
                 rect.setWidth(view->viewport()->width());
-            QStyleOption opt;
-            opt.rect = rect;
-            option.widget->style()->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, &opt, painter, option.widget);
+            const int margin = 6;
+            painter->save();
+            painter->setOpacity(0.4);
+            painter->setPen(QPen(Qt::black));
+            painter->drawLine(rect.topLeft().x() + margin ,
+                              rect.topLeft().y(),
+                              rect.topRight().x() - margin,
+                              rect.topRight().y());
+            painter->setPen(QPen(Qt::white));
+            painter->drawLine(rect.topLeft().x() + margin ,
+                              rect.topLeft().y() + 1,
+                              rect.topRight().x() - margin,
+                              rect.topRight().y() + 1);
+            painter->restore();
         }
         else
         {
@@ -110,10 +121,7 @@ protected:
     {
         if (isSeparator(index))
         {
-            int pm = option.widget->style()->pixelMetric(QStyle::PM_DefaultFrameWidth,
-                                                         nullptr,
-                                                         option.widget);
-            return QSize(pm, pm);
+            return QSize(2, 2);
         }
 
         return QStyledItemDelegate::sizeHint(option, index);


### PR DESCRIPTION
There were two problems in how the separators of Fancy Menu were drawn:

 1. Using a toolbar separator resulted in an invisible separator with some Qt styles because there is no guarantee that all Qt styles should draw `PE_IndicatorToolBarSeparator` (some may use a spacing instead);
 2. `PM_DefaultFrameWidth` may only be 1px with some styles, in which case, the separator might not be clearly visible with some LXQt themes (depending on the colors of Qt style).

This patch draws a separator with an opaqueness of 40%, such that it is clearly visible with all LXQt themes and Qt styles but not too bold.