### PR TITLE
mainmenu: Workaround lack of context menu with Qt 6.8.0

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -126,7 +126,7 @@ private slots:
     void showHideMenu();
     void searchMenu();
     void setSearchFocus(QAction *action);
-    void onRequestingCustomMenu(const QPoint& p);
+    void onRequestingCustomMenu(const QPoint& p, QObject * sender);
 };
 
 class LXQtMainMenuPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
Similar approach as in #2147, but we don't sacrifice the context menu triggered by "menu" key (if it is correctly triggered by Qt).

ref. #2145