### PR TITLE
Improve plugin-directorymenu icons (replace two generic icons)

### DIFF
--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -123,11 +123,11 @@ void DirectoryMenu::addActions(QMenu* menu, const QString& path)
 {
     mPathStrings.push_back(path);
 
-    QAction* openDirectoryAction = menu->addAction(XdgIcon::fromTheme(QStringLiteral("folder")), tr("Open"));
+    QAction* openDirectoryAction = menu->addAction(XdgIcon::fromTheme(QStringLiteral("document-open")), tr("Open"));
     connect(openDirectoryAction, &QAction::triggered, mOpenDirectorySignalMapper, [this] { mOpenDirectorySignalMapper->map(); } );
     mOpenDirectorySignalMapper->setMapping(openDirectoryAction, mPathStrings.back());
 
-    QAction* openTerminalAction = menu->addAction(XdgIcon::fromTheme(QStringLiteral("folder")), tr("Open in terminal"));
+    QAction* openTerminalAction = menu->addAction(XdgIcon::fromTheme(QStringLiteral("utilities-terminal")), tr("Open in terminal"));
     connect(openTerminalAction, &QAction::triggered, mOpenTerminalSignalMapper, [this] { mOpenTerminalSignalMapper->map(); } );
     mOpenTerminalSignalMapper->setMapping(openTerminalAction, mPathStrings.back());
 


### PR DESCRIPTION
Directory Menu's menu consists of:

- Open
- Open in terminal
- Directories [...]

Currently all icons were `folder`; this PR changes "Open" to `document-open` and "Open in terminal" to `utilities-terminal`. These icons are used in libfm-qt, for instance.

Screenshot (MATE icon theme):
![directory_menu](https://github.com/user-attachments/assets/34b90e19-0aa6-4caa-835b-32721beb5838)
