### PR TITLE
CMake: Allow installing desktop file in different root directory

### DIFF
--- a/autostart/CMakeLists.txt
+++ b/autostart/CMakeLists.txt
@@ -19,7 +19,7 @@ configure_file(lxqt-panel_wayland.desktop.in lxqt-panel_wayland.desktop @ONLY)
 
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/lxqt-panel_wayland.desktop"
-    DESTINATION "/usr/share/applications"
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
     RENAME "lxqt-panel.desktop"
     COMPONENT Runtime
 )


### PR DESCRIPTION
This uses path from GNUInstallDirs cmake module instead of hard-coding it.