### PR TITLE
mainmenu,fancymenu: Remove redundant QGroupBox .ui properties and AlignVCenter

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuconfiguration.ui
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.ui
@@ -19,15 +19,6 @@
      <property name="title">
       <string>General</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="QCheckBox" name="iconCB">

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.ui
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.ui
@@ -19,15 +19,6 @@
      <property name="title">
       <string>General</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="QCheckBox" name="iconCB">


### PR DESCRIPTION
The properties have the same default values as what they were set to.

The alignment looked odd (but arguably is a matter of taste.)