### PR TITLE
Fixed issues in wlroots task buttons

### DIFF
--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
@@ -89,6 +89,7 @@ public:
     QIcon icon;
     WindowProperties windowState;
     WId parentWindow = 0;
+    ::zwlr_foreign_toplevel_handle_v1 *ID = nullptr;
 
 Q_SIGNALS:
     void titleChanged();

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -72,11 +72,23 @@ public:
     virtual bool isShowingDesktop() const override;
     virtual bool showDesktop(bool value) override;
 
-private:
+private slots:
     void addWindow(WId wid);
-    bool acceptWindow(WId wid) const;
+    void removeWindow();
+    void removeTransient();
+    void onActivatedChanged();
+    void onParentChanged();
+    void onTitleChanged();
+    void onAppIdChanged();
+    void onStateChanged();
 
 private:
+    void addToWindows(WId winId);
+    bool acceptWindow(WId wid) const;
+    WId findWindow(WId tgt) const;
+    WId findTopParent(WId winId) const;
+    bool equalIds(WId windowId1, WId windowId2) const;
+
     /** Convert WId (i.e. quintptr into LXQtTaskbarWlrootsWindow*) */
     LXQtTaskbarWlrootsWindow *getWindow(WId windowId) const;
 


### PR DESCRIPTION
This PR fixes the following problems:

 * Multiple task buttons for a window and its child dialogs;
 * Deactivation of task button on title change (e.g., because of a tab switch in pcmanfm-qt); and
 * Deactivation of task button under other circumstances, like when dropdown QTerminal is shown.

It also fixes some logical issues in handling of parent changes, but I couldn't find a real world example for that.

Closes https://github.com/lxqt/lxqt-panel/issues/2097