### PR TITLE
Fix plugin loader (#2052)

### DIFF
--- a/panel/CMakeLists.txt
+++ b/panel/CMakeLists.txt
@@ -91,6 +91,8 @@ lxqt_translate_ts(QM_FILES SOURCES
 
 lxqt_app_translation_loader(SOURCES ${PROJECT_NAME})
 
+set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)
+
 add_executable(${PROJECT}
     ${PUB_HEADERS}
     ${PRIV_HEADERS}


### PR DESCRIPTION
The lxqt-plugin binary needs to export symbols that should be visible to plugins being loaded with QPluginLoader or dlopen.

Fixes https://github.com/lxqt/lxqt-panel/issues/2052