### PR TITLE
Made horizontal wheel scrolling work with Custom Command

### DIFF
--- a/plugin-customcommand/custombutton.cpp
+++ b/plugin-customcommand/custombutton.cpp
@@ -76,8 +76,10 @@ CustomButton::~CustomButton() = default;
 
 void CustomButton::wheelEvent(QWheelEvent *event)
 {
-    int y = event->angleDelta().y();
-    emit wheelScrolled(y);
+    QPoint anglePoint = event->angleDelta();
+    bool horizontal(qAbs(event->angleDelta().x()) > qAbs(anglePoint.y()));
+    int delta = horizontal ? anglePoint.x() : anglePoint.y();
+    emit wheelScrolled(delta);
     event->accept();
 }
 

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -214,11 +214,11 @@ void LXQtCustomCommand::updateButton() {
     mButton->updateWidth();
 }
 
-void LXQtCustomCommand::handleWheelScrolled(int yDelta)
+void LXQtCustomCommand::handleWheelScrolled(int delta)
 {
-    if (yDelta > 0 && !mWheelUp.isEmpty())
+    if (delta > 0 && !mWheelUp.isEmpty())
         runDetached(mWheelUp);
-    else if (yDelta < 0 && !mWheelDown.isEmpty())
+    else if (delta < 0 && !mWheelDown.isEmpty())
         runDetached(mWheelDown);
 }
 

--- a/plugin-customcommand/lxqtcustomcommand.h
+++ b/plugin-customcommand/lxqtcustomcommand.h
@@ -56,7 +56,7 @@ protected slots:
 private slots:
     void handleClick();
     void handleFinished(int exitCode, QProcess::ExitStatus exitStatus);
-    void handleWheelScrolled(int yDelta);
+    void handleWheelScrolled(int delta);
     void updateButton();
     void runCommand();
     void runDetached(QString command);


### PR DESCRIPTION
Previously, only the vertical wheel scrolling worked, which might not be ideal with a touchpad.

A confession: My concern wasn't the touchpad ;) I made this patch as a workaround for a regression about Wayland, because of which, Qt's vertical and horizontal wheel events are swapped under special circumstances. However, the end result is independent of that regression.