### PR TITLE
Fixed destination dir of lxqt-panel_wayland.desktop

### DIFF
--- a/autostart/CMakeLists.txt
+++ b/autostart/CMakeLists.txt
@@ -19,7 +19,7 @@ configure_file(lxqt-panel_wayland.desktop.in lxqt-panel_wayland.desktop @ONLY)
 
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/lxqt-panel_wayland.desktop"
-    DESTINATION "/usr/share/applications"
+    DESTINATION "${LXQT_DATA_DIR}/applications"
     RENAME "lxqt-panel.desktop"
     COMPONENT Runtime
 )


### PR DESCRIPTION
This file should not be installed directly into `/usr/share/applications`, otherwise it may fail when packaging downstream.