### PR TITLE
FancyMenu: share code with MainMenu

### DIFF
--- a/plugin-fancymenu/CMakeLists.txt
+++ b/plugin-fancymenu/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADERS
     lxqtfancymenuappmap.h
     lxqtfancymenuappmodel.h
     lxqtfancymenucategoriesmodel.h
+    lxqtfancymenushortcututils.h
     lxqtfancymenutypes.h
 )
 
@@ -17,6 +18,7 @@ set(SOURCES
     lxqtfancymenuappmap.cpp
     lxqtfancymenuappmodel.cpp
     lxqtfancymenucategoriesmodel.cpp
+    lxqtfancymenushortcututils.cpp
 )
 
 set(UIS

--- a/plugin-fancymenu/CMakeLists.txt
+++ b/plugin-fancymenu/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADERS
     lxqtfancymenuappmap.h
     lxqtfancymenuappmodel.h
     lxqtfancymenucategoriesmodel.h
+    lxqtfancymenucontextmenuutils.h
     lxqtfancymenushortcututils.h
     lxqtfancymenutypes.h
 )
@@ -18,6 +19,7 @@ set(SOURCES
     lxqtfancymenuappmap.cpp
     lxqtfancymenuappmodel.cpp
     lxqtfancymenucategoriesmodel.cpp
+    lxqtfancymenucontextmenuutils.cpp
     lxqtfancymenushortcututils.cpp
 )
 

--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -37,8 +37,6 @@
 #include <QResizeEvent>
 #include <lxqt-globalkeys.h>
 #include <QApplication>
-#include <QMetaEnum>
-#include <QStringBuilder>
 
 #include <XdgMenuWidget>
 #include <XdgIcon>
@@ -49,6 +47,8 @@
 #include <XdgAction>
 
 #include <QDir>
+
+#include "lxqtfancymenushortcututils.h"
 
 #define DEFAULT_SHORTCUT "Alt+F1"
 
@@ -339,28 +339,8 @@ bool LXQtFancyMenu::eventFilter(QObject *obj, QEvent *event)
     {
         if(event->type() == QEvent::KeyRelease)
         {
-            static const auto key_meta = QMetaEnum::fromType<Qt::Key>();
-            // if our shortcut key is pressed while the menu is open, close the menu
-            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-            QFlags<Qt::KeyboardModifier> mod = keyEvent->modifiers();
-            switch (keyEvent->key())
-            {
-            case Qt::Key_Alt:
-                mod &= ~Qt::AltModifier;
-                break;
-            case Qt::Key_Control:
-                mod &= ~Qt::ControlModifier;
-                break;
-            case Qt::Key_Shift:
-                mod &= ~Qt::ShiftModifier;
-                break;
-            case Qt::Key_Super_L:
-            case Qt::Key_Super_R:
-                mod &= ~Qt::MetaModifier;
-                break;
-            }
-            const QString press = QKeySequence{static_cast<int>(mod)}.toString() % QString::fromLatin1(key_meta.valueToKey(keyEvent->key())).remove(0, 4);
-            if (press == mShortcutSeq)
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if (LXQtFancyMenuShortcutUtils::match(keyEvent, mShortcutSeq))
             {
                 //TODO: isn't timer already fired by hide() ???
                 mHideTimer.start();

--- a/plugin-fancymenu/lxqtfancymenucontextmenuutils.cpp
+++ b/plugin-fancymenu/lxqtfancymenucontextmenuutils.cpp
@@ -1,0 +1,85 @@
+#include "lxqtfancymenucontextmenuutils.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QMimeData>
+#include <QUrl>
+
+#include <QMenu>
+
+#include <QMessageBox>
+
+#include <QFile>
+#include <QStandardPaths>
+#include <XdgIcon>
+#include <XdgDesktopFile>
+
+class LXQtFancyMenuContextMenuStrings
+{
+public:
+    Q_DECLARE_TR_FUNCTIONS(LXQtFancyMenuContextMenuStrings)
+};
+
+void LXQtFancyMenuContextMenuUtils::buildContextMenu(QMenu *menu,
+                                                     QWidget *window,
+                                                     const XdgDesktopFile& desktopFile)
+{
+    QString file = desktopFile.fileName();
+
+    QAction *a = nullptr;
+
+    if (desktopFile.actions().count() > 0 && desktopFile.type() == XdgDesktopFile::Type::ApplicationType)
+    {
+        for (int i = 0; i < desktopFile.actions().count(); ++i)
+        {
+            QString actionString(desktopFile.actions().at(i));
+            a = menu->addAction(desktopFile.actionIcon(actionString),
+                                desktopFile.actionName(actionString));
+
+            QObject::connect(a, &QAction::triggered, window,
+                             [window, desktopFile, actionString]
+                             {
+                                 desktopFile.actionActivate(actionString, QStringList());
+                                 window->hide();
+                             });
+        }
+        menu->addSeparator();
+    }
+
+    a = menu->addAction(XdgIcon::fromTheme(QLatin1String("desktop")), LXQtFancyMenuContextMenuStrings::tr("Add to desktop"));
+    QObject::connect(a, &QAction::triggered, window,
+                     [file, window]
+                     {
+                         QString desktop = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+                         QString destinationFile = desktop + QStringLiteral("/") + file.section(QStringLiteral("/"), -1);
+                         if (QFile::exists(destinationFile))
+                         {
+                             QMessageBox::StandardButton btn =
+                                 QMessageBox::question(window,
+                                                       LXQtFancyMenuContextMenuStrings::tr("Question"),
+                                                       LXQtFancyMenuContextMenuStrings::tr("A file with the same name already exists.\n"
+                                                                                           "Do you want to overwrite it?"));
+                             if (btn == QMessageBox::No)
+                                 return;
+
+                             if (!QFile::remove(destinationFile))
+                             {
+                                 QMessageBox::warning(window,
+                                                      LXQtFancyMenuContextMenuStrings::tr("Warning"),
+                                                      LXQtFancyMenuContextMenuStrings::tr("The file cannot be overwritten."));
+                                 return;
+                             }
+                         }
+                         QFile::copy(file, destinationFile);
+                     });
+
+    a = menu->addAction(XdgIcon::fromTheme(QLatin1String("edit-copy")), LXQtFancyMenuContextMenuStrings::tr("Copy"));
+    QObject::connect(a, &QAction::triggered, window,
+                     [file]
+                     {
+                         QClipboard* clipboard = QApplication::clipboard();
+                         QMimeData* data = new QMimeData();
+                         data->setUrls({QUrl::fromLocalFile(file)});
+                         clipboard->setMimeData(data);
+                     });
+}

--- a/plugin-fancymenu/lxqtfancymenucontextmenuutils.h
+++ b/plugin-fancymenu/lxqtfancymenucontextmenuutils.h
@@ -1,0 +1,16 @@
+#ifndef LXQTFANCYMENUCONTEXTMENUUTILS_H
+#define LXQTFANCYMENUCONTEXTMENUUTILS_H
+
+class QWidget;
+class QMenu;
+class XdgDesktopFile;
+
+class LXQtFancyMenuContextMenuUtils
+{
+public:
+    static void buildContextMenu(QMenu *menu,
+                                 QWidget *window,
+                                 const XdgDesktopFile &desktopFile);
+};
+
+#endif // LXQTFANCYMENUCONTEXTMENUUTILS_H

--- a/plugin-fancymenu/lxqtfancymenushortcututils.cpp
+++ b/plugin-fancymenu/lxqtfancymenushortcututils.cpp
@@ -1,0 +1,32 @@
+#include "lxqtfancymenushortcututils.h"
+
+#include <QKeyEvent>
+#include <QMetaEnum>
+
+bool LXQtFancyMenuShortcutUtils::match(QKeyEvent *event, const QString &sequence)
+{
+    //TODO: check if still needed or at least document this hack
+
+    static const auto key_meta = QMetaEnum::fromType<Qt::Key>();
+    // if our shortcut key is pressed while the menu is open, close the menu
+    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+    QFlags<Qt::KeyboardModifier> mod = keyEvent->modifiers();
+    switch (keyEvent->key())
+    {
+    case Qt::Key_Alt:
+        mod &= ~Qt::AltModifier;
+        break;
+    case Qt::Key_Control:
+        mod &= ~Qt::ControlModifier;
+        break;
+    case Qt::Key_Shift:
+        mod &= ~Qt::ShiftModifier;
+        break;
+    case Qt::Key_Super_L:
+    case Qt::Key_Super_R:
+        mod &= ~Qt::MetaModifier;
+        break;
+    }
+    const QString press = QKeySequence{static_cast<int>(mod)}.toString() % QString::fromLatin1(key_meta.valueToKey(keyEvent->key())).remove(0, 4);
+    return press == sequence;
+}

--- a/plugin-fancymenu/lxqtfancymenushortcututils.h
+++ b/plugin-fancymenu/lxqtfancymenushortcututils.h
@@ -1,0 +1,13 @@
+#ifndef LXQTFANCYMENUSHORTCUTUTILS_H
+#define LXQTFANCYMENUSHORTCUTUTILS_H
+
+class QString;
+class QKeyEvent;
+
+class LXQtFancyMenuShortcutUtils
+{
+public:
+    static bool match(QKeyEvent *event, const QString& sequence);
+};
+
+#endif // LXQTFANCYMENUSHORTCUTUTILS_H

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -41,8 +41,8 @@
 #include <lxqt-globalkeys.h>
 #include <algorithm> // for find_if()
 #include <QApplication>
-#include <QMetaEnum>
-#include <QStringBuilder>
+
+#include "../plugin-fancymenu/lxqtfancymenushortcututils.h"
 
 #include <XdgMenuWidget>
 #include <XdgIcon>
@@ -645,27 +645,8 @@ bool LXQtMainMenu::eventFilter(QObject *obj, QEvent *event)
     {
         if(event->type() == QEvent::KeyRelease)
         {
-            static const auto key_meta = QMetaEnum::fromType<Qt::Key>();
-            // if our shortcut key is pressed while the menu is open, close the menu
-            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-            QFlags<Qt::KeyboardModifier> mod = keyEvent->modifiers();
-            switch (keyEvent->key()) {
-                case Qt::Key_Alt:
-                    mod &= ~Qt::AltModifier;
-                    break;
-                case Qt::Key_Control:
-                    mod &= ~Qt::ControlModifier;
-                    break;
-                case Qt::Key_Shift:
-                    mod &= ~Qt::ShiftModifier;
-                    break;
-                case Qt::Key_Super_L:
-                case Qt::Key_Super_R:
-                    mod &= ~Qt::MetaModifier;
-                    break;
-            }
-            const QString press = QKeySequence{static_cast<int>(mod)}.toString() % QString::fromLatin1(key_meta.valueToKey(keyEvent->key())).remove(0, 4);
-            if (press == mShortcutSeq)
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if(LXQtFancyMenuShortcutUtils::match(keyEvent, mShortcutSeq))
             {
                 mHideTimer.start();
                 mMenu->hide(); // close the app menu

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -126,7 +126,7 @@ private slots:
     void showHideMenu();
     void searchMenu();
     void setSearchFocus(QAction *action);
-    void onRequestingCustomMenu(const QPoint& p);
+    void onRequestingCustomMenu(const QPoint& pos);
 };
 
 class LXQtMainMenuPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
This PR aims at sharing common code between the 2 menu implementations.
The common code is not much but sharing makes it possible to keep behavior consistent with less effort I think.

TODO:
1. where to put common files?
2. Is the shortcut hack still needed? Can it at least be documented better, maybe linking Qt BUGs etc?
3. Some includes are not needed anymore so I removed them and reordered based on their function. Still better job could be done here.