### PR TITLE
Fixed issues in wlroots task buttons

### DIFF
--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
@@ -262,6 +262,7 @@ void LXQtTaskbarWlrootsWindowManagment::zwlr_foreign_toplevel_manager_v1_topleve
 
 LXQtTaskbarWlrootsWindow::LXQtTaskbarWlrootsWindow(::zwlr_foreign_toplevel_handle_v1 *id) : zwlr_foreign_toplevel_handle_v1(id)
 {
+    ID = id;
 }
 
 
@@ -379,9 +380,16 @@ void LXQtTaskbarWlrootsWindow::zwlr_foreign_toplevel_handle_v1_done()
      */
 
     // (1) title, if it changed
+    bool checkActivation;
     if (m_pendingState.titleChanged)
     {
         windowState.title = m_pendingState.title;
+        // prevent deactivation on title change
+        checkActivation = m_pendingState.activatedChanged;
+    }
+    else
+    {
+        checkActivation = true;
     }
 
     // (2) appId, if it changed
@@ -423,7 +431,7 @@ void LXQtTaskbarWlrootsWindow::zwlr_foreign_toplevel_handle_v1_done()
         m_pendingState.minimizedChanged = true;
     }
 
-    if (m_pendingState.activated != windowState.activated)
+    if (checkActivation && m_pendingState.activated != windowState.activated)
     {
         windowState.activated           = m_pendingState.activated;
         m_pendingState.activatedChanged = true;

--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
@@ -89,6 +89,7 @@ public:
     QIcon icon;
     WindowProperties windowState;
     WId parentWindow = 0;
+    ::zwlr_foreign_toplevel_handle_v1 *ID = nullptr;
 
 Q_SIGNALS:
     void titleChanged();

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -75,6 +75,9 @@ public:
 private:
     void addWindow(WId wid);
     bool acceptWindow(WId wid) const;
+    WId findWindow(WId tgt) const;
+    WId findTopParent(WId winId) const;
+    bool equalIds(WId windowId1, WId windowId2) const;
 
 private:
     /** Convert WId (i.e. quintptr into LXQtTaskbarWlrootsWindow*) */


### PR DESCRIPTION
This PR fixes the parent-child problem (multiple task buttons for a window and its child dialogs) as well as the deactivation of task button on title change (e.g., because of a tab switch in pcmanfm-qt).

Closes https://github.com/lxqt/lxqt-panel/issues/2097

EDIT: There are still minor issues (maybe two), which I'll investigate separately.