### PR TITLE
Implemented "Show Desktop" in wlroots backend

### DIFF
--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.h
@@ -22,6 +22,7 @@ public:
     ~LXQtTaskbarWlrootsWindowManagment();
 
     inline bool isShowingDesktop() const { return m_isShowingDesktop; }
+    inline void setShowingDesktop(bool show) { m_isShowingDesktop = show; }
 
 protected:
     void zwlr_foreign_toplevel_manager_v1_toplevel(struct ::zwlr_foreign_toplevel_handle_v1 *toplevel);

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -98,6 +98,9 @@ private:
     WId activeWindow = 0;
     std::vector<WId> windows;
 
+    // for showing desktop
+    std::vector<WId> showDesktopWins;
+
     // key=transient child, value=leader
     QHash<WId, WId> transients;
 };


### PR DESCRIPTION
This logic is followed:

 * On showing desktop, all of the currently handled windows are minimized.
 * On restoring windows, only those windows that were minimized by showing desktop are restored, i.e., if a window is minimized *before or after* showing desktop, it won't be restored.
 * On restoring windows, the previously focused window is focused again (if still existing).
 * If all windows that were minimized on showing desktop are unminimized or closed by the user, clicking the widget will show desktop again.

I didn't find a reliable way of restoring the order of the windows — `lastActivated` didn't work well after restoring windows.