### PR TITLE
Made timezone switch by mouse wheel optional in clock

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -48,6 +48,7 @@ LXQtWorldClock::LXQtWorldClock(const ILXQtPanelPluginStartupInfo &startupInfo):
     mPopup(nullptr),
     mTimer(new QTimer(this)),
     mUpdateInterval(1),
+    mTimeZoneWheel(true),
     mAutoRotate(true),
     mShowWeekNumber(true),
     mShowTooltip(false),
@@ -231,6 +232,8 @@ void LXQtWorldClock::settingsChanged()
     QString timezonePosition = _settings->value(QLatin1String("timezonePosition"), QString()).toString();
     QString timezoneFormatType = _settings->value(QLatin1String("timezoneFormatType"), QString()).toString();
 
+    mTimeZoneWheel = _settings->value(QLatin1String("timeZoneWheel"), true).toBool();
+
     // date
     bool showDate = _settings->value(QLatin1String("showDate"), false).toBool();
 
@@ -371,7 +374,7 @@ QDialog *LXQtWorldClock::configureDialog()
 
 void LXQtWorldClock::wheelScrolled(int delta)
 {
-    if (mTimeZones.count() > 1)
+    if (mTimeZoneWheel && mTimeZones.count() > 1)
     {
         mActiveTimeZone = mTimeZones[(mTimeZones.indexOf(mActiveTimeZone) + ((delta > 0) ? -1 : 1) + mTimeZones.size()) % mTimeZones.size()];
         setTimeText();

--- a/plugin-worldclock/lxqtworldclock.h
+++ b/plugin-worldclock/lxqtworldclock.h
@@ -83,6 +83,7 @@ private:
     QString mDefaultTimeZone;
     QString mActiveTimeZone;
     QString mFormat;
+    bool mTimeZoneWheel;
 
     bool mAutoRotate;
     bool mShowWeekNumber;

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -86,6 +86,8 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
     connect(ui->showWeekNumberCB,     &QCheckBox::clicked, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->showTooltipCB,        &QCheckBox::clicked, this, &LXQtWorldClockConfiguration::saveSettings);
 
+    connect(ui->wheelCB,              &QCheckBox::clicked, this, &LXQtWorldClockConfiguration::saveSettings);
+
     loadSettings();
 }
 
@@ -236,6 +238,8 @@ void LXQtWorldClockConfiguration::loadSettings()
     ui->autorotateCB->setChecked(settings().value(QStringLiteral("autoRotate"), true).toBool());
     ui->showWeekNumberCB->setChecked(settings().value(QL1S("showWeekNumber"), true).toBool());
 
+    ui->wheelCB->setChecked(settings().value(QLatin1String("timeZoneWheel"), true).toBool());
+
     mLockCascadeSettingChanges = false;
 }
 
@@ -381,6 +385,8 @@ void LXQtWorldClockConfiguration::saveSettings()
     settings().setValue(QLatin1String("autoRotate"), ui->autorotateCB->isChecked());
     settings().setValue(QL1S("showWeekNumber"), ui->showWeekNumberCB->isChecked());
     settings().setValue(QLatin1String("showTooltip"), ui->showTooltipCB->isChecked());
+
+    settings().setValue(QLatin1String("timeZoneWheel"), ui->wheelCB->isChecked());
 }
 
 void LXQtWorldClockConfiguration::timeFormatChanged(int index)

--- a/plugin-worldclock/lxqtworldclockconfiguration.ui
+++ b/plugin-worldclock/lxqtworldclockconfiguration.ui
@@ -513,6 +513,13 @@
         </layout>
        </item>
        <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="wheelCB">
+         <property name="text">
+          <string>Change displayed time zone with mouse wheel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>&lt;b&gt;Note:&lt;/b&gt; Middle-click the clock to view the time and date for all configured timezones.</string>


### PR DESCRIPTION
All timezones are shown on a popup by middle clicking the clock, and wheel switching may make you go to bed at 8 pm because you may have done it inadvertently, especially when the clock is near the desktop switcher.

The default is as before.

NOTE: Please don't merge before the release of 2.2.0.