### PR TITLE
plugin-dom: Add tooltip

### DIFF
--- a/plugin-dom/domplugin.cpp
+++ b/plugin-dom/domplugin.cpp
@@ -38,6 +38,7 @@ DomPlugin::DomPlugin(const ILXQtPanelPluginStartupInfo &startupInfo):
     mButton.setAutoRaise(true);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mButton.setIcon(XdgIcon::fromTheme(QStringLiteral("preferences-plugin")));
+    mButton.setToolTip(tr("Panel DOM Tree"));
     connect(&mButton, &QToolButton::clicked, this, &DomPlugin::showDialog);
 }
 


### PR DESCRIPTION
`"Panel DOM Tree"` is already translated here: https://github.com/isf63/lxqt-panel/blob/26c8aa1d66086f994c83bbb139652994bd5d058b/plugin-dom/treewindow.ui#L14