### PR TITLE
Default values for new widgets

### DIFF
--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -200,7 +200,7 @@ void LXQtFancyMenu::settingsChanged()
     setMenuFontSize();
 
     //clear the search to not leaving the menu in wrong state
-    mFilterClear = settings()->value(QStringLiteral("filterClear"), false).toBool();
+    mFilterClear = settings()->value(QStringLiteral("filterClear"), true).toBool();
     mWindow->setFilterClear(mFilterClear);
 
     bool buttonsAtTop = settings()->value(QStringLiteral("buttonsAtTop"), false).toBool();

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -142,7 +142,7 @@ void LXQtFancyMenuConfiguration::loadSettings()
     systemFont.fromString(lxqtSettings.value(QStringLiteral("font"), this->font()).toString());
     lxqtSettings.endGroup();
     ui->customFontSizeSB->setValue(settings().value(QStringLiteral("customFontSize"), systemFont.pointSize()).toInt());
-    ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), false).toBool());
+    ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), true).toBool());
 
     ui->autoSelSB->setValue(settings().value(QStringLiteral("autoSelDelay"), 250).toInt());
     ui->autoSelCB->setChecked(settings().value(QStringLiteral("autoSel"), false).toBool());

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -62,7 +62,7 @@ LXQtTaskBar::LXQtTaskBar(ILXQtPanelPlugin *plugin, QWidget *parent) :
     QFrame(parent),
     mSignalMapper(new QSignalMapper(this)),
     mButtonStyle(Qt::ToolButtonTextBesideIcon),
-    mButtonWidth(400),
+    mButtonWidth(220),
     mButtonHeight(100),
     mCloseOnMiddleClick(true),
     mRaiseOnCurrentDesktop(true),
@@ -423,7 +423,7 @@ void LXQtTaskBar::settingsChanged()
     bool showOnlyMinimizedTasksOld = mShowOnlyMinimizedTasks;
     const bool iconByClassOld = mIconByClass;
 
-    mButtonWidth = mPlugin->settings()->value(QStringLiteral("buttonWidth"), 400).toInt();
+    mButtonWidth = mPlugin->settings()->value(QStringLiteral("buttonWidth"), 220).toInt();
     mButtonHeight = mPlugin->settings()->value(QStringLiteral("buttonHeight"), 100).toInt();
     QString s = mPlugin->settings()->value(QStringLiteral("buttonStyle")).toString().toUpper();
 

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -107,7 +107,7 @@ void LXQtTaskbarConfiguration::loadSettings()
     ui->middleClickCB->setChecked(settings().value(QStringLiteral("closeOnMiddleClick"), true).toBool());
     ui->raiseOnCurrentDesktopCB->setChecked(settings().value(QStringLiteral("raiseOnCurrentDesktop"), false).toBool());
     ui->buttonStyleCB->setCurrentIndex(ui->buttonStyleCB->findData(settings().value(QStringLiteral("buttonStyle"), QLatin1String("IconText"))));
-    ui->buttonWidthSB->setValue(settings().value(QStringLiteral("buttonWidth"), 400).toInt());
+    ui->buttonWidthSB->setValue(settings().value(QStringLiteral("buttonWidth"), 220).toInt());
     ui->buttonHeightSB->setValue(settings().value(QStringLiteral("buttonHeight"), 100).toInt());
     ui->groupingGB->setChecked(settings().value(QStringLiteral("groupingEnabled"),true).toBool());
     ui->showGroupOnHoverCB->setChecked(settings().value(QStringLiteral("showGroupOnHover"),true).toBool());


### PR DESCRIPTION
When adding a plugin in  a new panel default settings as in `panel.conf` are applied.
* Fancy Menu: search was not cleared 
* Taskbar: when adding a taskbar to a new empty panel with some windows open there was no space left to right click panel settings.