### PR TITLE
panel: Use the wlroots backend with unknown Wayland compositors

### DIFF
--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -263,7 +263,7 @@ void LXQtPanelApplicationPrivate::loadBackend()
         }
     }
 
-    if ( preferredBackend.isEmpty() && xdgCurrentDesktops.contains( QStringLiteral("wlroots") ) )
+    if ( preferredBackend.isEmpty() && xdgSessionType == QStringLiteral("wayland") ) )
     {
         qDebug() << "Specialized backend unavailable. Falling back to generic wlroots";
         preferredBackend = QStringLiteral("wlroots");


### PR DESCRIPTION
The description of the LXQtPanelApplicationPrivate::loadBackend() method already states that if we cannot identify the correct backend for a Wayland session, we should fall back to the wlroots backend module. This is reasonable given how broadly the wlr protocols are implemented. However, this was not happening due to a small error where we checked for the wlroots string in XDG_CURRENT_DESKTOP, which is not a valid option.

This change fixes this by checking XDG_SESSION_TYPE for "wayland" instead. As this is fallback logic, this is safe as the preferred backend logic using XDG_CURRENT_DESKTOP still wins over this.