### PR TITLE
Check visibility of task buttons only relative to task-bar

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -382,7 +382,7 @@ void LXQtTaskBar::refreshPlaceholderVisibility()
     bool haveVisibleWindow = false;
     for (auto i = mKnownWindows.cbegin(), i_e = mKnownWindows.cend(); i_e != i; ++i)
     {
-        if ((*i)->isVisible())
+        if ((*i)->isVisibleTo(this))
         {
             haveVisibleWindow = true;
             break;


### PR DESCRIPTION
Checking the absolute visibility in `LXQtTaskBar::refreshPlaceholderVisibility()` caused a problem when an auto-hiding panel was hidden on Wayland.

Fixes https://github.com/lxqt/lxqt-panel/issues/2191