### PR TITLE
Workaround for mount plugin with a GLib-mounted encrypted volume

### DIFF
--- a/plugin-mount/menudiskitem.cpp
+++ b/plugin-mount/menudiskitem.cpp
@@ -80,9 +80,12 @@ MenuDiskItem::MenuDiskItem(Solid::Device device, Popup *popup):
 
 MenuDiskItem::~MenuDiskItem() = default;
 
-void MenuDiskItem::setMountStatus(bool mounted)
+void MenuDiskItem::setMountStatus()
 {
-    mEjectButton->setEnabled(mounted);
+    if (mDevice.isValid())
+    {
+        mEjectButton->setEnabled(mDevice.as<Solid::StorageAccess>()->isAccessible() || !opticalParent().udi().isEmpty());
+    }
 }
 
 void MenuDiskItem::updateMountStatus()
@@ -96,7 +99,7 @@ void MenuDiskItem::updateMountStatus()
         mDiskButton->setIcon(icon);
         mDiskButton->setText(mDevice.description());
 
-        setMountStatus(mDevice.as<Solid::StorageAccess>()->isAccessible() || !opticalParent().udi().isEmpty());
+        setMountStatus();
     }
     else
         emit invalid(mDevice.udi());

--- a/plugin-mount/menudiskitem.h
+++ b/plugin-mount/menudiskitem.h
@@ -44,7 +44,7 @@ public:
     ~MenuDiskItem();
 
     QString deviceUdi() const { return mDevice.udi(); }
-    void setMountStatus(bool mounted);
+    void setMountStatus();
 
 private:
     void updateMountStatus();

--- a/plugin-mount/popup.cpp
+++ b/plugin-mount/popup.cpp
@@ -137,6 +137,20 @@ void Popup::onDeviceRemoved(QString const & udi)
 
 void Popup::showEvent(QShowEvent *event)
 {
+    // NOTE: This is a workaround for the lack of "Solid::StorageAccess::accessibilityChanged"
+    // when an encrypted volume is mounted by GLib/GIO.
+    const int size = layout()->count() - 1;
+    for (int i = size; 0 <= i; --i)
+    {
+        QWidget *w = layout()->itemAt(i)->widget();
+        if (w == mPlaceholder)
+            continue;
+        if (MenuDiskItem *it = static_cast<MenuDiskItem *>(w))
+        {
+            it->setMountStatus();
+        }
+    }
+
     mPlaceholder->setVisible(mDisplayCount == 0);
     realign();
     setFocus();


### PR DESCRIPTION
`Solid::StorageAccess::accessibilityChanged` isn't emitted when an encrypted volume is mounted by GLib/GIO (e.g., through pcmanfm-qt). This is a workaround.

Closes https://github.com/lxqt/lxqt-panel/issues/1639