### PR TITLE
Handle Wayland screens by using their names

### DIFF
--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -38,6 +38,8 @@
 #include "ilxqtpanel.h"
 #include "lxqtpanelglobals.h"
 
+#define CFG_KEY_SCREENNAME "screen-name" // also used by LXQtPanelApplication (on Wayland)
+
 class QMenu;
 class Plugin;
 class QAbstractItemModel;
@@ -220,7 +222,7 @@ public:
     int length() const { return mLength; }
     bool lengthInPercents() const { return mLengthInPercents; }
     LXQtPanel::Alignment alignment() const { return mAlignment; }
-    int screenNum() const { return mScreenNum; }
+    int screenNum() const { return (mWaylandScreenNum >= 0 ? mWaylandScreenNum : mScreenNum); }
     QColor fontColor() const { return mFontColor; }
     QColor backgroundColor() const { return mBackgroundColor; }
     QString backgroundImage() const { return mBackgroundImage; }
@@ -616,6 +618,23 @@ private:
      * \sa mScreenNum, canPlacedOn(), findAvailableScreen().
      */
     int mActualScreenNum;
+    /**
+     * @brief The Wayland screen number, which is found based on the screen name.
+     * It can be different from mScreenNum and is not saved to the config file.
+     * Its initial value is -1, meaning that it is not set yet.
+     *
+     * \sa mScreenNum, canPlacedOn(), findAvailableScreen().
+     */
+    int mWaylandScreenNum;
+    /**
+     * @brief The name of the Wayland screen, on which this panel should be
+     * shown. If the panel cannot be shown on that screen, LXQtPanel will
+     * determine another screen. The screen that the panel is actually
+     * shown on is stored in mActualScreenNum.
+     *
+     * \sa mScreenNum, mActualScreenNum.
+     */
+    QString mScreenName;
     /**
      * @brief QTimer for delayed saving of changed settings. In many cases,
      * instead of storing changes to disk immediately we start this timer.

--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -481,13 +481,18 @@ void LXQtPanelApplication::handleWaylandScreenAdded(QScreen* newScreen)
         d->mSettings->endGroup();
         if (screenName == newScreen->name())
         {
+            bool alreadyExists = false;
             for (const auto& panel : std::as_const(mPanels))
             {
                 if (panel->name() == name)
-                    return; // the panel already exists (and is hidden)
+                { // the panel already exists (and is hidden)
+                    alreadyExists = true;
+                    break;
+                }
             }
+            if (alreadyExists)
+                continue;
             addPanel(name);
-            return;
         }
     }
 }

--- a/panel/lxqtpanelapplication.h
+++ b/panel/lxqtpanelapplication.h
@@ -160,6 +160,12 @@ private slots:
      */
     void handleScreenAdded(QScreen* newScreen);
     /*!
+     * \brief Adds the panel whose screen name is that of the new screen
+     * on Wayland if it does not exist.
+     * \param newScreen The QScreen that was created and added.
+     */
+    void handleWaylandScreenAdded(QScreen* newScreen);
+    /*!
      * \brief Handles screen destruction. This is a workaround for a Qt bug.
      * For further information, see the implementation notes.
      * \param screenObj The QScreen that was destroyed.


### PR DESCRIPTION
The main reason behind this change is that screen setting by using numbers may not work with all Wayland compositors.

With this patch, and on Wayland,

 * The screen names are used for determining where the panels should be shown;
 * A panel is not moved to another screen when its screen is disconnected (unlike on X11);
 * If the screen assigned to a panel is not connected on startup, that panel won't be created, but it will be created as soon as its corresponding screen is connected.

IMPORTANT NOTE: Since I couldn't test this patch, I made it based on some assumptions. For example, I don't know if Qt or the compositor hides a panel, automatically moves it to another screen, or just causes a crash when its screen is unplugged. Here, I've *assumed* that it hides the panel. So, the patch should be tested thoroughly, and it might need changes.