### PR TITLE
Prevent panel from accepting focus with some Wayland compositors

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -620,19 +620,10 @@ void LXQtWMBackend_KWinWayland::addWindow(LXQtTaskBarPlasmaWindow *window)
                 emit activeWindowChanged(activeWindow->getWindowId());
             }
         }
-        else
+        else if (activeWindow == effectiveWindow)
         {
-            // NOTE: LXQtTaskGroup does not handle well null active window
-            // This  would break minimize on click functionality.
-            // Since window is deactivated because another window became active,
-            // we pretend to still be active until we receive signal from newly active
-            // window which will register itself and emit activeWindowChanged() as above
-
-            // if (activeWindow == effectiveWindow)
-            // {
-            //     activeWindow = nullptr;
-            //     emit activeWindowChanged(0);
-            // }
+            activeWindow = nullptr;
+            emit activeWindowChanged(0);
         }
     });
 

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -258,7 +258,17 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
             anchors.setFlag(LayerShellQt::Window::AnchorRight);
             mLayerWindow->setAnchors(anchors);
 
-            mLayerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+#if (QT_VERSION >= QT_VERSION_CHECK(6,8,0))
+            // WARNING: Only the following desktops are known to give the focus to child popups
+            // when the panel does not accept focus.
+            const QRegularExpression desktops(QStringLiteral("(?i)(kde|kwin|wayfire|hyprland)"));
+
+            if (desktops.match(qEnvironmentVariable("XDG_CURRENT_DESKTOP")).hasMatch())
+                mLayerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityNone);
+            else
+#endif
+                mLayerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+
             mLayerWindow->setCloseOnDismissed(false);
 
             mLayerWindow->setExclusiveEdge(LayerShellQt::Window::AnchorBottom);


### PR DESCRIPTION
Unfortunately, several Wayland compositors won't let panel popups have focus if the panel does not accept focus.

However, some compositors don't have this issue, and we can use `KeyboardInteractivityNone` with them. The patch does that for `kwin_wayland`, 'wayfire' and 'hyprland', and with Qt ≥ 6.8 (because I'm not sure it works with previous versions of Qt).

NOTE: This is an ugly patch, but the current situation of Wayland compositors isn't better. The patch can be considered as a temporary solution.