### PR TITLE
Prefer en_US over en_GB in root translations

### DIFF
--- a/plugin-mount/configuration.ui
+++ b/plugin-mount/configuration.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Behaviour</string>
+      <string>Behavior</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">

--- a/plugin-sysstat/lxqtsysstatconfiguration.ui
+++ b/plugin-sysstat/lxqtsysstatconfiguration.ui
@@ -309,7 +309,7 @@
      <item>
       <widget class="QGroupBox" name="coloursGB">
        <property name="title">
-        <string>Colours</string>
+        <string>Colors</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_8" columnstretch="2,3">
         <property name="horizontalSpacing">

--- a/plugin-worldclock/lxqtworldclockconfiguration.ui
+++ b/plugin-worldclock/lxqtworldclockconfiguration.ui
@@ -374,7 +374,7 @@
             <item>
              <widget class="QPushButton" name="customisePB">
               <property name="text">
-               <string>&amp;Customise ...</string>
+               <string>&amp;Customize ...</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Prefer en_US over en_GB in several translations. More people are familiar with en_US.

Translations should be able to be preserved no problem.

"Behaviour" and "Behavior" were both translated already. This deprecates "Behaviour".