### PR TITLE
Fixed three bugs with multi-screen setups on Wayland

### DIFF
--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -352,13 +352,18 @@ LXQtPanelApplication::LXQtPanelApplication(int& argc, char** argv)
 
     d->loadBackend();
 
-    // This is a workaround for Qt 5 bug #40681.
-    const auto allScreens = screens();
-    for(QScreen* screen : allScreens)
+    if (QGuiApplication::platformName() == QStringLiteral("xcb"))
     {
-        connect(screen, &QScreen::destroyed, this, &LXQtPanelApplication::screenDestroyed);
+        // This is a workaround for Qt 5 bug #40681.
+        const auto allScreens = screens();
+        for(QScreen* screen : allScreens)
+        {
+            connect(screen, &QScreen::destroyed, this, &LXQtPanelApplication::screenDestroyed);
+        }
+        connect(this, &QGuiApplication::screenAdded, this, &LXQtPanelApplication::handleScreenAdded);
+
     }
-    connect(this, &QGuiApplication::screenAdded, this, &LXQtPanelApplication::handleScreenAdded);
+
     connect(this, &QCoreApplication::aboutToQuit, this, &LXQtPanelApplication::cleanup);
 
 


### PR DESCRIPTION
This patch fixes three issues on Wayland:

 * First, if a new panel was added to another screen, it wouldn't be positioned on that screen without a module restart; i.e., an on-the-fly screen positioning was impossible.
 * Second, if the screen of a panel was removed and added again, that panel wouldn't be shown without a module restart.
 * Finally, if the screen of a panel was removed, it wouldn't be moved to an existing screen without a module restart.

Closes https://github.com/lxqt/lxqt-panel/issues/2073