### PR TITLE
Functional draft for backlight scrollwheel feature

### DIFF
--- a/plugin-backlight/backlight.cpp
+++ b/plugin-backlight/backlight.cpp
@@ -70,13 +70,11 @@ bool LXQtBacklight::eventFilter(QObject *obj, QEvent *event)
     if (obj == m_backlightButton) {
         if (event->type() == QEvent::Wheel) {
             if(! m_backlightSlider) {
-                // NOTE: Workaround ot prevent crash
+                // NOTE: Workaround to prevent crash
                 // TODO: The event can probably be handled directly in the plugin
                 m_backlightSlider = new SliderDialog(m_backlightButton);
                 connect(m_backlightSlider, &SliderDialog::dialogClosed, this, &LXQtBacklight::deleteSlider);
-                //printf("New Slider\n");
             }
-            qInfo() << "Handling backlight wheel event (2)";
             auto ev = static_cast<QWheelEvent*>(event);
             m_backlightSlider->handleWheelEvent(ev);
             return true;

--- a/plugin-backlight/backlight.h
+++ b/plugin-backlight/backlight.h
@@ -57,6 +57,9 @@ protected Q_SLOTS:
     void showSlider(bool);
     void deleteSlider();
 
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+
 private:
     QToolButton *m_backlightButton;
     SliderDialog *m_backlightSlider;

--- a/plugin-backlight/sliderdialog.cpp
+++ b/plugin-backlight/sliderdialog.cpp
@@ -107,19 +107,15 @@ void SliderDialog::updateBacklight()
 }
 
 void SliderDialog::handleWheelEvent(QWheelEvent *event) {
-    qInfo() << "Handling bakclight wheel event SET BACKLIGHT VALUE";
     auto cur_pos = m_slider->sliderPosition();
     // auto cur_pos = m_backlight->getBacklight();
     auto delta = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep;
     auto step = delta * m_slider->singleStep();
     auto value = cur_pos + step;
-    qInfo() << "Handling bakclight wheel event SET BACKLIGHT VALUE" << delta << cur_pos << step << "->" << value;
-
-
+    qInfo().nospace() << "Handling backlight wheel event (set value: " << value << ")";
     // m_slider->setSliderPosition(m_slider->sliderPosition()
     //                   + (event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * m_slider->singleStep()));
     m_slider->setValue(value);
-
 }
 
 void SliderDialog::downButtonClicked(bool)

--- a/plugin-backlight/sliderdialog.cpp
+++ b/plugin-backlight/sliderdialog.cpp
@@ -26,7 +26,7 @@
 
 #include <QVBoxLayout>
 #include <QFrame>
-#include <QEvent>
+#include <QWheelEvent>
 #include <QDebug>
 #include "sliderdialog.h"
 
@@ -104,6 +104,22 @@ void SliderDialog::updateBacklight()
         m_slider->setValue(m_backlight->getBacklight());
     else
         m_slider->setValue( (m_backlight->getBacklight() * 100) / maxBacklight);
+}
+
+void SliderDialog::handleWheelEvent(QWheelEvent *event) {
+    qInfo() << "Handling bakclight wheel event SET BACKLIGHT VALUE";
+    auto cur_pos = m_slider->sliderPosition();
+    // auto cur_pos = m_backlight->getBacklight();
+    auto delta = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep;
+    auto step = delta * m_slider->singleStep();
+    auto value = cur_pos + step;
+    qInfo() << "Handling bakclight wheel event SET BACKLIGHT VALUE" << delta << cur_pos << step << "->" << value;
+
+
+    // m_slider->setSliderPosition(m_slider->sliderPosition()
+    //                   + (event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * m_slider->singleStep()));
+    m_slider->setValue(value);
+
 }
 
 void SliderDialog::downButtonClicked(bool)

--- a/plugin-backlight/sliderdialog.h
+++ b/plugin-backlight/sliderdialog.h
@@ -41,13 +41,14 @@ class SliderDialog: public QDialog
 public:
     SliderDialog(QWidget *parent);
     void updateBacklight();
+    void handleWheelEvent(QWheelEvent* event);
 
 Q_SIGNALS:
     void dialogClosed();
 
 protected:
     bool event(QEvent *event) override;
-    
+
 private:
     QSlider *m_slider;
     QToolButton *m_upButton, *m_downButton;


### PR DESCRIPTION
Closes #2200 

TODO:
- [ ] Contrary to the volume slider the slider (dialog) widget is destroyed on close (-> keep it)
- [ ] On dev setup at least root permissions are required to set the backlight value
- [ ] Make sure the value is always correct (in range [1..10])
