### PR TITLE
Support auto-selection in Fancy Menu

### DIFF
--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -209,6 +209,10 @@ void LXQtFancyMenu::settingsChanged()
     bool categoriesAtRight = settings()->value(QStringLiteral("categoriesAtRight"), true).toBool();
     mWindow->setCategoryPosition(categoriesAtRight ? LXQtFancyMenuCategoryPosition::Right : LXQtFancyMenuCategoryPosition::Left);
 
+    mWindow->setAutoSelection(settings()->value(QStringLiteral("autoSel"), false).toBool());
+    int delay = qBound(50, settings()->value(QStringLiteral("autoSelDelay"), 250).toInt(), 1000);
+    mWindow->setAutoSelectionDelay(delay);
+
     realign();
 }
 

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -81,7 +81,14 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
     connect(ui->shortcutEd->addMenuAction(tr("Reset")), &QAction::triggered, this, &LXQtFancyMenuConfiguration::shortcutReset);
 
     connect(ui->customFontCB, &QAbstractButton::toggled, this, &LXQtFancyMenuConfiguration::customFontChanged);
-    connect(ui->customFontSizeSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &LXQtFancyMenuConfiguration::customFontSizeChanged);
+    connect(ui->customFontSizeSB, QOverload<int>::of(&QSpinBox::valueChanged), this, &LXQtFancyMenuConfiguration::customFontSizeChanged);
+
+    connect(ui->autoSelCB, &QAbstractButton::toggled, this, [this] (bool checked) {
+        this->settings().setValue(QStringLiteral("autoSel"), checked);
+    });
+    connect(ui->autoSelSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+        this->settings().setValue(QStringLiteral("autoSelDelay"), value);
+    });
 
     connect(mShortcut, &GlobalKeyShortcut::Action::shortcutChanged, this, &LXQtFancyMenuConfiguration::globalShortcutChanged);
 
@@ -136,6 +143,9 @@ void LXQtFancyMenuConfiguration::loadSettings()
     lxqtSettings.endGroup();
     ui->customFontSizeSB->setValue(settings().value(QStringLiteral("customFontSize"), systemFont.pointSize()).toInt());
     ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), false).toBool());
+
+    ui->autoSelSB->setValue(settings().value(QStringLiteral("autoSelDelay"), 250).toInt());
+    ui->autoSelCB->setChecked(settings().value(QStringLiteral("autoSel"), false).toBool());
 
     bool buttonsAtTop = settings().value(QStringLiteral("buttonsAtTop"), false).toBool();
     int buttRowPosIdx = ui->buttRowPosCB->findData(buttonsAtTop ? LXQtFancyMenuButtonPosition::Top : LXQtFancyMenuButtonPosition::Bottom);

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.ui
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.ui
@@ -93,6 +93,35 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="autoSelCB">
+        <property name="text">
+         <string>Auto-select after:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="autoSelSB">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="minimum">
+         <number>50</number>
+        </property>
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="singleStep">
+         <number>50</number>
+        </property>
+        <property name="value">
+         <number>250</number>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -290,6 +319,22 @@
     <hint type="destinationlabel">
      <x>431</x>
      <y>53</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>autoSelCB</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>autoSelSB</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>78</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>311</x>
+     <y>132</y>
     </hint>
    </hints>
   </connection>

--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -145,8 +145,8 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     connect(&mSearchTimer, &QTimer::timeout, this, &LXQtFancyMenuWindow::doSearch);
     mSearchTimer.setInterval(350); // typing speed (not very fast)
 
-    mSelTimer.setSingleShot(true);
-    connect(&mSelTimer, &QTimer::timeout, this, &LXQtFancyMenuWindow::autoSelect);
+    mAutoSelTimer.setSingleShot(true);
+    connect(&mAutoSelTimer, &QTimer::timeout, this, &LXQtFancyMenuWindow::autoSelect);
 
     mSearchEdit = new QLineEdit;
     mSearchEdit->setPlaceholderText(tr("Search..."));
@@ -399,10 +399,12 @@ bool LXQtFancyMenuWindow::eventFilter(QObject *watched, QEvent *e)
         }
     }
     else if (mAutoSel
-             && (watched == mCategoryView->viewport() || watched == mAppView->viewport())
-             && e->type() == QEvent::MouseMove)
+             && (watched == mCategoryView->viewport() || watched == mAppView->viewport()))
     {
-        mSelTimer.start();
+        if (e->type() == QEvent::MouseMove)
+            mAutoSelTimer.start();
+        else if (e->type() == QEvent::Leave)
+            mAutoSelTimer.stop();
     }
 
     return QWidget::eventFilter(watched, e);

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -78,6 +78,15 @@ public:
 
     void setCustomFont(const QFont& f);
 
+    void setAutoSelection(bool autoSel) {
+        mAutoSel = autoSel;
+        if (!mAutoSel)
+            mSelTimer.stop();
+    }
+    void setAutoSelectionDelay(int delay) {
+        mSelTimer.setInterval(delay);
+    }
+
 signals:
     void aboutToShow();
     void aboutToHide();
@@ -102,6 +111,8 @@ private slots:
     void runSystemConfigDialog();
 
     void onAppViewCustomMenu(const QPoint &p);
+
+    void autoSelect();
 
 private:
     void runCommandHelper(const QString& cmd);
@@ -131,6 +142,8 @@ private:
     LXQtFancyMenuCategoriesModel *mCategoryModel;
 
     QTimer mSearchTimer;
+    QTimer mSelTimer;
+    bool mAutoSel = false;
     bool mFilterClear = false;
 };
 

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -81,10 +81,10 @@ public:
     void setAutoSelection(bool autoSel) {
         mAutoSel = autoSel;
         if (!mAutoSel)
-            mSelTimer.stop();
+            mAutoSelTimer.stop();
     }
     void setAutoSelectionDelay(int delay) {
-        mSelTimer.setInterval(delay);
+        mAutoSelTimer.setInterval(delay);
     }
 
 signals:
@@ -142,7 +142,7 @@ private:
     LXQtFancyMenuCategoriesModel *mCategoryModel;
 
     QTimer mSearchTimer;
-    QTimer mSelTimer;
+    QTimer mAutoSelTimer;
     bool mAutoSel = false;
     bool mFilterClear = false;
 };


### PR DESCRIPTION
The default is kept to be selection by clicking. The auto-selection delay can be set from 50 to 1000 ms, with its default being 250 ms (like in Qt menus).

Closes https://github.com/lxqt/lxqt-panel/issues/2000