### PR TITLE
Minor GUI cleanup for Fancy Menu

### DIFF
--- a/plugin-fancymenu/lxqtfancymenucategoriesmodel.cpp
+++ b/plugin-fancymenu/lxqtfancymenucategoriesmodel.cpp
@@ -53,7 +53,6 @@ QVariant LXQtFancyMenuCategoriesModel::data(const QModelIndex &idx, int role) co
     switch (role)
     {
     case Qt::DisplayRole:
-    case Qt::ToolTipRole:
         return item.menuTitle;
     case Qt::EditRole:
         return item.menuName;

--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -155,7 +155,7 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     connect(mSearchEdit, &QLineEdit::returnPressed, this, &LXQtFancyMenuWindow::activateCurrentApp);
 
     mSettingsButton = new QToolButton;
-    mSettingsButton->setIcon(XdgIcon::fromTheme(QStringLiteral("preferences-desktop"))); //TODO: preferences-system?
+    mSettingsButton->setIcon(XdgIcon::fromTheme(QStringLiteral("preferences-system")));
     mSettingsButton->setText(tr("LXQt Configuration Center"));
     mSettingsButton->setToolTip(mSettingsButton->text());
     connect(mSettingsButton, &QToolButton::clicked, this, &LXQtFancyMenuWindow::runSystemConfigDialog);
@@ -165,6 +165,12 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     mPowerButton->setText(tr("Leave"));
     mPowerButton->setToolTip(mPowerButton->text());
     connect(mPowerButton, &QToolButton::clicked, this, &LXQtFancyMenuWindow::runPowerDialog);
+
+    mAboutButton = new QToolButton;
+    mAboutButton->setIcon(XdgIcon::fromTheme(QStringLiteral("lxqt-about")));
+    mAboutButton->setText(tr("About LXQt"));
+    mAboutButton->setToolTip(mAboutButton->text());
+    connect(mAboutButton, &QToolButton::clicked, this, &LXQtFancyMenuWindow::runAboutgDialog);
 
     mAppView = new QListView;
     mAppView->setObjectName(QStringLiteral("AppView"));
@@ -207,6 +213,7 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     mMainLayout->addLayout(mViewLayout);
 
     mButtonsLayout = new QHBoxLayout;
+    mButtonsLayout->addWidget(mAboutButton);
     mButtonsLayout->addStretch();
     mButtonsLayout->addWidget(mSettingsButton);
     mButtonsLayout->addWidget(mPowerButton);
@@ -293,6 +300,11 @@ void LXQtFancyMenuWindow::runPowerDialog()
 void LXQtFancyMenuWindow::runSystemConfigDialog()
 {
     runCommandHelper(QLatin1String("lxqt-config"));
+}
+
+void LXQtFancyMenuWindow::runAboutgDialog()
+{
+    runCommandHelper(QLatin1String("lxqt-about"));
 }
 
 void LXQtFancyMenuWindow::onAppViewCustomMenu(const QPoint& p)
@@ -602,6 +614,7 @@ void LXQtFancyMenuWindow::updateButtonIconSize()
     const QSize iconSize(sz, sz);
     mSettingsButton->setIconSize(iconSize);
     mPowerButton->setIconSize(iconSize);
+    mAboutButton->setIconSize(iconSize);
 }
 
 void LXQtFancyMenuWindow::setSearchEditFocus()

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -109,6 +109,7 @@ private slots:
 
     void runPowerDialog();
     void runSystemConfigDialog();
+    void runAboutgDialog();
 
     void onAppViewCustomMenu(const QPoint &p);
 
@@ -133,6 +134,7 @@ private:
 
     QToolButton *mSettingsButton;
     QToolButton *mPowerButton;
+    QToolButton *mAboutButton;
     QLineEdit *mSearchEdit;
     QListView *mAppView;
     QListView *mCategoryView;


### PR DESCRIPTION
 1. Tooltips of categories are removed because they were the same as displayed names and only disruptive.
 2. The icon of config center button is corrected (its text was already corrected by @@stefonarch in https://github.com/lxqt/lxqt-panel/commit/ed50e7a9242509a298afffae77d4ed78547261b5).
 3. About button is added.