### PR TITLE
Fix volume icon on two-tone themes

### DIFF
--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -175,7 +175,6 @@ void VolumePopup::updateStockIcon()
     else
         iconName = QLatin1String("audio-volume-high");
 
-    iconName.append(QLatin1String("-panel"));
     m_muteToggleButton->setIcon(XdgIcon::fromTheme(iconName));
     emit stockIconChanged(iconName);
 }


### PR DESCRIPTION
This line of code is removed so that two-tone themes can work properly. One example is Azuma's LXQt-colors theme, anbd LXQT's own Leech theme, which have dark panels but white popups. Currently, this issue causes the volume icons on non-skeuomorphic icon themes (like papirus) to be white and blend with the pushbutton. 

removing this line will cause the panel icon for the volume plugin to pull from the "panel" directory of the icon theme, while the popup version should pull from "actions". this is perfectly safe, because icon themes that are either "dark" or "light" will have these icons the same color in both directories. So the end user will see no difference, except for the fact that this plugin now works on two-tone themes. 

This fix has been tested and works very well. I have tried the icons at many scales and on multiple themes. it works a treat. Some icon themes don't respond to it because they don't structure them right, but for the ones that do, this fix works well. but at the very least, with this change, the ball is now in their court, and not LXQt's, because LXQt would now support it. 