### PR TITLE
Workaround for translucency artifacts with Qt 6.8.0 on Wayland

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -45,6 +45,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QDropEvent>
+#include <QPainter>
 #include <XdgIcon>
 #include <XdgDirs>
 
@@ -1317,6 +1318,22 @@ bool LXQtPanel::event(QEvent *event)
         mShowDelayTimer.stop();
         hidePanel();
         break;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6,8,0))
+    case QEvent::Paint:
+    // NOTE: Starting from Qt 6.8.0, random artifacts are possible in
+    // translucent windows under Wayland. This a workaround.
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        QPainter p(this);
+        p.setClipRegion(static_cast<QPaintEvent*>(event)->region());
+        auto origMode = p.compositionMode();
+        p.setCompositionMode(QPainter::CompositionMode_Clear);
+        p.fillRect(rect(), Qt::transparent);
+        p.setCompositionMode(origMode);
+    }
+    break;
+#endif
 
     default:
         break;


### PR DESCRIPTION
Since Qt 6.8.0, random artifacts are possible in a translucent panel — and, generally, in all translucent windows (based on QWidget, not QML) — under Wayland. They may happen when the panel starts. They're sometimes temporary, sometimes persistent, especially when the panel doesn't accept focus.

This is a simple workaround, which guarantees fully transparent pixels before painting.

NOTE: The workaround has been 100% effective for me elsewhere (also see https://github.com/lxqt/lxqt-notificationd/pull/402) and is effective in the case of panel too.