### PR TITLE
An option to reverse the order of tray items

### DIFF
--- a/plugin-statusnotifier/statusnotifierconfiguration.cpp
+++ b/plugin-statusnotifier/statusnotifierconfiguration.cpp
@@ -46,6 +46,7 @@ StatusNotifierConfiguration::StatusNotifierConfiguration(PluginSettings *setting
 
     loadSettings();
 
+    connect(ui->orderCB, &QCheckBox::toggled, this, &StatusNotifierConfiguration::saveSettings);
     connect(ui->attentionSB, &QAbstractSpinBox::editingFinished, this, &StatusNotifierConfiguration::saveSettings);
 }
 
@@ -56,6 +57,7 @@ StatusNotifierConfiguration::~StatusNotifierConfiguration()
 
 void StatusNotifierConfiguration::loadSettings()
 {
+    ui->orderCB->setChecked(settings().value(QStringLiteral("reverseOrder"), false).toBool());
     ui->attentionSB->setValue(settings().value(QStringLiteral("attentionPeriod"), 5).toInt());
     mAutoHideList = settings().value(QStringLiteral("autoHideList")).toStringList();
     mHideList = settings().value(QStringLiteral("hideList")).toStringList();
@@ -63,6 +65,7 @@ void StatusNotifierConfiguration::loadSettings()
 
 void StatusNotifierConfiguration::saveSettings()
 {
+    settings().setValue(QStringLiteral("reverseOrder"), ui->orderCB->isChecked());
     settings().setValue(QStringLiteral("attentionPeriod"), ui->attentionSB->value());
     settings().setValue(QStringLiteral("autoHideList"), mAutoHideList);
     settings().setValue(QStringLiteral("hideList"), mHideList);

--- a/plugin-statusnotifier/statusnotifierconfiguration.ui
+++ b/plugin-statusnotifier/statusnotifierconfiguration.ui
@@ -18,6 +18,17 @@
     <number>5</number>
    </property>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="orderCB">
+       <property name="text">
+        <string>Reverse the order of items</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>5</number>

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -196,6 +196,16 @@ void StatusNotifierWidget::itemRemoved(const QString &serviceAndPath)
 
 void StatusNotifierWidget::settingsChanged()
 {
+    LXQt::GridLayout *layout = qobject_cast<LXQt::GridLayout*>(this->layout());
+    if (mPlugin->settings()->value(QStringLiteral("reverseOrder"), false).toBool())
+    {
+        layout->setItemsOrder(LXQt::GridLayout::ItemsOrder::LastToFirst);
+    }
+    else
+    {
+        layout->setItemsOrder(LXQt::GridLayout::ItemsOrder::FirstToLast);
+    }
+
     mAttentionPeriod = mPlugin->settings()->value(QStringLiteral("attentionPeriod"), 5).toInt();
     mAutoHideList = mPlugin->settings()->value(QStringLiteral("autoHideList")).toStringList();
     mHideList = mPlugin->settings()->value(QStringLiteral("hideList")).toStringList();


### PR DESCRIPTION
By default, the order is from the oldest to the newest item.

NOTE: This PR needs https://github.com/lxqt/liblxqt/pull/353

Closes https://github.com/lxqt/lxqt-panel/issues/2124