### PR TITLE
Made auto-hiding on overlapping work under kwin_wayland

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -502,8 +502,13 @@ bool LXQtWMBackend_KWinWayland::isAreaOverlapped(const QRect &area) const
 {
     for(auto &window : std::as_const(windows))
     {
-        if(window->geometry.intersects(area))
+        if(!window->wasUnmapped
+           && getWindowWorkspace(window->getWindowId()) == getCurrentWorkspace()
+           && !window->windowState.testFlag(LXQtTaskBarPlasmaWindow::state::state_minimized)
+           && window->geometry.intersects(area))
+        {
             return true;
+        }
     }
     return false;
 }

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -323,7 +323,10 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
     {
         if (mHidable && mHideOnOverlap
             // when a window is moved, resized, shaded, or minimized
-            && (prop == int(LXQtTaskBarWindowProperty::Geometry) || prop == int(LXQtTaskBarWindowProperty::State)))
+            && (prop == int(LXQtTaskBarWindowProperty::Geometry)
+                || prop == int(LXQtTaskBarWindowProperty::State)
+                // on Wayland, workspace change is not seen as geometry change
+                || (mLayerWindow && prop == int(LXQtTaskBarWindowProperty::Workspace))))
         {
             if (!mHidden)
             {

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -696,29 +696,40 @@ void LXQtPanel::setPanelGeometry(bool animate)
             {
                 mWAnimation = new QVariantAnimation(this);
                 mWAnimation->setEasingCurve(QEasingCurve::Linear);
+                mWAnimation->setStartValue(static_cast<qreal>(0));
+                mWAnimation->setEndValue(static_cast<qreal>(1));
                 connect(mWAnimation, &QVariantAnimation::finished, this, [this] {
                     if (mHidden)
+                    {
                         setMargins();
+                        // "setWindowOpacity()" does not work on Wayland
+                        if (!mVisibleMargin)
+                            LXQtPanelWidget->setVisible(false);
+                    }
                 });
                 connect(mWAnimation, &QVariantAnimation::valueChanged, this,
                         [this] (const QVariant &value) {
                     QMargins margins = layerWindowMargins();
                     QMarginsF m((mWAnimation->endValue().toReal() - value.toReal())
-                                * mLayerWindow->margins().toMarginsF() / 100
-                                + value.toReal() * margins.toMarginsF() / 100);
+                                * mLayerWindow->margins().toMarginsF()
+                                + value.toReal() * margins.toMarginsF());
                     mLayerWindow->setMargins(m.toMargins());
                     windowHandle()->requestUpdate();
                 });
             }
             mWAnimation->setDuration(mAnimationTime);
-            mWAnimation->setStartValue(static_cast<qreal>(0));
-            mWAnimation->setEndValue(static_cast<qreal>(100));
             if (!mHidden)
+            {
                 setMargins();
+                if (!mVisibleMargin)
+                    LXQtPanelWidget->setVisible(true);
+            }
             mWAnimation->start();
         }
         else
         {
+            if (!mVisibleMargin)
+                LXQtPanelWidget->setVisible(!mHidden);
             setMargins();
             mLayerWindow->setMargins(layerWindowMargins());
             windowHandle()->requestUpdate();

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -532,6 +532,14 @@ private:
      * @return The height/width of the panel.
      */
     int getReserveDimension();
+
+    /**
+     * @brief Calculates the margins of the layer window under Wayland
+     * by considering the hidden state of the panel.
+     * @return The margins of the layer window.
+     */
+    QMargins layerWindowMargins();
+
     /**
      * @brief Stores the geometry of the non-hidden panel, for use in
      * calculatePopupWindowPos()
@@ -691,7 +699,8 @@ private:
     /**
      * @brief The animation used for showing/hiding an auto-hiding panel.
      */
-    QPropertyAnimation *mAnimation;
+    QPropertyAnimation *mAnimation; // on X11
+    QVariantAnimation *mWAnimation; // on Wayland
 
     LayerShellQt::Window *mLayerWindow;
 


### PR DESCRIPTION
First, the method `LXQtWMBackend_KWinWayland::isAreaOverlapped()` needed enhancements.

Second, `QVariantAnimation` is used to set appropriate negative margins and have animation with auto-hiding. The animation is exactly like in X11.

NOTE: I'm not sure that negative margins work under other Wayland compositors, but for now, auto-hiding on overlapping can't work with them. KWin wins again ;)

Closes https://github.com/lxqt/lxqt-panel/issues/2113