### PR TITLE
Fixed handling of windows that are on all desktops

### DIFF
--- a/panel/backends/ilxqtabstractwmiface.cpp
+++ b/panel/backends/ilxqtabstractwmiface.cpp
@@ -50,3 +50,10 @@ void ILXQtAbstractWMInterface::moveApplicationToPrevNextDesktop(WId windowId, bo
 
     setWindowOnWorkspace(windowId, targetWorkspace);
 }
+
+int ILXQtAbstractWMInterface::onAllWorkspacesEnum() const
+{
+    // Virtual destops have 1-based indexes.
+    // NOTE: The real value of this enum may be negative (as in X11).
+    return 0;
+}

--- a/panel/backends/ilxqtabstractwmiface.h
+++ b/panel/backends/ilxqtabstractwmiface.h
@@ -87,6 +87,8 @@ public:
     virtual void moveApplicationToPrevNextDesktop(WId windowId, bool next); // Default implementation
     virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next, bool raiseOnCurrentDesktop) = 0;
 
+    virtual int onAllWorkspacesEnum() const;
+
     virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const = 0;
 
     virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft) = 0;

--- a/panel/backends/lxqtdummywmbackend.cpp
+++ b/panel/backends/lxqtdummywmbackend.cpp
@@ -152,6 +152,11 @@ void LXQtDummyWMBackend::moveApplicationToPrevNextMonitor(WId, bool, bool)
     //No-op
 }
 
+int LXQtDummyWMBackend::onAllWorkspacesEnum() const
+{
+    return 0;
+}
+
 bool LXQtDummyWMBackend::isWindowOnScreen(QScreen *, WId) const
 {
     return false;

--- a/panel/backends/lxqtdummywmbackend.h
+++ b/panel/backends/lxqtdummywmbackend.h
@@ -79,6 +79,8 @@ public:
 
     void moveApplicationToPrevNextMonitor(WId windowId, bool next, bool raiseOnCurrentDesktop) override;
 
+    int onAllWorkspacesEnum() const override;
+
     bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
 
     virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft) override;

--- a/panel/backends/lxqttaskbartypes.h
+++ b/panel/backends/lxqttaskbartypes.h
@@ -79,9 +79,4 @@ enum class LXQtTaskBarWindowLayer
     KeepAbove
 };
 
-enum class LXQtTaskBarWorkspace
-{
-    ShowOnAll = 0 // Virtual destops have 1-based indexes
-};
-
 #endif // LXQTTASKBARTYPES_H

--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -504,7 +504,7 @@ bool LXQtWMBackend_KWinWayland::isAreaOverlapped(const QRect &area) const
     for(auto &window : std::as_const(windows))
     {
         if(!window->wasUnmapped
-           && ((d = getWindowWorkspace(window->getWindowId())) == getCurrentWorkspace() || d <= 0)
+           && ((d = getWindowWorkspace(window->getWindowId())) == getCurrentWorkspace() || d == onAllWorkspacesEnum())
            && !window->windowState.testFlag(LXQtTaskBarPlasmaWindow::state::state_minimized)
            && window->geometry.intersects(area))
         {

--- a/panel/backends/xcb/lxqtwmbackend_x11.cpp
+++ b/panel/backends/xcb/lxqtwmbackend_x11.cpp
@@ -554,6 +554,11 @@ void LXQtWMBackendX11::moveApplicationToPrevNextMonitor(WId windowId, bool next,
     }
 }
 
+int LXQtWMBackendX11::onAllWorkspacesEnum() const
+{
+    return NET::OnAllDesktops;
+}
+
 bool LXQtWMBackendX11::isWindowOnScreen(QScreen *screen, WId windowId) const
 {
     //TODO: old code was:

--- a/panel/backends/xcb/lxqtwmbackend_x11.h
+++ b/panel/backends/xcb/lxqtwmbackend_x11.h
@@ -80,6 +80,8 @@ public:
 
     virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next, bool raiseOnCurrentDesktop) override;
 
+    virtual int onAllWorkspacesEnum() const override;
+
     virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
 
     virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft) override;

--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -129,7 +129,7 @@ void DesktopSwitch::onWindowChanged(WId id, int prop)
         || prop == int(LXQtTaskBarWindowProperty::Workspace))
     {
         int desktop = mBackend->getWindowWorkspace(id);
-        if (desktop == int(LXQtTaskBarWorkspace::ShowOnAll))
+        if (desktop == mBackend->onAllWorkspacesEnum())
             return;
         if (prop == int(LXQtTaskBarWindowProperty::Workspace))
         { // remove the urgent hint from desktops that do not contain the window

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -581,8 +581,8 @@ void LXQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
         deskMenu->setEnabled(mBackend->supportsAction(mWindow, LXQtTaskBarBackendAction::MoveToDesktop));
 
         a = deskMenu->addAction(tr("&All Desktops"));
-        a->setData(int(LXQtTaskBarWorkspace::ShowOnAll));
-        a->setEnabled(winDesk != int(LXQtTaskBarWorkspace::ShowOnAll));
+        a->setData(mBackend->onAllWorkspacesEnum());
+        a->setEnabled(winDesk != mBackend->onAllWorkspacesEnum());
         connect(a, &QAction::triggered, this, &LXQtTaskButton::moveApplicationToDesktop);
         deskMenu->addSeparator();
 
@@ -743,7 +743,7 @@ void LXQtTaskButton::setUrgencyHint(bool set)
 bool LXQtTaskButton::isOnDesktop(int desktop) const
 {
     int d = mBackend->getWindowWorkspace(mWindow);
-    return d == desktop || d <= 0; // means "on all desktops"
+    return d == desktop || d == mBackend->onAllWorkspacesEnum();
 }
 
 bool LXQtTaskButton::isOnCurrentScreen() const


### PR DESCRIPTION
The problem was that each backend may have a different enum for such windows — e.g., that of X11 is -1 — while the code assumed a value of zero for all.