### PR TITLE
Capitalize remaining plugin titles

### DIFF
--- a/plugin-colorpicker/translations/colorpicker.desktop.yaml
+++ b/plugin-colorpicker/translations/colorpicker.desktop.yaml
@@ -1,2 +1,2 @@
-Desktop Entry/Name: "Color picker"
+Desktop Entry/Name: "Color Picker"
 Desktop Entry/Comment: "Get the color under the cursor and maintains a list of recently selected colors"

--- a/plugin-cpuload/translations/cpuload.desktop.yaml
+++ b/plugin-cpuload/translations/cpuload.desktop.yaml
@@ -1,2 +1,2 @@
-Desktop Entry/Name: "CPU monitor"
+Desktop Entry/Name: "CPU Monitor"
 Desktop Entry/Comment: "Displays the current CPU load"

--- a/plugin-desktopswitch/translations/desktopswitch.desktop.yaml
+++ b/plugin-desktopswitch/translations/desktopswitch.desktop.yaml
@@ -1,2 +1,2 @@
-Desktop Entry/Name: "Desktop switcher"
+Desktop Entry/Name: "Desktop Switcher"
 Desktop Entry/Comment: "Allows easy switching between virtual desktops"


### PR DESCRIPTION
These were the only plugins whose titles were not capitalized in English.

"CPU monitor"
"Color picker"
"Desktop switcher"