### PR TITLE
Prevent redundant writing to config file on startup

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -379,13 +379,13 @@ void LXQtPanel::readSettings()
 
     QColor color = mSettings->value(QStringLiteral(CFG_KEY_FONTCOLOR), QString()).value<QColor>();
     if (color.isValid())
-        setFontColor(color, true);
+        setFontColor(color, false);
 
-    setOpacity(mSettings->value(QStringLiteral(CFG_KEY_OPACITY), 100).toInt(), true);
+    setOpacity(mSettings->value(QStringLiteral(CFG_KEY_OPACITY), 100).toInt(), false);
     mReserveSpace = mSettings->value(QStringLiteral(CFG_KEY_RESERVESPACE), true).toBool();
     color = mSettings->value(QStringLiteral(CFG_KEY_BACKGROUNDCOLOR), QString()).value<QColor>();
     if (color.isValid())
-        setBackgroundColor(color, true);
+        setBackgroundColor(color, false);
 
     QString image = mSettings->value(QStringLiteral(CFG_KEY_BACKGROUNDIMAGE), QString()).toString();
     if (!image.isEmpty())
@@ -1287,7 +1287,7 @@ void LXQtPanel::setBackgroundImage(QString path, bool save)
  ************************************************/
 void LXQtPanel::setOpacity(int opacity, bool save)
 {
-    mOpacity = opacity;
+    mOpacity = qBound(0, opacity, 100);
     updateStyleSheet();
 
     if (save)

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -370,10 +370,20 @@ void Plugin::settingsChanged()
  ************************************************/
 void Plugin::saveSettings()
 {
-    mSettings->setValue(QStringLiteral("alignment"), (mAlignment == AlignLeft) ? QStringLiteral("Left") : QStringLiteral("Right"));
-    mSettings->setValue(QStringLiteral("type"), mDesktopFile.id());
-    mSettings->sync();
-
+    bool syncSettings = false;
+    const QString alignment(mAlignment == AlignLeft ? QStringLiteral("Left") : QStringLiteral("Right"));
+    if (mSettings->value(QStringLiteral("alignment")).toString() != alignment)
+    {
+        mSettings->setValue(QStringLiteral("alignment"), alignment);
+        syncSettings = true;
+    }
+    if (mSettings->value(QStringLiteral("type")).toString() != mDesktopFile.id())
+    {
+        mSettings->setValue(QStringLiteral("type"), mDesktopFile.id());
+        syncSettings = true;
+    }
+    if (syncSettings)
+        mSettings->sync();
 }
 
 


### PR DESCRIPTION
LXQt Panel wrote heavily to its config file on startup for no good reason. Most of those redundant writings were done in `Plugin::saveSettings()`, for every active plugin.

By "redundant" I mean that the config file does not change after being written to. That may be acceptable on some occasions, but not on startup.