### PR TITLE
Fixed taskbar when a window is shown on all desktops

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -500,10 +500,11 @@ void LXQtWMBackend_KWinWayland::refreshIconGeometry(WId windowId, const QRect &g
 
 bool LXQtWMBackend_KWinWayland::isAreaOverlapped(const QRect &area) const
 {
+    int d;
     for(auto &window : std::as_const(windows))
     {
         if(!window->wasUnmapped
-           && getWindowWorkspace(window->getWindowId()) == getCurrentWorkspace()
+           && ((d = getWindowWorkspace(window->getWindowId())) == getCurrentWorkspace() || d <= 0)
            && !window->windowState.testFlag(LXQtTaskBarPlasmaWindow::state::state_minimized)
            && window->geometry.intersects(area))
         {

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -742,7 +742,8 @@ void LXQtTaskButton::setUrgencyHint(bool set)
  ************************************************/
 bool LXQtTaskButton::isOnDesktop(int desktop) const
 {
-    return mBackend->getWindowWorkspace(mWindow) == desktop;
+    int d = mBackend->getWindowWorkspace(mWindow);
+    return d == desktop || d <= 0; // means "on all desktops"
 }
 
 bool LXQtTaskButton::isOnCurrentScreen() const


### PR DESCRIPTION
This patch fixes two issues:

 * On X11 and kwin_wayland, windows that were shown on all desktops wouldn't be shown on the taskbar if "Show only windows from desktop" was checked; and
 * On kwin_wayland, auto-hiding on overlapping didn't work with such windows.

Fixes https://github.com/lxqt/lxqt-panel/issues/2186