### PR TITLE
Set fallback icons - Configure Panel dialog

### DIFF
--- a/panel/config/configpaneldialog.cpp
+++ b/panel/config/configpaneldialog.cpp
@@ -36,15 +36,15 @@ ConfigPanelDialog::ConfigPanelDialog(LXQtPanel *panel, QWidget *parent):
     setAttribute(Qt::WA_DeleteOnClose);
 
     mPlacementPage = new ConfigPlacement(panel, this);
-    addPage(mPlacementPage, tr("Placement"), QLatin1String("configure-toolbars"));
+    addPage(mPlacementPage, tr("Placement"), QStringList() << QStringLiteral("configure-toolbars") << QStringLiteral("preferences-desktop"));
     connect(this, &ConfigPanelDialog::reset, mPlacementPage, &ConfigPlacement::reset);
 
     mStylingPage = new ConfigStyling(panel, this);
-    addPage(mStylingPage, tr("Styling"), QLatin1String("colormanagement"));
+    addPage(mStylingPage, tr("Styling"), QStringList() << QLatin1String("colormanagement") << QLatin1String("preferences-desktop-theme") << QStringLiteral("preferences-desktop"));
     connect(this, &ConfigPanelDialog::reset, mStylingPage, &ConfigStyling::reset);
 
     mPluginsPage = new ConfigPluginsWidget(panel, this);
-    addPage(mPluginsPage, tr("Widgets"), QLatin1String("preferences-plugin"));
+    addPage(mPluginsPage, tr("Widgets"), QStringList() << QLatin1String("preferences-plugin") << QLatin1String("preferences-desktop"));
     connect(this, &ConfigPanelDialog::reset, mPluginsPage, &ConfigPluginsWidget::reset);
 
     connect(this, &ConfigPanelDialog::accepted, panel, [panel] {

--- a/panel/config/configpaneldialog.cpp
+++ b/panel/config/configpaneldialog.cpp
@@ -40,11 +40,12 @@ ConfigPanelDialog::ConfigPanelDialog(LXQtPanel *panel, QWidget *parent):
     connect(this, &ConfigPanelDialog::reset, mPlacementPage, &ConfigPlacement::reset);
 
     mStylingPage = new ConfigStyling(panel, this);
-    addPage(mStylingPage, tr("Styling"), QStringList() << QLatin1String("colormanagement") << QLatin1String("preferences-desktop-theme") << QStringLiteral("preferences-desktop"));
+    addPage(mStylingPage, tr("Styling"), QStringList() << QStringLiteral("colormanagement") << QStringLiteral("preferences-desktop-theme")
+        << QStringLiteral("preferences-desktop"));
     connect(this, &ConfigPanelDialog::reset, mStylingPage, &ConfigStyling::reset);
 
     mPluginsPage = new ConfigPluginsWidget(panel, this);
-    addPage(mPluginsPage, tr("Widgets"), QStringList() << QLatin1String("preferences-plugin") << QLatin1String("preferences-desktop"));
+    addPage(mPluginsPage, tr("Widgets"), QStringList() << QStringLiteral("preferences-plugin") << QStringLiteral("preferences-desktop"));
     connect(this, &ConfigPanelDialog::reset, mPluginsPage, &ConfigPluginsWidget::reset);
 
     connect(this, &ConfigPanelDialog::accepted, panel, [panel] {


### PR DESCRIPTION
With MATE icon theme, before:
![before](https://github.com/user-attachments/assets/62f23768-6610-49fc-b62c-4f908a0bbe39)
After:
![after](https://github.com/user-attachments/assets/4da66a93-724d-4a85-8dad-56aeb7809da8)
Breeze icon theme (no change):
![breeze](https://github.com/user-attachments/assets/f4711fab-c334-4985-afdf-2bad1989d044)
