### PR TITLE
Fixed default terminal of directorymenu plugin

### DIFF
--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -101,11 +101,8 @@ void DirectoryMenu::openDirectory(const QString& path)
 
 void DirectoryMenu::openInTerminal(const QString& path)
 {
-    // Create list of arguments
-    QStringList args;
-    args << QStringLiteral("--workdir") << QDir::toNativeSeparators(path);
-    // Execute the default terminal program with arguments
-    QProcess::startDetached(mDefaultTerminal, args);
+    // Execute the default terminal program in the given working directory
+    QProcess::startDetached(mDefaultTerminal, QStringList(), QDir::toNativeSeparators(path));
 }
 
 void DirectoryMenu::addMenu(QString path)
@@ -192,5 +189,5 @@ void DirectoryMenu::settingsChanged()
     }
 
     // Set default terminal
-    mDefaultTerminal = settings()->value(QStringLiteral("defaultTerminal"), QString()).toString();
+    mDefaultTerminal = settings()->value(QStringLiteral("defaultTerminal"), QStringLiteral("xterm")).toString();
 }


### PR DESCRIPTION
This patch fixes two issues:

 * The `Open in terminal` menu-item wouldn't work if no default terminal was defined. The patch minimizes the chance by choosing `xterm` in this case.
 * The previous code worked only with QTerminal and Konsole, excluding all terminals that didn't have the `--workdir` option.

Closes https://github.com/lxqt/lxqt-panel/issues/2121