### PR TITLE
Fixed a crash in worldclock popup on Wayland with Qt 6.8.0

### DIFF
--- a/plugin-worldclock/lxqtworldclock.h
+++ b/plugin-worldclock/lxqtworldclock.h
@@ -67,7 +67,6 @@ public:
 private slots:
     void timeout();
     void wheelScrolled(int);
-    void deletePopup();
     void updateTimeText();
 
 private:
@@ -127,13 +126,6 @@ public:
     LXQtWorldClockPopup(QWidget *parent = nullptr);
 
     void show();
-
-signals:
-    void deactivated();
-
-protected:
-    virtual bool event(QEvent* );
-
 };
 
 class LXQtWorldClockLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
The crash was in `deleteLater()`. The code is simplified, such that there's no need to `deleteLater()`. It's also good for X11.

Fixes https://github.com/lxqt/lxqt-panel/issues/2146

NOTE: This is similar to https://github.com/lxqt/lxqt-notificationd/pull/375 and https://github.com/lxqt/lximage-qt/pull/666, and shows that we should be more cautious when using `deleteLater()`.