### PR TITLE
Restore Z-order on toggling desktop-showing with wlroots

### DIFF
--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
@@ -352,7 +352,7 @@ void LXQtTaskbarWlrootsWindow::zwlr_foreign_toplevel_handle_v1_state(wl_array *s
 
         case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED: {
             m_pendingState.activated = true;
-            m_pendingState.minimized = false;; // an active window isn't minimized
+            m_pendingState.minimized = false; // an active window isn't minimized
             break;
         }
 

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -88,13 +88,14 @@ private:
     WId findWindow(WId tgt) const;
     WId findTopParent(WId winId) const;
     bool equalIds(WId windowId1, WId windowId2) const;
+    void setLastActivated(WId id);
 
     /** Convert WId (i.e. quintptr into LXQtTaskbarWlrootsWindow*) */
     LXQtTaskbarWlrootsWindow *getWindow(WId windowId) const;
 
     std::unique_ptr<LXQtTaskbarWlrootsWindowManagment> m_managment;
 
-    QHash<WId, QTime> lastActivated;
+    QHash<WId, qint64> lastActivated;
     WId activeWindow = 0;
     std::vector<WId> windows;
 


### PR DESCRIPTION
The Z-order (= overlapping order in stacking WMs) is restored based on the activation time. For that, the one-millisecond limitation should be circumvented because multiple windows may be unminimized and activated by the code in less than that interval.