### PR TITLE
Set size policy in plugin-backlight and plugin-colorpicker

### DIFF
--- a/plugin-backlight/backlight.cpp
+++ b/plugin-backlight/backlight.cpp
@@ -34,6 +34,7 @@ LXQtBacklight::LXQtBacklight(const ILXQtPanelPluginStartupInfo &startupInfo):
     m_backlightButton = new QToolButton();
     // use our own icon
     m_backlightButton->setIcon(QIcon::fromTheme(QStringLiteral("brightnesssettings")));
+    m_backlightButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(m_backlightButton, &QToolButton::clicked, this, &LXQtBacklight::showSlider);
 

--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -80,7 +80,7 @@ void ColorPicker::realign()
 
 ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent)
 {
-    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     mSeparator = new QFrame();
     mSeparator->setFrameShape(QFrame::VLine);
@@ -93,12 +93,14 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent)
     mPickerButton->setAccessibleName(mPickerButton->objectName());
     mPickerButton->setAutoRaise(true);
     mPickerButton->setIcon(QIcon::fromTheme(QLatin1String("color-picker"), QIcon::fromTheme(QLatin1String("color-select-symbolic"))));
+    mPickerButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     mColorButton = new ColorButton();
     mColorButton->setObjectName(QStringLiteral("ColorPickerColorButton"));
     mColorButton->setAccessibleName(mColorButton->objectName());
     mColorButton->setAutoRaise(true);
     mColorButton->setStyleSheet(QStringLiteral("::menu-indicator{ image: none; }"));
+    mColorButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     QBoxLayout *layout = new QBoxLayout(QBoxLayout::LeftToRight);
     layout->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
Fixes an inconsistency in themes when they expect an expanding size policy, which is what most plugins have set. Some themes with incorrect styling due to this: KDE-Plasma, Ambiance, Kvantum.