### PR TITLE
Fixed the urgent hint of desktop switcher

### DIFF
--- a/panel/backends/xcb/lxqtwmbackend_x11.cpp
+++ b/panel/backends/xcb/lxqtwmbackend_x11.cpp
@@ -95,7 +95,7 @@ void LXQtWMBackendX11::onWindowChanged(WId windowId, NET::Properties prop, NET::
     }
 
     // window changed virtual desktop
-    if (prop.testFlag(NET::WMDesktop) || prop.testFlag(NET::WMGeometry))
+    if (prop.testFlag(NET::WMDesktop))
     {
         emit windowPropertyChanged(windowId, int(LXQtTaskBarWindowProperty::Workspace));
     }

--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -97,6 +97,7 @@ private slots:
     void registerShortcuts();
     void shortcutRegistered();
     void onWindowChanged(WId id, int prop);
+    void onWindowRemoved(WId id);
 };
 
 class DesktopSwitchUnsupported : public QObject, public ILXQtPanelPlugin


### PR DESCRIPTION
This PR does three things:

 1. It fixes the persistence of urgent hint in the switcher after closing a window with an urgent hint, and so, closes https://github.com/lxqt/lxqt-panel/issues/1917
 2. When the property of a window changes, it checks the `Urgency` and `Workspace` properties of that window — in addition to `State` — and sets the switcher urgency accordingly.
 3. It also corrects emitting of `windowPropertyChanged` with X11. Previously it was emitted with both `NET::WMDesktop` and `NET::WMGeometry` flags, while the second flag was redundant.

A word about 2:

When a window demands attention, its desktop does too. Also, when a window that demands attention is moved between desktops, the desktop that demands attention changes accordingly. These points weren't considered in the master code.