### PR TITLE
Workaround for kwin_wayland's problems in showing desktop

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqttaskbarplasmawindowmanagment.h
+++ b/panel/backends/wayland/kwin_wayland/lxqttaskbarplasmawindowmanagment.h
@@ -115,6 +115,7 @@ public:
     ~LXQtTaskBarPlasmaWindowManagment();
 
     inline bool isShowingDesktop() const { return m_isShowingDesktop; }
+    inline void setShowingDesktop(bool show) { m_isShowingDesktop = show; }
 
 protected:
     void org_kde_plasma_window_management_show_desktop_changed(uint32_t state) override;

--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.h
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.h
@@ -104,6 +104,7 @@ private:
     void addWindow(LXQtTaskBarPlasmaWindow *window);
     bool acceptWindow(LXQtTaskBarPlasmaWindow *window) const;
     void updateWindowAcceptance(LXQtTaskBarPlasmaWindow *window);
+    void setLastActivated(WId id);
 
 private:
     LXQtTaskBarPlasmaWindow *getWindow(WId windowId) const;
@@ -112,13 +113,16 @@ private:
 
     std::unique_ptr<LXQtTaskBarPlasmaWindowManagment> m_managment;
 
-    QHash<LXQtTaskBarPlasmaWindow *, QTime> lastActivated;
+    QHash<WId, qint64> lastActivated;
     LXQtTaskBarPlasmaWindow *activeWindow = nullptr;
     std::vector<std::unique_ptr<LXQtTaskBarPlasmaWindow>> windows;
     // key=transient child, value=leader
     QHash<LXQtTaskBarPlasmaWindow *, LXQtTaskBarPlasmaWindow *> transients;
     // key=leader, values=transient children
     QMultiHash<LXQtTaskBarPlasmaWindow *, LXQtTaskBarPlasmaWindow *> transientsDemandingAttention;
+
+    // for showing desktop
+    std::vector<WId> showDesktopWins;
 };
 
 class LXQtWMBackendKWinWaylandLibrary: public QObject, public ILXQtWMBackendLibrary


### PR DESCRIPTION
At least there were two problems in KWin's handling of showing desktop: it didn't minimize pcmanfm-qt's windows, and it minimized what it shouldn't, e.g., the windows on the bottom layer or Conky.

Here I circumvented KWin's handling of showing desktop by doing it directly, as I did for the wlroots backend but with small changes. One good thing about KWin is that it doesn't automatically focus a window on unminimizing it. So, the implementation got even better, IMO.

NOTE: kwin_x11 has had exactly the same problems for a long time, but I'm not motivated to log into X11 and make a workaround there — at least not for now ;)