### PR TITLE
Guard `QDrag` with `QPointer` to prevent DND crash

### DIFF
--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -157,7 +157,7 @@ void QuickLaunchButton::mouseMoveEvent(QMouseEvent *e)
         return;
     }
 
-    QDrag *drag = new QDrag(this);
+    QPointer<QDrag> drag = new QDrag(this);
     ButtonMimeData *mimeData = new ButtonMimeData();
     mimeData->setButton(this);
     drag->setMimeData(mimeData);
@@ -165,7 +165,7 @@ void QuickLaunchButton::mouseMoveEvent(QMouseEvent *e)
     drag->exec(Qt::MoveAction);
 
     // Icon was dropped outside the panel, remove button
-    if (!drag->target())
+    if (drag && !drag->target())
     {
         selfRemove();
     }

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -350,7 +350,7 @@ void LXQtTaskButton::mouseMoveEvent(QMouseEvent* event)
     if ((event->position().toPoint() - mDragStartPosition).manhattanLength() < QApplication::startDragDistance())
         return;
 
-    QDrag *drag = new QDrag(this);
+    QPointer<QDrag> drag = new QDrag(this);
     drag->setMimeData(mimeData());
     QIcon ico = icon();
     QPixmap img = ico.pixmap(ico.actualSize({32, 32}));

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -372,7 +372,8 @@ void LXQtTaskButton::mouseMoveEvent(QMouseEvent* event)
 
     // if button is dropped out of panel (e.g. on desktop)
     // it is not deleted automatically by Qt
-    drag->deleteLater();
+    if (drag)
+        drag->deleteLater();
 
     // release mouse appropriately, by positioning the event outside
     // the button rectangle (otherwise, the button will be toggled)


### PR DESCRIPTION
Since the destiny of `QDrag` depends on external factors after `QDrag::exec()`, it shouldn't be used without a safeguard after that call.