### PR TITLE
Optionally disable move-to-layer and move-to-output

### DIFF
--- a/panel/backends/lxqttaskbartypes.h
+++ b/panel/backends/lxqttaskbartypes.h
@@ -43,7 +43,9 @@ enum class LXQtTaskBarBackendAction
     Minimize,
     RollUp,
     FullScreen,
-    DesktopSwitch
+    DesktopSwitch,
+    MoveToLayer,
+    MoveToOutput
 };
 
 enum class LXQtTaskBarWindowProperty

--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -123,6 +123,15 @@ bool LXQtWMBackend_KWinWayland::supportsAction(WId windowId, LXQtTaskBarBackendA
         state = LXQtTaskBarPlasmaWindow::state::state_fullscreenable;
         break;
 
+    case LXQtTaskBarBackendAction::DesktopSwitch:
+        return true;
+
+    case LXQtTaskBarBackendAction::MoveToLayer:
+        return true;
+
+    case LXQtTaskBarBackendAction::MoveToOutput:
+        return true;
+
     default:
         return false;
     }

--- a/panel/backends/xcb/lxqtwmbackend_x11.cpp
+++ b/panel/backends/xcb/lxqtwmbackend_x11.cpp
@@ -241,6 +241,12 @@ bool LXQtWMBackendX11::supportsAction(WId windowId, LXQtTaskBarBackendAction act
     case LXQtTaskBarBackendAction::DesktopSwitch:
         return true;
 
+    case LXQtTaskBarBackendAction::MoveToLayer:
+        return true;
+
+    case LXQtTaskBarBackendAction::MoveToOutput:
+        return true;
+
     default:
         return false;
     }

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -609,11 +609,13 @@ void LXQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     {
         menu->addSeparator();
         a = menu->addAction(tr("Move To N&ext Monitor"));
+        a->setEnabled(mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::MoveToOutput));
         connect(a, &QAction::triggered, this, [this] { moveApplicationToPrevNextMonitor(true); });
         a->setEnabled(mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::Move) &&
                       (state != LXQtTaskBarWindowState::FullScreen
                        || ((state == LXQtTaskBarWindowState::FullScreen) && mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::FullScreen))));
         a = menu->addAction(tr("Move To &Previous Monitor"));
+        a->setEnabled(mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::MoveToOutput));
         connect(a, &QAction::triggered, this, [this] { moveApplicationToPrevNextMonitor(false); });
     }
 
@@ -690,6 +692,7 @@ void LXQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     menu->addSeparator();
 
     QMenu* layerMenu = menu->addMenu(tr("&Layer"));
+    layerMenu->setEnabled(mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::MoveToLayer));
 
     LXQtTaskBarWindowLayer currentLayer = mBackend->getWindowLayer(mWindow);
 


### PR DESCRIPTION
I have added two options, `MoveToLayer` and `MoveToOutput` options to `enum class LXQtTaskBarBackendAction` and made suitable changes to `plugin-taskbar/lxqttaskbutton.cpp`. Additionally, I have made changes to XCB and KWin plugins. On wlroots, the `Move to Layer` and `Move to Output` should be greyed out.