### PR TITLE
Added a missing header

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -33,6 +33,7 @@
 #include <QIcon>
 #include <QTime>
 #include <QScreen>
+#include <QGuiApplication>
 
 auto findWindow(const std::vector<std::unique_ptr<LXQtTaskBarPlasmaWindow>>& windows, LXQtTaskBarPlasmaWindow *window)
 {

--- a/panel/resources/panel.conf
+++ b/panel/resources/panel.conf
@@ -1,8 +1,5 @@
 panels=panel1
 
-[General]
-preferred_backend=KDE:kwin_wayland,KWIN:kwin_wayland
-
 [panel1]
 plugins=fancymenu,desktopswitch,quicklaunch,taskbar,statusnotifier,tray,mount,volume,worldclock,showdesktop
 position=Bottom


### PR DESCRIPTION
Found by @stefonarch. Fixes https://github.com/lxqt/lxqt-panel/issues/2089

Also removed `preferred_backend` from the shipped config file to remain neutral.