### PR TITLE
plugin-desktopswitch: Don't use DesktopSwitchButton::LabelType invali…

### DIFF
--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -58,7 +58,7 @@ DesktopSwitch::DesktopSwitch(const ILXQtPanelPluginStartupInfo &startupInfo) :
     mRows(-1),
     mShowOnlyActive(false),
     mDesktops(nullptr),
-    mLabelType(static_cast<DesktopSwitchButton::LabelType>(-1))
+    mLabelType(DesktopSwitchButton::LABEL_TYPE_INVALID)
 {
     auto *x11Application = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
     Q_ASSERT_X(x11Application, "DesktopSwitch", "Expected X11 connection");

--- a/plugin-desktopswitch/desktopswitchbutton.h
+++ b/plugin-desktopswitch/desktopswitchbutton.h
@@ -43,6 +43,7 @@ class DesktopSwitchButton : public QToolButton
 
 public:
     enum LabelType { // Must match with combobox indexes
+        LABEL_TYPE_INVALID = -1,
         LABEL_TYPE_NUMBER = 0,
         LABEL_TYPE_NAME = 1,
         LABEL_TYPE_NONE = 2


### PR DESCRIPTION
…d value

Stops undefined behavior.
Reference:
enum foo { a = 0, b = UINT_MAX }; // range: [0, UINT_MAX] foo x = foo(-1); // undefined behavior since CWG 1766,
                 // even if foo's underlying type is unsigned int