### PR TITLE
Add plugin-sensors plugin instance icon

### DIFF
--- a/plugin-sensors/resources/sensors.desktop.in
+++ b/plugin-sensors/resources/sensors.desktop.in
@@ -1,3 +1,4 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=LXQtPanel/Plugin
+Icon=temperature-normal


### PR DESCRIPTION
Adds an (okay) icon to plugin-sensors' plugin entry, previously there was none.

Icon exists in some KDE icon themes such as Breeze.

![sensors](https://github.com/user-attachments/assets/c3b4d524-fca6-4b5b-845b-abf9919cc4db)
