### PR TITLE
Wayfire backend

### DIFF
--- a/panel/backends/ilxqtabstractwmiface.h
+++ b/panel/backends/ilxqtabstractwmiface.h
@@ -76,7 +76,7 @@ public:
     // Workspaces
     // NOTE: indexes are 1-based, 0 means "Show on All desktops"
     virtual int getWorkspacesCount() const = 0;
-    virtual QString getWorkspaceName(int idx) const = 0;
+    virtual QString getWorkspaceName(int idx, QString outputName = QString()) const = 0;
 
     virtual int getCurrentWorkspace() const = 0;
     virtual bool setCurrentWorkspace(int idx) = 0;
@@ -121,7 +121,7 @@ signals:
     // Workspaces
     void workspacesCountChanged();
     void workspaceNameChanged(int idx);
-    void currentWorkspaceChanged(int idx);
+    void currentWorkspaceChanged(int idx, QString outputName = QString());
 
     // TODO: needed?
     void activeWindowChanged(WId windowId);

--- a/panel/backends/lxqtdummywmbackend.cpp
+++ b/panel/backends/lxqtdummywmbackend.cpp
@@ -122,7 +122,7 @@ int LXQtDummyWMBackend::getWorkspacesCount() const
     return 1; // Fake 1 workspace
 }
 
-QString LXQtDummyWMBackend::getWorkspaceName(int) const
+QString LXQtDummyWMBackend::getWorkspaceName(int, QString) const
 {
     return QString();
 }
@@ -199,4 +199,3 @@ bool LXQtDummyWMBackend::showDesktop(bool)
 {
     return false;
 }
-

--- a/panel/backends/lxqtdummywmbackend.h
+++ b/panel/backends/lxqtdummywmbackend.h
@@ -69,7 +69,7 @@ public:
 
     // Workspaces
     int getWorkspacesCount() const override;
-    QString getWorkspaceName(int idx) const override;
+    QString getWorkspaceName(int idx, QString outputName = QString()) const override;
 
     int getCurrentWorkspace() const override;
     bool setCurrentWorkspace(int idx) override;

--- a/panel/backends/wayland/CMakeLists.txt
+++ b/panel/backends/wayland/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(kwin_wayland)
 add_subdirectory(wlroots)
+add_subdirectory(wayfire)

--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -377,7 +377,7 @@ int LXQtWMBackend_KWinWayland::getWorkspacesCount() const
     return m_workspaceInfo->numberOfDesktops();
 }
 
-QString LXQtWMBackend_KWinWayland::getWorkspaceName(int idx) const
+QString LXQtWMBackend_KWinWayland::getWorkspaceName(int idx, QString) const
 {
     return m_workspaceInfo->getDesktopName(idx - 1); //Return to 0-based
 }

--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.h
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.h
@@ -73,7 +73,7 @@ public:
 
     // Workspaces
     virtual int getWorkspacesCount() const override;
-    virtual QString getWorkspaceName(int idx) const override;
+    virtual QString getWorkspaceName(int idx, QString sceenName = QString()) const override;
 
     virtual int getCurrentWorkspace() const override;
     virtual bool setCurrentWorkspace(int idx) override;

--- a/panel/backends/wayland/wayfire/CMakeLists.txt
+++ b/panel/backends/wayland/wayfire/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(PLATFORM_NAME wayfire)
+
+set(PREFIX_NAME wmbackend)
+set(PROGRAM "lxqt-panel")
+set(BACKEND "backend")
+set(NAME ${PREFIX_NAME}_${PLATFORM_NAME})
+project(${PROGRAM}_${BACKEND}_${NAME})
+
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS WaylandClient Concurrent)
+find_package(Qt6Xdg)
+
+set(PROG_SHARE_DIR ${CMAKE_INSTALL_FULL_DATAROOTDIR}/lxqt/${PROGRAM}/${BACKEND})
+set(PLUGIN_SHARE_DIR ${PROG_SHARE_DIR}/${BACKEND}/${NAME})
+#************************************************
+
+if (NOT DEFINED PLUGIN_DIR)
+    set (PLUGIN_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/${PROGRAM})
+endif (NOT DEFINED PLUGIN_DIR)
+
+set(QTX_LIBRARIES Qt6::Gui Qt6::GuiPrivate)
+
+set(
+    SRC
+    wayfire-common.cpp wayfire-common.h
+    lxqtwmbackend_wf.cpp lxqtwmbackend_wf.h
+)
+
+add_library(${NAME} MODULE ${SRC}) # build dynamically loadable modules
+install(TARGETS ${NAME} DESTINATION ${PLUGIN_DIR}/${BACKEND}) # install the *.so file
+
+target_link_libraries(${NAME} ${QTX_LIBRARIES} Qt6::Concurrent Qt6::WaylandClient Qt6Xdg)
+
+# qt6_generate_wayland_protocol_client_sources(${NAME} FILES
+#     ${CMAKE_CURRENT_SOURCE_DIR}/wlr-foreign-toplevel-management-unstable-v1.xml
+# )

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
@@ -652,7 +652,14 @@ QString LXQtTaskbarWayfireBackend::getWorkspaceName(int x, QString outputName) c
 
 int LXQtTaskbarWayfireBackend::getCurrentWorkspace() const
 {
-    return 1;
+    QJsonObject outputInfo = mWayfire.getOutputInfo( mWayfire.getActiveOutput() );
+    QJsonObject outputWS   = outputInfo[QSL("workspace")].toObject();
+
+    int nCols  = outputWS[QSL("grid_width")].toInt();  // Total columns in workspace grid
+    int curRow = outputWS[QSL("y")].toInt(); // Current workspace row (0-based)
+    int curCol = outputWS[QSL("x")].toInt(); // Current workspace column (0-based)
+
+    return curRow * nCols + curCol + 1;
 }
 
 bool LXQtTaskbarWayfireBackend::setCurrentWorkspace(int x)

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
@@ -175,8 +175,10 @@ QIcon getIconForAppId(QString mAppId)
 LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
     ILXQtAbstractWMInterface(parent)
 {
+    mWayfire.reset(new LXQt::Panel::Wayfire());
+
     // emit workspaceCountChanged()
-    connect(&mWayfire, &LXQt::Panel::Wayfire::workspaceSetChanged, [this] ( QJsonDocument )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::workspaceSetChanged, [this] ( QJsonDocument )
     {
         // QJsonObject response = respJson.object();
 
@@ -185,46 +187,47 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
 
         // if (output[QStringLiteral("id")].toInt() == mScreenId)
         // {
-        //     mWSetId = wsInfo[QStringLiteral("index")].toInt();
+        // mWSetId = wsInfo[QStringLiteral("index")].toInt();
 
-        //     QJsonObject ws = wsInfo[QStringLiteral("workspace")].toObject();
-        //     mWS.row    = ws[QStringLiteral("y")].toInt();
-        //     mWS.column = ws[QStringLiteral("x")].toInt();
+        // QJsonObject ws = wsInfo[QStringLiteral("workspace")].toObject();
+        // mWS.row    = ws[QStringLiteral("y")].toInt();
+        // mWS.column = ws[QStringLiteral("x")].toInt();
 
-        //     if ((bool)tasksSett->value(QStringLiteral("ShowCurrentWSetOnly")) == true)
-        //     {
-        //         clearLayout();
-        //         populateLayout();
-        //     }
+        // if ((bool)tasksSett->value(QStringLiteral("ShowCurrentWSetOnly")) == true)
+        // {
+        // clearLayout();
+        // populateLayout();
+        // }
         // }
     });
 
     // emit currentWorkspaceChanged(idx)
-    connect(&mWayfire, &LXQt::Panel::Wayfire::workspaceChanged, [this] ( QJsonDocument )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::workspaceChanged, [this] ( QJsonDocument )
     {
         // QJsonObject response = respJson.object();
 
         // QJsonObject wsInfo = response[QStringLiteral("new-workspace")].toObject();
         // QJsonObject output = response[QStringLiteral("output-data")].toObject();
 
-        // /** Same output and wset */
+        ///** Same output and wset */
         // QJsonObject wset = response[QStringLiteral("wset-data")].toObject();
 
-        // if ((output[QStringLiteral("id")].toInt() == mScreenId) && (wset[QStringLiteral("index")].toInt() == mWSetId))
+        // if ((output[QStringLiteral("id")].toInt() == mScreenId) && (wset[QStringLiteral("index")].toInt()
+        // == mWSetId))
         // {
-        //     mWS.row    = wsInfo[QStringLiteral("y")].toInt();
-        //     mWS.column = wsInfo[QStringLiteral("x")].toInt();
+        // mWS.row    = wsInfo[QStringLiteral("y")].toInt();
+        // mWS.column = wsInfo[QStringLiteral("x")].toInt();
 
-        //     if ((bool)tasksSett->value("ShowCurrentWorkspaceOnly") == true)
-        //     {
-        //         clearLayout();
-        //         populateLayout();
-        //     }
+        // if ((bool)tasksSett->value("ShowCurrentWorkspaceOnly") == true)
+        // {
+        // clearLayout();
+        // populateLayout();
+        // }
         // }
     });
 
     // emit windowAdded(WId)
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewMapped, [this] ( QJsonDocument respJson )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewMapped, [this] ( QJsonDocument respJson )
     {
         QJsonObject response = respJson.object();
 
@@ -248,17 +251,17 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
     });
 
     // emit windowPropertyChanged(WId, state) for all windows
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewFocused, [this] ( QJsonDocument )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewFocused, [this] ( QJsonDocument )
     {
         for ( WaylandId viewId : mViews.keys())
         {
             emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::State);
         }
 
-        emit activeWindowChanged(mWayfire.getActiveView());
+        emit activeWindowChanged(mWayfire->getActiveView());
     });
 
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewTitleChanged, [this] ( QJsonDocument respJson )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewTitleChanged, [this] ( QJsonDocument respJson )
     {
         QJsonObject response = respJson.object();
         QJsonObject view     = response[QStringLiteral("view")].toObject();
@@ -273,7 +276,7 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
         emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Title);
     });
 
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewAppIdChanged, [this] ( QJsonDocument respJson )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewAppIdChanged, [this] ( QJsonDocument respJson )
     {
         QJsonObject response = respJson.object();
         QJsonObject view     = response[QStringLiteral("view")].toObject();
@@ -289,12 +292,12 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
         emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Icon);
     });
 
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewOutputChanged, [this] ( QJsonDocument )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewOutputChanged, [this] ( QJsonDocument )
     {
         // no-op
     });
 
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewWorkspaceChanged, [this] ( QJsonDocument respJson )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewWorkspaceChanged, [this] ( QJsonDocument respJson )
     {
         QJsonObject response = respJson.object();
         QJsonObject view     = response[QStringLiteral("view")].toObject();
@@ -309,7 +312,7 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
         emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Workspace);
     });
 
-    connect(&mWayfire, &LXQt::Panel::Wayfire::viewUnmapped, [this] ( QJsonDocument respJson )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::viewUnmapped, [this] ( QJsonDocument respJson )
     {
         QJsonObject response = respJson.object();
         QJsonObject view     = response[QStringLiteral("view")].toObject();
@@ -323,6 +326,8 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
 
         emit windowRemoved(viewId);
     });
+
+    mWayfire->connectToServer();
 }
 
 bool LXQtTaskbarWayfireBackend::supportsAction(WId, LXQtTaskBarBackendAction action) const
@@ -380,7 +385,7 @@ bool LXQtTaskbarWayfireBackend::reloadWindows()
         emit windowRemoved(windowId);
     }
 
-    QJsonArray views = mWayfire.listViews();
+    QJsonArray views = mWayfire->listViews();
     while (views.count())
     {
         QJsonObject view = views.takeAt(0).toObject();
@@ -514,25 +519,25 @@ bool LXQtTaskbarWayfireBackend::setWindowState(WId windowId, LXQtTaskBarWindowSt
     {
       case LXQtTaskBarWindowState::Minimized:
     {
-        mWayfire.minimizeView(viewId, set);
+        mWayfire->minimizeView(viewId, set);
         break;
     }
 
       case LXQtTaskBarWindowState::Maximized:
     {
-        mWayfire.maximizeView(viewId, (set ? 15 : 0));
+        mWayfire->maximizeView(viewId, (set ? 15 : 0));
         break;
     }
 
       case LXQtTaskBarWindowState::MaximizedVertically:
     {
-        mWayfire.maximizeView(viewId, (set ? 3 : 0));
+        mWayfire->maximizeView(viewId, (set ? 3 : 0));
         break;
     }
 
       case LXQtTaskBarWindowState::MaximizedHorizontally:
     {
-        mWayfire.maximizeView(viewId, (set ? 12 : 0));
+        mWayfire->maximizeView(viewId, (set ? 12 : 0));
         break;
     }
 
@@ -540,7 +545,7 @@ bool LXQtTaskbarWayfireBackend::setWindowState(WId windowId, LXQtTaskBarWindowSt
     {
         if (set)
         {
-            mWayfire.restoreView(viewId);
+            mWayfire->restoreView(viewId);
         }
 
         break;
@@ -548,7 +553,7 @@ bool LXQtTaskbarWayfireBackend::setWindowState(WId windowId, LXQtTaskBarWindowSt
 
       case LXQtTaskBarWindowState::FullScreen:
     {
-        mWayfire.fullscreenView(viewId, set);
+        mWayfire->fullscreenView(viewId, set);
         break;
     }
 
@@ -567,7 +572,7 @@ bool LXQtTaskbarWayfireBackend::isWindowActive(WId windowId) const
         return false;
     }
 
-    return (mWayfire.getActiveView() == viewId);
+    return (mWayfire->getActiveView() == viewId);
 }
 
 bool LXQtTaskbarWayfireBackend::raiseWindow(WId windowId, bool onCurrentWorkSpace)
@@ -580,7 +585,7 @@ bool LXQtTaskbarWayfireBackend::raiseWindow(WId windowId, bool onCurrentWorkSpac
         return false;
     }
 
-    return mWayfire.focusView(viewId);
+    return mWayfire->focusView(viewId);
 }
 
 bool LXQtTaskbarWayfireBackend::closeWindow(WId windowId)
@@ -591,22 +596,22 @@ bool LXQtTaskbarWayfireBackend::closeWindow(WId windowId)
         return false;
     }
 
-    return mWayfire.closeView(viewId);
+    return mWayfire->closeView(viewId);
 }
 
 WId LXQtTaskbarWayfireBackend::getActiveWindow() const
 {
-    return mWayfire.getActiveView();
+    return mWayfire->getActiveView();
 }
 
 int LXQtTaskbarWayfireBackend::getWorkspacesCount() const
 {
-    return 1;
+    return 4;
 }
 
 QString LXQtTaskbarWayfireBackend::getWorkspaceName(int x) const
 {
-    QJsonObject nameObj = mWayfire.getWorkspaceName(x);
+    QJsonObject nameObj = mWayfire->getWorkspaceName(x);
 
     return nameObj[QStringLiteral("value")].toString();
 }
@@ -689,13 +694,13 @@ bool LXQtTaskbarWayfireBackend::showDesktop(bool yes)
 
     mIsDesktopShowing = yes;
 
-    return mWayfire.showDesktop(mWayfire.getActiveOutput());
+    return mWayfire->showDesktop(mWayfire->getActiveOutput());
 }
 
 int LXQtWMBackendWayfireLibrary::getBackendScore(const QString& key) const
 {
     // Only wayfire is supported
-    if (key == QStringLiteral("wayfire"))
+    if ((key == QStringLiteral("wayfire")) || (key == QStringLiteral("Wayfire")))
     {
         return 100;
     }

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
@@ -1,0 +1,710 @@
+#include "wayfire-common.h"
+#include "lxqtwmbackend_wf.h"
+
+#include <QIcon>
+#include <QTime>
+#include <QScreen>
+#include <algorithm>
+
+QString U8Str(const char *str)
+{
+    return QString::fromUtf8(str);
+}
+
+static inline QString getPixmapIcon(QString name)
+{
+    QStringList paths{
+        U8Str("/usr/local/share/pixmaps/"),
+        U8Str("/usr/share/pixmaps/"),
+    };
+
+    QStringList sfxs{
+        U8Str(".svg"), U8Str(".png"), U8Str(".xpm")
+    };
+
+    for (QString path : paths)
+    {
+        for (QString sfx : sfxs)
+        {
+            if (QFile::exists(path + name + sfx))
+            {
+                return path + name + sfx;
+            }
+        }
+    }
+
+    return QString();
+}
+
+QIcon getIconForAppId(QString mAppId)
+{
+    if (mAppId.isEmpty() or (mAppId == U8Str("Unknown")))
+    {
+        return QIcon();
+    }
+
+    /** Wine apps */
+    if (mAppId.endsWith(U8Str(".exe")))
+    {
+        return QIcon::fromTheme(U8Str("wine"));
+    }
+
+    /** Check if a theme icon exists called @mAppId */
+    if (QIcon::hasThemeIcon(mAppId))
+    {
+        return QIcon::fromTheme(mAppId);
+    }
+    /** Check if the theme icon is @mAppId, but all lower-case letters */
+    else if (QIcon::hasThemeIcon(mAppId.toLower()))
+    {
+        return QIcon::fromTheme(mAppId.toLower());
+    }
+
+    QStringList appDirs = {
+        QDir::home().filePath(U8Str(".local/share/applications/")),
+        U8Str("/usr/local/share/applications/"),
+        U8Str("/usr/share/applications/"),
+    };
+
+    /**
+     * Assume mAppId == desktop-file-name (ideal situation) or mAppId.toLower() == desktop-file-name (cheap
+     * fallback)
+     */
+    QString iconName;
+
+    for (QString path : appDirs)
+    {
+        /** Get the icon name from desktop (mAppId: as it is) */
+        if (QFile::exists(path + mAppId + U8Str(".desktop")))
+        {
+            QSettings desktop(path + mAppId + U8Str(".desktop"), QSettings::IniFormat);
+            iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+        }
+        /** Get the icon name from desktop (mAppId: all lower-case letters) */
+        else if (QFile::exists(path + mAppId.toLower() + U8Str(".desktop")))
+        {
+            QSettings desktop(path + mAppId.toLower() + U8Str(".desktop"), QSettings::IniFormat);
+            iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+        }
+
+        /** No icon specified: try else-where */
+        if (iconName.isEmpty())
+        {
+            continue;
+        }
+
+        /** We got an iconName, and it's in the current theme */
+        if (QIcon::hasThemeIcon(iconName))
+        {
+            return QIcon::fromTheme(iconName);
+        }
+        /** Not a theme icon, but an absolute path */
+        else if (QFile::exists(iconName))
+        {
+            return QIcon(iconName);
+        }
+        /** Not theme icon or absolute path. So check /usr/share/pixmaps/ */
+        else
+        {
+            iconName = getPixmapIcon(iconName);
+
+            if (not iconName.isEmpty())
+            {
+                return QIcon(iconName);
+            }
+        }
+    }
+
+    /* Check all desktop files for @mAppId */
+    for (QString path : appDirs)
+    {
+        QStringList desktops = QDir(path).entryList({U8Str("*.desktop")});
+        for (QString dskf : desktops)
+        {
+            QSettings desktop(path + dskf, QSettings::IniFormat);
+
+            QString exec = desktop.value(U8Str("Desktop Entry/Exec"), U8Str("abcd1234/-")).toString();
+            QString name = desktop.value(U8Str("Desktop Entry/Name"), U8Str("abcd1234/-")).toString();
+            QString cls  = desktop.value(U8Str("Desktop Entry/StartupWMClass"),
+                U8Str("abcd1234/-")).toString();
+
+            QString execPath = U8Str(std::filesystem::path(exec.toStdString()).filename().c_str());
+
+            if (mAppId.compare(execPath, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            } else if (mAppId.compare(name, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            } else if (mAppId.compare(cls, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            }
+
+            if (not iconName.isEmpty())
+            {
+                if (QIcon::hasThemeIcon(iconName))
+                {
+                    return QIcon::fromTheme(iconName);
+                } else if (QFile::exists(iconName))
+                {
+                    return QIcon(iconName);
+                } else
+                {
+                    iconName = getPixmapIcon(iconName);
+
+                    if (not iconName.isEmpty())
+                    {
+                        return QIcon(iconName);
+                    }
+                }
+            }
+        }
+    }
+
+    iconName = getPixmapIcon(iconName);
+
+    if (not iconName.isEmpty())
+    {
+        return QIcon(iconName);
+    }
+
+    return QIcon();
+}
+
+LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
+    ILXQtAbstractWMInterface(parent)
+{
+    // emit workspaceCountChanged()
+    connect(&mWayfire, &LXQt::Panel::Wayfire::workspaceSetChanged, [this] ( QJsonDocument )
+    {
+        // QJsonObject response = respJson.object();
+
+        // QJsonObject wsInfo = response[QStringLiteral("new-wset-data")].toObject();
+        // QJsonObject output = response[QStringLiteral("output-data")].toObject();
+
+        // if (output[QStringLiteral("id")].toInt() == mScreenId)
+        // {
+        //     mWSetId = wsInfo[QStringLiteral("index")].toInt();
+
+        //     QJsonObject ws = wsInfo[QStringLiteral("workspace")].toObject();
+        //     mWS.row    = ws[QStringLiteral("y")].toInt();
+        //     mWS.column = ws[QStringLiteral("x")].toInt();
+
+        //     if ((bool)tasksSett->value(QStringLiteral("ShowCurrentWSetOnly")) == true)
+        //     {
+        //         clearLayout();
+        //         populateLayout();
+        //     }
+        // }
+    });
+
+    // emit currentWorkspaceChanged(idx)
+    connect(&mWayfire, &LXQt::Panel::Wayfire::workspaceChanged, [this] ( QJsonDocument )
+    {
+        // QJsonObject response = respJson.object();
+
+        // QJsonObject wsInfo = response[QStringLiteral("new-workspace")].toObject();
+        // QJsonObject output = response[QStringLiteral("output-data")].toObject();
+
+        // /** Same output and wset */
+        // QJsonObject wset = response[QStringLiteral("wset-data")].toObject();
+
+        // if ((output[QStringLiteral("id")].toInt() == mScreenId) && (wset[QStringLiteral("index")].toInt() == mWSetId))
+        // {
+        //     mWS.row    = wsInfo[QStringLiteral("y")].toInt();
+        //     mWS.column = wsInfo[QStringLiteral("x")].toInt();
+
+        //     if ((bool)tasksSett->value("ShowCurrentWorkspaceOnly") == true)
+        //     {
+        //         clearLayout();
+        //         populateLayout();
+        //     }
+        // }
+    });
+
+    // emit windowAdded(WId)
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewMapped, [this] ( QJsonDocument respJson )
+    {
+        QJsonObject response = respJson.object();
+
+        QJsonObject view = response[QStringLiteral("view")].toObject();
+
+        /** Ghost view: these are unmapped xwayland views */
+        if (view[QStringLiteral("pid")].toInt() == -1)
+        {
+            return;
+        }
+
+        /** We want only the "toplevel" views */
+        QString role = view[QStringLiteral("role")].toString();
+
+        if (role != QStringLiteral("toplevel"))
+        {
+            return;
+        }
+
+        emit windowAdded(view[QStringLiteral("id")].toInt());
+    });
+
+    // emit windowPropertyChanged(WId, state) for all windows
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewFocused, [this] ( QJsonDocument )
+    {
+        for ( WaylandId viewId : mViews.keys())
+        {
+            emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::State);
+        }
+
+        emit activeWindowChanged(mWayfire.getActiveView());
+    });
+
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewTitleChanged, [this] ( QJsonDocument respJson )
+    {
+        QJsonObject response = respJson.object();
+        QJsonObject view     = response[QStringLiteral("view")].toObject();
+
+        if (view.empty())
+        {
+            return;
+        }
+
+        int64_t viewId = view[QStringLiteral("id")].toInt();
+
+        emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Title);
+    });
+
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewAppIdChanged, [this] ( QJsonDocument respJson )
+    {
+        QJsonObject response = respJson.object();
+        QJsonObject view     = response[QStringLiteral("view")].toObject();
+
+        if (view.empty())
+        {
+            return;
+        }
+
+        int64_t viewId = view[QStringLiteral("id")].toInt();
+
+        emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::WindowClass);
+        emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Icon);
+    });
+
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewOutputChanged, [this] ( QJsonDocument )
+    {
+        // no-op
+    });
+
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewWorkspaceChanged, [this] ( QJsonDocument respJson )
+    {
+        QJsonObject response = respJson.object();
+        QJsonObject view     = response[QStringLiteral("view")].toObject();
+
+        if (view.empty())
+        {
+            return;
+        }
+
+        int64_t viewId = view[QStringLiteral("id")].toInt();
+
+        emit windowPropertyChanged(viewId, (int)LXQtTaskBarWindowProperty::Workspace);
+    });
+
+    connect(&mWayfire, &LXQt::Panel::Wayfire::viewUnmapped, [this] ( QJsonDocument respJson )
+    {
+        QJsonObject response = respJson.object();
+        QJsonObject view     = response[QStringLiteral("view")].toObject();
+
+        if (view.empty())
+        {
+            return;
+        }
+
+        int64_t viewId = view[QStringLiteral("id")].toInt();
+
+        emit windowRemoved(viewId);
+    });
+}
+
+bool LXQtTaskbarWayfireBackend::supportsAction(WId, LXQtTaskBarBackendAction action) const
+{
+    switch (action)
+    {
+      case LXQtTaskBarBackendAction::Move:
+        return true;
+
+      case LXQtTaskBarBackendAction::Resize:
+        return true;
+
+      case LXQtTaskBarBackendAction::Maximize:
+        return true;
+
+      case LXQtTaskBarBackendAction::MaximizeVertically:
+        return true;
+
+      case LXQtTaskBarBackendAction::MaximizeHorizontally:
+        return true;
+
+      case LXQtTaskBarBackendAction::Minimize:
+        return true;
+
+      case LXQtTaskBarBackendAction::RollUp:
+        return false;
+
+      case LXQtTaskBarBackendAction::FullScreen:
+        return true;
+
+      case LXQtTaskBarBackendAction::DesktopSwitch:
+        return true;
+
+      case LXQtTaskBarBackendAction::MoveToDesktop:
+        return true;
+
+      case LXQtTaskBarBackendAction::MoveToLayer:
+        return true;
+
+      case LXQtTaskBarBackendAction::MoveToOutput:
+        return true;
+
+      default:
+        return false;
+    }
+
+    return false;
+}
+
+bool LXQtTaskbarWayfireBackend::reloadWindows()
+{
+    // Force removal and re-adding
+    for (WId windowId : mViews.keys())
+    {
+        emit windowRemoved(windowId);
+    }
+
+    QJsonArray views = mWayfire.listViews();
+    while (views.count())
+    {
+        QJsonObject view = views.takeAt(0).toObject();
+        WaylandId id(view[QStringLiteral("id")].toInt());
+
+        mViews[id] = view;
+    }
+
+    for (WId windowId : mViews.keys())
+    {
+        emit windowAdded(windowId);
+    }
+
+    return true;
+}
+
+QVector<WId> LXQtTaskbarWayfireBackend::getCurrentWindows() const
+{
+    QVector<WId> ids;
+    for ( WaylandId viewId : mViews.keys())
+    {
+        ids << viewId;
+    }
+
+    return ids;
+}
+
+QString LXQtTaskbarWayfireBackend::getWindowTitle(WId windowId) const
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return QString();
+    }
+
+    return mViews[viewId][QStringLiteral("title")].toString();
+}
+
+bool LXQtTaskbarWayfireBackend::applicationDemandsAttention(WId) const
+{
+    return false;
+}
+
+QIcon LXQtTaskbarWayfireBackend::getApplicationIcon(WId windowId, int devicePixels) const
+{
+    Q_UNUSED(devicePixels)
+
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return QIcon();
+    }
+
+    return getIconForAppId(mViews[viewId][QStringLiteral("app-id")].toString());
+}
+
+QString LXQtTaskbarWayfireBackend::getWindowClass(WId windowId) const
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return QString();
+    }
+
+    return mViews[viewId][QStringLiteral("app-id")].toString();
+}
+
+LXQtTaskBarWindowLayer LXQtTaskbarWayfireBackend::getWindowLayer(WId) const
+{
+    return LXQtTaskBarWindowLayer::Normal;
+}
+
+bool LXQtTaskbarWayfireBackend::setWindowLayer(WId, LXQtTaskBarWindowLayer)
+{
+    return false;
+}
+
+LXQtTaskBarWindowState LXQtTaskbarWayfireBackend::getWindowState(WId windowId) const
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return LXQtTaskBarWindowState::Minimized;
+    }
+
+    if (mViews[viewId][QStringLiteral("mapped")].toBool())
+    {
+        return LXQtTaskBarWindowState::Hidden;
+    }
+
+    if (mViews[viewId][QStringLiteral("minimized")].toBool())
+    {
+        return LXQtTaskBarWindowState::Minimized;
+    }
+
+    if (mViews[viewId][QStringLiteral("fullscreen")].toBool())
+    {
+        return LXQtTaskBarWindowState::FullScreen;
+    }
+
+    // WLR_EDGE_TOP | WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT == 1 | 2 | 4 | 8 == 15
+    if (mViews[viewId][QStringLiteral("tiled")].toInt() == 15)
+    {
+        return LXQtTaskBarWindowState::Maximized;
+    }
+
+    // WLR_EDGE_TOP | WLR_EDGE_BOTTOM == 1 | 2 == 3
+    if (mViews[viewId][QStringLiteral("tiled")].toInt() == 3)
+    {
+        return LXQtTaskBarWindowState::MaximizedVertically;
+    }
+
+    // WLR_EDGE_LEFT | WLR_EDGE_RIGHT == 4 | 8 == 12
+    if (mViews[viewId][QStringLiteral("tiled")].toInt() == 12)
+    {
+        return LXQtTaskBarWindowState::MaximizedHorizontally;
+    }
+
+    return LXQtTaskBarWindowState::Normal;
+}
+
+bool LXQtTaskbarWayfireBackend::setWindowState(WId windowId, LXQtTaskBarWindowState state, bool set)
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return false;
+    }
+
+    switch (state)
+    {
+      case LXQtTaskBarWindowState::Minimized:
+    {
+        mWayfire.minimizeView(viewId, set);
+        break;
+    }
+
+      case LXQtTaskBarWindowState::Maximized:
+    {
+        mWayfire.maximizeView(viewId, (set ? 15 : 0));
+        break;
+    }
+
+      case LXQtTaskBarWindowState::MaximizedVertically:
+    {
+        mWayfire.maximizeView(viewId, (set ? 3 : 0));
+        break;
+    }
+
+      case LXQtTaskBarWindowState::MaximizedHorizontally:
+    {
+        mWayfire.maximizeView(viewId, (set ? 12 : 0));
+        break;
+    }
+
+      case LXQtTaskBarWindowState::Normal:
+    {
+        if (set)
+        {
+            mWayfire.restoreView(viewId);
+        }
+
+        break;
+    }
+
+      case LXQtTaskBarWindowState::FullScreen:
+    {
+        mWayfire.fullscreenView(viewId, set);
+        break;
+    }
+
+      default:
+        return false;
+    }
+
+    return true;
+}
+
+bool LXQtTaskbarWayfireBackend::isWindowActive(WId windowId) const
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return false;
+    }
+
+    return (mWayfire.getActiveView() == viewId);
+}
+
+bool LXQtTaskbarWayfireBackend::raiseWindow(WId windowId, bool onCurrentWorkSpace)
+{
+    Q_UNUSED(onCurrentWorkSpace) // Cannot be done on a generic wlroots-based compositor!
+
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return false;
+    }
+
+    return mWayfire.focusView(viewId);
+}
+
+bool LXQtTaskbarWayfireBackend::closeWindow(WId windowId)
+{
+    WaylandId viewId(windowId);
+    if (!mViews.contains(viewId))
+    {
+        return false;
+    }
+
+    return mWayfire.closeView(viewId);
+}
+
+WId LXQtTaskbarWayfireBackend::getActiveWindow() const
+{
+    return mWayfire.getActiveView();
+}
+
+int LXQtTaskbarWayfireBackend::getWorkspacesCount() const
+{
+    return 1;
+}
+
+QString LXQtTaskbarWayfireBackend::getWorkspaceName(int x) const
+{
+    QJsonObject nameObj = mWayfire.getWorkspaceName(x);
+
+    return nameObj[QStringLiteral("value")].toString();
+}
+
+int LXQtTaskbarWayfireBackend::getCurrentWorkspace() const
+{
+    return 1;
+}
+
+bool LXQtTaskbarWayfireBackend::setCurrentWorkspace(int)
+{
+    return false;
+}
+
+int LXQtTaskbarWayfireBackend::getWindowWorkspace(WId) const
+{
+    return 1;
+}
+
+bool LXQtTaskbarWayfireBackend::setWindowOnWorkspace(WId, int)
+{
+    return true;
+}
+
+void LXQtTaskbarWayfireBackend::moveApplicationToPrevNextMonitor(WId viewId, bool nextOp, bool raiseWindow)
+{
+    Q_UNUSED(viewId)
+    Q_UNUSED(nextOp)
+    Q_UNUSED(raiseWindow)
+    // Depends on the wsets plugin
+    // 1. Get the current output id and its active wset-id
+    // 2. Get the previous/next output id and its active wset-id, if any.
+    // 3. If we have a target wset, move the viewId from current wset to target wset
+    // 4. If raiseWindow == true, set view as focused
+}
+
+bool LXQtTaskbarWayfireBackend::isWindowOnScreen(QScreen *scrn, WId windowId) const
+{
+    WaylandId viewId(windowId);
+    return mViews[viewId][QStringLiteral("output")] == scrn->name();
+}
+
+bool LXQtTaskbarWayfireBackend::setDesktopLayout(Qt::Orientation, int, int, bool)
+{
+    // Wayfire does not support dynamic setting of desktops.
+    return false;
+}
+
+void LXQtTaskbarWayfireBackend::moveApplication(WId)
+{
+    // no-op
+}
+
+void LXQtTaskbarWayfireBackend::resizeApplication(WId)
+{
+    // no-op
+}
+
+void LXQtTaskbarWayfireBackend::refreshIconGeometry(WId, const QRect &)
+{
+    // no-op
+}
+
+bool LXQtTaskbarWayfireBackend::isAreaOverlapped(const QRect &) const
+{
+    return false;
+}
+
+bool LXQtTaskbarWayfireBackend::isShowingDesktop() const
+{
+    return mIsDesktopShowing;
+}
+
+bool LXQtTaskbarWayfireBackend::showDesktop(bool yes)
+{
+    if (mIsDesktopShowing == yes)
+    {
+        return true;
+    }
+
+    mIsDesktopShowing = yes;
+
+    return mWayfire.showDesktop(mWayfire.getActiveOutput());
+}
+
+int LXQtWMBackendWayfireLibrary::getBackendScore(const QString& key) const
+{
+    // Only wayfire is supported
+    if (key == QStringLiteral("wayfire"))
+    {
+        return 100;
+    }
+
+    // Unsupported
+    return 0;
+}
+
+ILXQtAbstractWMInterface*LXQtWMBackendWayfireLibrary::instance() const
+{
+    return new LXQtTaskbarWayfireBackend(nullptr);
+}

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "../../ilxqtabstractwmiface.h"
+#include "wayfire-common.h"
+
+#include <QTime>
+#include <QHash>
+#include <vector>
+
+class LXQtTaskbarWayfireWindow;
+class LXQtTaskbarWayfireWindowManagment;
+class LXQtWayfireWaylandWorkspaceInfo;
+
+
+class LXQtTaskbarWayfireBackend : public ILXQtAbstractWMInterface
+{
+    Q_OBJECT
+
+  public:
+    explicit LXQtTaskbarWayfireBackend(QObject *parent = nullptr);
+
+    // Backend
+    virtual bool supportsAction(WId windowId, LXQtTaskBarBackendAction action) const override;
+
+    // Windows
+    virtual bool reloadWindows() override;
+
+    // Get the current windows
+    virtual QVector<WId> getCurrentWindows() const override;
+
+    // Get the window title
+    virtual QString getWindowTitle(WId windowId) const override;
+
+    // We do not support this
+    virtual bool applicationDemandsAttention(WId windowId) const override;
+
+    // Support for this is based on app-id (handled by LXQt)
+    virtual QIcon getApplicationIcon(WId windowId, int devicePixels) const override;
+
+    // Same as app-id
+    virtual QString getWindowClass(WId windowId) const override;
+
+    // Allways-on-Bottom, Normal or Always-on-top.
+    // Always-on-bottom is not available on wayfire
+    virtual LXQtTaskBarWindowLayer getWindowLayer(WId windowId) const override;
+    virtual bool setWindowLayer(WId windowId, LXQtTaskBarWindowLayer layer) override;
+
+    // Hidden, FullScreen, Minimized, Maximized, MaximizedVertical, MaximizedHorizontally, Normal, RolledUp
+    virtual LXQtTaskBarWindowState getWindowState(WId windowId) const override;
+    virtual bool setWindowState(WId windowId, LXQtTaskBarWindowState state, bool set) override;
+
+    // Is window active
+    virtual bool isWindowActive(WId windowId) const override;
+
+    // Set window as active
+    virtual bool raiseWindow(WId windowId, bool onCurrentWorkSpace) override;
+
+    // Close window
+    virtual bool closeWindow(WId windowId) override;
+
+    // Get active window
+    virtual WId getActiveWindow() const override;
+
+    // Workspaces
+    virtual int getWorkspacesCount() const override;
+    virtual QString getWorkspaceName(int idx) const override;
+
+    // Get/Set the current workspace
+    virtual int getCurrentWorkspace() const override;
+    virtual bool setCurrentWorkspace(int idx) override;
+
+    // Get/Set the workspace of a window
+    virtual int getWindowWorkspace(WId windowId) const override;
+    virtual bool setWindowOnWorkspace(WId windowId, int idx) override;
+
+    // Move window to previous/next desktop
+    virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next,
+        bool raiseOnCurrentDesktop) override;
+
+    virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
+
+    // Not supported on wayfire at the moment
+    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft);
+
+    // X11 Specific
+    virtual void moveApplication(WId windowId) override;
+    virtual void resizeApplication(WId windowId) override;
+
+    // ???
+    virtual void refreshIconGeometry(WId windowId, const QRect & geom) override;
+
+    // Panel internal - not supported
+    virtual bool isAreaOverlapped(const QRect& area) const override;
+
+    // Show Desktop
+    virtual bool isShowingDesktop() const override;
+    virtual bool showDesktop(bool value) override;
+
+  private slots:
+    void addWindow(WId wid);
+    void removeWindow();
+    void removeTransient();
+    void onActivatedChanged();
+    void onParentChanged();
+    void onTitleChanged();
+    void onAppIdChanged();
+    void onStateChanged();
+
+  private:
+    void addToWindows(WId winId);
+    bool acceptWindow(WId wid) const;
+    WId findWindow(WId tgt) const;
+    WId findTopParent(WId winId) const;
+    bool equalIds(WId windowId1, WId windowId2) const;
+
+    /** Convert WId (i.e. quintptr into LXQtTaskbarWayfireWindow*) */
+    LXQtTaskbarWayfireWindow *getWindow(WId windowId) const;
+
+    // std::unique_ptr<LXQtTaskbarWayfireWindowManagment> mManagment;
+    LXQt::Panel::Wayfire mWayfire;
+
+    // Hash-map of view ids, vs their properties
+    QHash<WaylandId, QJsonObject> mViews;
+
+    // key=transient child, value=leader
+    QHash<WaylandId, WaylandId> transients;
+
+
+    // Is Desktop Shown
+    bool mIsDesktopShowing = false;
+};
+
+
+class LXQtWMBackendWayfireLibrary : public QObject, public ILXQtWMBackendLibrary
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "lxqt.org/Panel/WMInterface/1.0")
+    Q_INTERFACES(ILXQtWMBackendLibrary)
+
+  public:
+    int getBackendScore(const QString& key) const override;
+
+    ILXQtAbstractWMInterface * instance() const override;
+};

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
@@ -98,14 +98,13 @@ class LXQtTaskbarWayfireBackend : public ILXQtAbstractWMInterface
 
   private:
     // std::unique_ptr<LXQtTaskbarWayfireWindowManagment> mManagment;
-    QScopedPointer<LXQt::Panel::Wayfire> mWayfire;
+    LXQt::Panel::Wayfire mWayfire;
 
     // Hash-map of view ids, vs their properties
     QHash<WaylandId, QJsonObject> mViews;
 
     // key=transient child, value=leader
     QHash<WaylandId, WaylandId> transients;
-
 
     // Is Desktop Shown
     bool mIsDesktopShowing = false;

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
@@ -96,28 +96,9 @@ class LXQtTaskbarWayfireBackend : public ILXQtAbstractWMInterface
     virtual bool isShowingDesktop() const override;
     virtual bool showDesktop(bool value) override;
 
-  private slots:
-    void addWindow(WId wid);
-    void removeWindow();
-    void removeTransient();
-    void onActivatedChanged();
-    void onParentChanged();
-    void onTitleChanged();
-    void onAppIdChanged();
-    void onStateChanged();
-
   private:
-    void addToWindows(WId winId);
-    bool acceptWindow(WId wid) const;
-    WId findWindow(WId tgt) const;
-    WId findTopParent(WId winId) const;
-    bool equalIds(WId windowId1, WId windowId2) const;
-
-    /** Convert WId (i.e. quintptr into LXQtTaskbarWayfireWindow*) */
-    LXQtTaskbarWayfireWindow *getWindow(WId windowId) const;
-
     // std::unique_ptr<LXQtTaskbarWayfireWindowManagment> mManagment;
-    LXQt::Panel::Wayfire mWayfire;
+    QScopedPointer<LXQt::Panel::Wayfire> mWayfire;
 
     // Hash-map of view ids, vs their properties
     QHash<WaylandId, QJsonObject> mViews;

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
@@ -63,7 +63,7 @@ class LXQtTaskbarWayfireBackend : public ILXQtAbstractWMInterface
 
     // Workspaces
     virtual int getWorkspacesCount() const override;
-    virtual QString getWorkspaceName(int idx) const override;
+    virtual QString getWorkspaceName(int idx, QString outputName = QString()) const override;
 
     // Get/Set the current workspace
     virtual int getCurrentWorkspace() const override;

--- a/panel/backends/wayland/wayfire/wayfire-common.cpp
+++ b/panel/backends/wayland/wayfire/wayfire-common.cpp
@@ -570,11 +570,13 @@ bool LXQt::Panel::Wayfire::maximizeView(WaylandId viewId, int edges) const
 
     // request[QSL("method")] = QSL("wm-actions/set-tiled");
     // request[QSL("data")]   = QJsonObject({
-    // {QSL("view_id"), QJsonValue::fromVariant((quint64)viewId)},
-    // {QSL("edges"), edges}
+    //     {QSL("view_id"), QJsonValue::fromVariant((quint64)viewId)},
+    //     {QSL("view-id"), QJsonValue::fromVariant((quint64)viewId)},
+    //     {QSL("id"), QJsonValue::fromVariant((quint64)viewId)},
+    //     {QSL("edges"), edges}
     // });
 
-    request[QSL("method")] = (edges ? QSL("slot_c") : QSL("restore"));
+    request[QSL("method")] = (edges ? QSL("grid/slot_c") : QSL("grid/restore"));
     request[QSL("data")]   = QJsonObject({
         {QSL("view_id"), QJsonValue::fromVariant((quint64)viewId)},
     });
@@ -620,7 +622,7 @@ bool LXQt::Panel::Wayfire::restoreView(WaylandId viewId) const
     {
         return minimizeView(viewId, false);
     }
-    /** The view is maximized, unmaximize it */
+    /** The view is fullscreened, un-fullscreen it */
     else if (viewInfo[QSL("fullscreen")] == true)
     {
         return fullscreenView(viewId, false);

--- a/panel/backends/wayland/wayfire/wayfire-common.cpp
+++ b/panel/backends/wayland/wayfire/wayfire-common.cpp
@@ -1,0 +1,650 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset https://lxqt.org
+ *
+ * Copyright: 2023 LXQt team Authors:
+ *  Filippo Gentile <filippogentile@disroot.org>
+ *
+ * This program or library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "wayfire-common.h"
+
+// Socket related
+#include <sys/socket.h>
+#include <sys/un.h>
+
+// Other headers
+#include <unistd.h>
+#include <errno.h>
+
+
+LXQt::Panel::WayfireImpl::WayfireImpl() : QRunnable()
+{
+    wfSock.fd = -1;
+}
+
+void LXQt::Panel::WayfireImpl::stop()
+{
+    mTerminate = true;
+
+    if (wfSock.fd != -1)
+    {
+        close(wfSock.fd);
+        wfSock.fd = -1;
+    }
+
+    qApp->processEvents();
+}
+
+uint32_t LXQt::Panel::WayfireImpl::request(QJsonDocument req)
+{
+    QMutexLocker locker(&mutex);
+
+    if (!mConnected)
+    {
+        return 0;
+    }
+
+    writeJson(req);
+
+    // Generate a unique request ID
+    static std::atomic<uint32_t> requestCounter(0);
+    uint32_t reqId = ++requestCounter;
+
+    if (requestCounter == UINT32_MAX)
+    {
+        requestCounter = 1;
+    }
+
+    mPendingRequests << reqId;
+    return reqId;
+}
+
+void LXQt::Panel::WayfireImpl::run()
+{
+    emit started();
+
+    while (true)
+    {
+        int nready = poll(&wfSock, 1, 10);
+
+        /** Something went wrong while polling */
+        if (nready < 0)
+        {
+            qWarning() << "[Error]:" << strerror(errno);
+        }
+
+        /** Bye bye..! */
+        if (mTerminate)
+        {
+            return;
+        }
+
+        /** Nothing to read */
+        if (nready == 0)
+        {
+            continue;
+        }
+
+        /** We have something to read. Let's see what it is. */
+        if (wfSock.revents & (POLLRDNORM | POLLERR))
+        {
+            QJsonDocument resp = readJson();
+
+            /** This is an event */
+            if (resp.isObject() && resp.object().contains(QStringLiteral("event")))
+            {
+                emit wayfireEvent(resp);
+            }
+            /** This is the response to a request */
+            else
+            {
+                // Lock the mutex
+                QMutexLocker locker(&mutex);
+
+                uint32_t reqId = mPendingRequests.takeFirst();
+
+                // Emit signal asynchronously
+                QMetaObject::invokeMethod(this, [this, reqId, resp] ()
+                {
+                    emit response(reqId, resp);
+                }, Qt::QueuedConnection);
+
+                emit response(reqId, resp);
+            }
+        }
+    }
+}
+
+bool LXQt::Panel::WayfireImpl::writeJson(QJsonDocument j)
+{
+    QByteArray str = j.toJson(QJsonDocument::Compact);
+    uint32_t size  = str.size();
+
+    // Write the size of the JSON data
+    ssize_t ret = write(wfSock.fd, &size, sizeof(size));
+
+    if (ret == -1)
+    {
+        // Handle write error
+        qDebug() << "Failed to write size to socket:" << strerror(errno);
+        // throw std::runtime_error("Failed to write size to socket");
+    } else if (ret != sizeof(size))
+    {
+        // Handle partial write
+        qDebug() << "Partial write of size to socket:" << ret << "bytes written, expected" << sizeof(size);
+        // throw std::runtime_error("Partial write of size to socket");
+    }
+
+    // Write the JSON data
+    const char *data     = str.constData();
+    ssize_t bytesWritten = 0;
+
+    while (bytesWritten < str.size())
+    {
+        ret = write(wfSock.fd, data + bytesWritten, str.size() - bytesWritten);
+
+        if (ret == -1)
+        {
+            // Handle write error
+            qDebug() << "Failed to write JSON data to socket:" << strerror(errno);
+            return false;
+        } else if (ret == 0)
+        {
+            // Handle socket closed by peer
+            qDebug() << "Socket closed by peer while writing JSON data";
+            return false;
+        }
+
+        bytesWritten += ret;
+    }
+
+    /** We succeeded in writing the JSON data successfully */
+    return true;
+}
+
+QJsonDocument LXQt::Panel::WayfireImpl::readJson()
+{
+    uint32_t msgSize;
+
+    if (!readExact(reinterpret_cast<char*>(&msgSize), sizeof(msgSize)))
+    {
+        return QJsonDocument();
+    }
+
+    QByteArray buffer(msgSize, Qt::Uninitialized);
+    if (!readExact(buffer.data(), msgSize))
+    {
+        return QJsonDocument();
+    }
+
+    return QJsonDocument::fromJson(buffer);
+}
+
+bool LXQt::Panel::WayfireImpl::readExact(char *buf, uint size)
+{
+    while (size > 0)
+    {
+        int ret = read(wfSock.fd, buf, size);
+
+        if (ret == -1)
+        {
+            qCritical() << "Failed to read from socket: " << strerror(errno);
+            return false;
+        }
+
+        buf  += ret;
+        size -= ret;
+    }
+
+    return true;
+}
+
+// Helper function to create a QJsonDocument from an initializer list
+QJsonDocument createJsonObject(std::initializer_list<std::pair<QString, QJsonValue>> initList)
+{
+    QJsonObject obj;
+
+    for (const auto& pair : initList)
+    {
+        obj.insert(pair.first, pair.second);
+    }
+
+    return QJsonDocument(obj);
+}
+
+LXQt::Panel::Wayfire::Wayfire(QString wfSock) : QObject()
+{
+    impl.reset(new WayfireImpl());
+    impl->wfSockPath = (wfSock.isEmpty() ? qEnvironmentVariable("WAYFIRE_SOCKET") : wfSock);
+
+    /** Always emit this for any wayfire event */
+    connect(impl.data(), &LXQt::Panel::WayfireImpl::wayfireEvent, this, &LXQt::Panel::Wayfire::genericEvent);
+
+    /** Parse the events and emit the correct signal */
+    connect(impl.data(), &LXQt::Panel::WayfireImpl::wayfireEvent, this, &LXQt::Panel::Wayfire::parseEvents);
+}
+
+LXQt::Panel::Wayfire::~Wayfire()
+{
+    impl->stop();
+
+    if (impl->wfSock.fd != -1)
+    {
+        close(impl->wfSock.fd);
+        impl->wfSock.fd = -1;
+    }
+
+    impl.reset(nullptr);
+}
+
+bool LXQt::Panel::Wayfire::connectToServer() const
+{
+    impl->wfSock.fd     = socket(AF_UNIX, SOCK_STREAM, 0);
+    impl->wfSock.events = POLLRDNORM;
+
+    if (impl->wfSock.fd == -1)
+    {
+        qCritical() << "Failed to create socket: " << strerror(errno);
+        return false;
+    }
+
+    struct sockaddr_un addr;
+    addr.sun_family = AF_UNIX,
+
+    strncpy(addr.sun_path, impl->wfSockPath.toUtf8().data(), sizeof(addr.sun_path) - 1);
+    addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
+
+    if (::connect(impl->wfSock.fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+    {
+        qCritical() << "Failed to connect to socket: " << strerror(errno);
+        qCritical() << "Ensure that ipc and ipc-rules plugins are enabled.";
+        qCritical() <<
+            "If these plugins were enabled after starting this session, please restart the session.";
+        close(impl->wfSock.fd);
+        return false;
+    }
+
+    impl->mConnected = true;
+
+    /** Run the impl in a separate thread */
+    QThreadPool::globalInstance()->start(impl.data());
+
+    /** Make a request and forget about it. */
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/events/watch");
+    genericRequest(QJsonDocument(request));
+
+    return true;
+}
+
+QJsonArray LXQt::Panel::Wayfire::listOutputs() const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/list-outputs");
+
+    QJsonDocument response = genericRequest(QJsonDocument(request));
+
+    if (response.isArray())
+    {
+        return response.array();
+    }
+
+    return QJsonArray();
+}
+
+WaylandId LXQt::Panel::Wayfire::getActiveOutput() const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/get-focused-output");
+
+    QJsonObject reply = genericRequest(QJsonDocument(request)).object();
+
+    if (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"))
+    {
+        QJsonObject opInfo = reply[QStringLiteral("info")].toObject();
+        uint32_t opId = opInfo[QStringLiteral("id")].toInt();
+
+        return WaylandId(opId);
+    }
+
+    return WaylandId();
+}
+
+bool LXQt::Panel::Wayfire::focusOutput(WaylandId opId) const
+{
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("oswitch/switch-output");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("output-id"), QJsonValue::fromVariant((quint64)opId)},
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    if (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool LXQt::Panel::Wayfire::showDesktop(WaylandId opId) const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("wm-actions/toggle_showdesktop");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("output_id"), QJsonValue::fromVariant((quint64)opId)},
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+QJsonObject LXQt::Panel::Wayfire::getWorkspaceSetsInfo() const
+{
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/list-wsets");
+
+    return genericRequest(QJsonDocument(request)).object();
+}
+
+QJsonObject LXQt::Panel::Wayfire::getWorkspaceName(int x) const
+{
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("wayfire/get-config-option");
+    request[QStringLiteral("option")] = QStringLiteral("workspace-names/eDP-1_workspace_1");
+
+    QJsonDocument wsNameDoc = genericRequest(QJsonDocument(request));
+
+    qDebug() << wsNameDoc.toJson().constData();
+
+    return wsNameDoc.object();
+}
+
+bool LXQt::Panel::Wayfire::setWorkspaceName(int, QString) const
+{
+    return false;
+}
+
+bool LXQt::Panel::Wayfire::switchToWorkspace(WaylandId opId, int64_t nth) const
+{
+    int64_t row;
+    int64_t col;
+
+    QJsonObject wsetsInfo = getWorkspaceSetsInfo();
+    int64_t nRows = wsetsInfo[ QStringLiteral("grid_height")].toInt();
+    int64_t nCols = wsetsInfo[ QStringLiteral("grid_width")].toInt();
+
+    row = (int)(nth / nRows);
+    col = nth % nCols;
+
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("vswitch/set-workspace");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("output-id"), QJsonValue::fromVariant((quint64)opId)},
+        {QStringLiteral("x"), QJsonValue::fromVariant((quint64)col)},
+        {QStringLiteral("y"), QJsonValue::fromVariant((quint64)row)},
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+QJsonArray LXQt::Panel::Wayfire::listViews() const
+{
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/list-views");
+
+    return genericRequest(QJsonDocument(request)).array();
+}
+
+WaylandId LXQt::Panel::Wayfire::getActiveView() const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/get-focused-view");
+
+    QJsonObject reply = genericRequest(QJsonDocument(request)).object();
+
+    if (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"))
+    {
+        QJsonObject viewInfo = reply[QStringLiteral("info")].toObject();
+        uint32_t viewId = viewInfo[QStringLiteral("id")].toInt();
+
+        return WaylandId(viewId);
+    }
+
+    return WaylandId();
+}
+
+QJsonObject LXQt::Panel::Wayfire::getViewInfo(WaylandId viewId) const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/view-info");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("id"), QJsonValue::fromVariant((quint64)viewId)}
+    });
+
+    QJsonObject reply = genericRequest(QJsonDocument(request)).object();
+
+    if (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"))
+    {
+        return reply[QStringLiteral("info")].toObject();
+    }
+
+    return QJsonObject();
+}
+
+bool LXQt::Panel::Wayfire::focusView(WaylandId viewId) const
+{
+    QJsonObject viewInfo = getViewInfo(viewId);
+
+    if ((viewInfo.isEmpty() == false) && (viewInfo[QStringLiteral("minimized")].toBool() == true))
+    {
+        minimizeView(viewId, false);
+    }
+
+    QJsonObject request;
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/focus-view");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("id"), QJsonValue::fromVariant((quint64)viewId)}
+    });
+
+    QJsonObject reply = genericRequest(QJsonDocument(request)).object();
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+bool LXQt::Panel::Wayfire::minimizeView(WaylandId viewId, bool yes) const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("wm-actions/set-minimized");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("view_id"), QJsonValue::fromVariant((quint64)viewId)}
+    });
+
+    request[QStringLiteral("data")] = QJsonObject({
+        {QStringLiteral("state"), yes}
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    if (reply[QStringLiteral("result")] != QStringLiteral("ok"))
+    {
+        qDebug() << QJsonDocument(reply).toJson().data() << "\n";
+    }
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+bool LXQt::Panel::Wayfire::maximizeView(WaylandId viewId, int edges) const
+{
+    QJsonObject viewInfo = getViewInfo( viewId );
+
+}
+
+bool LXQt::Panel::Wayfire::fullscreenView(WaylandId viewId, bool yes) const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("wm-actions/set-fullscreen");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("view_id"), QJsonValue::fromVariant((quint64)viewId)},
+        {QStringLiteral("state"), yes}
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+bool LXQt::Panel::Wayfire::restoreView(WaylandId viewId) const
+{
+    QJsonObject viewInfo = getViewInfo(viewId);
+
+    if (viewInfo.isEmpty())
+    {
+        return false;
+    }
+
+    /** If it's minimized, unminimize it */
+    if (viewInfo[QStringLiteral("minimized")] == true)
+    {
+        return minimizeView(viewId, false);
+    }
+    /** The view is maximized, unmaximize it */
+    else if (viewInfo[QStringLiteral("fullscreen")] == true)
+    {
+        return fullscreenView(viewId, false);
+    }
+    /** The view is maximized, unmaximize it */
+    else if (viewInfo[QStringLiteral("tiled-edges")] == 15)
+    {
+        return maximizeView(viewId, false);
+    }
+
+    return false;
+}
+
+bool LXQt::Panel::Wayfire::closeView(WaylandId viewId) const
+{
+    QJsonObject request;
+
+    request[QStringLiteral("method")] = QStringLiteral("window-rules/close-view");
+    request[QStringLiteral("data")]   = QJsonObject({
+        {QStringLiteral("id"), QJsonValue::fromVariant((quint64)viewId)}
+    });
+
+    QJsonDocument reply = genericRequest(QJsonDocument(request));
+
+    return (reply[QStringLiteral("result")].toString() == QStringLiteral("ok"));
+}
+
+QJsonDocument LXQt::Panel::Wayfire::genericRequest(QJsonDocument request) const
+{
+    if (!impl->mConnected)
+    {
+        QJsonDocument reply{
+            {QStringLiteral("result"), QStringLiteral("failed")}
+        };
+        return reply;
+    }
+
+    uint32_t reqId = impl->request(request);
+    std::shared_ptr<QJsonDocument> reply = std::make_shared<QJsonDocument>();
+
+    QEventLoop loop;
+
+    auto connection = connect(
+        impl.data(), &LXQt::Panel::WayfireImpl::response, &loop,
+        [&reply, reqId, &loop] (uint32_t id, QJsonDocument response)
+    {
+        if (id == reqId)
+        {
+            *reply = response;  // Update the content of the shared_ptr
+            loop.quit();
+        }
+    });
+
+    loop.exec();
+
+    // Disconnect the signal-slot connection to avoid any potential issues
+    disconnect(connection);
+
+    // Return the QJsonDocument, not the shared_ptr
+    return *reply;
+}
+
+void LXQt::Panel::Wayfire::parseEvents(QJsonDocument response)
+{
+    QString event = response[QStringLiteral("event")].toString();
+
+    if (event == QStringLiteral("view-mapped"))
+    {
+        emit viewMapped(response);
+    } else if (event == QStringLiteral("view-focused"))
+    {
+        emit viewFocused(response);
+    } else if (event == QStringLiteral("view-title-changed"))
+    {
+        emit viewTitleChanged(response);
+    } else if (event == QStringLiteral("view-app-id-changed"))
+    {
+        emit viewAppIdChanged(response);
+    } else if (event == QStringLiteral("view-geometry-changed"))
+    {
+        emit viewGeometryChanged(response);
+    } else if (event == QStringLiteral("view-tiled"))
+    {
+        emit viewTitleChanged(response);
+    } else if (event == QStringLiteral("view-minimized"))
+    {
+        emit viewMinimized(response);
+    } else if (event == QStringLiteral("view-set-output"))
+    {
+        emit viewOutputChanged(response);
+    } else if (event == QStringLiteral("view-workspace-changed"))
+    {
+        emit viewWorkspaceChanged(response);
+    } else if (event == QStringLiteral("view-unmapped"))
+    {
+        emit viewUnmapped(response);
+    } else if (event == QStringLiteral("output-added"))
+    {
+        emit outputAdded(response);
+    } else if (event == QStringLiteral("output-removed"))
+    {
+        emit outputRemoved(response);
+    } else if (event == QStringLiteral("output-gain-focus"))
+    {
+        emit outputFocused(response);
+    } else if (event == QStringLiteral("output-wset-changed"))
+    {
+        emit workspaceSetChanged(response);
+    } else if (event == QStringLiteral("wset-workspace-changed"))
+    {
+        emit workspaceChanged(response);
+    } else
+    {
+        emit genericEvent(response);
+    }
+}

--- a/panel/backends/wayland/wayfire/wayfire-common.h
+++ b/panel/backends/wayland/wayfire/wayfire-common.h
@@ -1,29 +1,22 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL2+
- *
- * LXQt - a lightweight, Qt based, desktop toolset
- * https://lxqt.org
- *
- * Copyright: 2023 LXQt team
- * Authors:
- *  Filippo Gentile <filippogentile@disroot.org>
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
+/* BEGIN_COMMON_COPYRIGHT_HEADER (c)LGPL2+
+*
+* LXQt - a lightweight, Qt based, desktop toolset https://lxqt.org
+*
+* Copyright: 2023 LXQt team Authors:
+*  Filippo Gentile <filippogentile@disroot.org>
+*
+* This program or library is free software; you can redistribute it and/or modify it under the terms of the
+* GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the
+* License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+* implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+* License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this library; if not,
+* write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*
+* END_COMMON_COPYRIGHT_HEADER */
 
 #pragma once
 
@@ -137,10 +130,10 @@ class LXQt::Panel::Wayfire : public QObject
     bool showDesktop(WaylandId opId) const;
 
     /** Request the compositor to send us the wsets information */
-    QJsonObject getWorkspaceSetsInfo() const;
+    QJsonArray getWorkspaceSetsInfo() const;
 
     /** Request the compositor to send us the wsets information */
-    QJsonObject getWorkspaceName(int) const;
+    QString getWorkspaceName(int, QString outputName = QString()) const;
     bool setWorkspaceName(int, QString) const;
 
     /** Request the compositor to change the current workspace */

--- a/panel/backends/wayland/wayfire/wayfire-common.h
+++ b/panel/backends/wayland/wayfire/wayfire-common.h
@@ -1,22 +1,22 @@
 /* BEGIN_COMMON_COPYRIGHT_HEADER (c)LGPL2+
-*
-* LXQt - a lightweight, Qt based, desktop toolset https://lxqt.org
-*
-* Copyright: 2023 LXQt team Authors:
-*  Filippo Gentile <filippogentile@disroot.org>
-*
-* This program or library is free software; you can redistribute it and/or modify it under the terms of the
-* GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the
-* License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
-* implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-* License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this library; if not,
-* write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-*
-* END_COMMON_COPYRIGHT_HEADER */
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset https://lxqt.org
+ *
+ * Copyright: 2023 LXQt team Authors:
+ *  Filippo Gentile <filippogentile@disroot.org>
+ *
+ * This program or library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
 
 #pragma once
 
@@ -123,6 +123,9 @@ class LXQt::Panel::Wayfire : public QObject
     /** Request the compositor to send us the outputs information */
     WaylandId getActiveOutput() const;
 
+    /** Request the compositor to send us information of a given output */
+    QJsonObject getOutputInfo(WaylandId opId) const;
+
     /** Request the compositor to focus a given output */
     bool focusOutput(WaylandId opId) const;
 
@@ -137,7 +140,7 @@ class LXQt::Panel::Wayfire : public QObject
     bool setWorkspaceName(int, QString) const;
 
     /** Request the compositor to change the current workspace */
-    bool switchToWorkspace(WaylandId opId, int64_t nth) const;
+    bool switchToWorkspace(WaylandId opId, int64_t nth, WaylandId viewId = WaylandId()) const;
 
     /** Request the compositor to send us the list of views */
     QJsonArray listViews() const;
@@ -162,6 +165,9 @@ class LXQt::Panel::Wayfire : public QObject
 
     /** Request the compositor to focus a given view */
     bool restoreView(WaylandId viewId) const;
+
+    /** Request the compositor to focus a given view */
+    bool sendViewToWorkspace(WaylandId viewId, int nth) const;
 
     /** Request the compositor to focus a given view */
     bool closeView(WaylandId viewId) const;

--- a/panel/backends/wayland/wayfire/wayfire-common.h
+++ b/panel/backends/wayland/wayfire/wayfire-common.h
@@ -1,0 +1,281 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2023 LXQt team
+ * Authors:
+ *  Filippo Gentile <filippogentile@disroot.org>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#pragma once
+
+/** For struct pollfd */
+#include <poll.h>
+
+/* For QString, QThread, QTimer, etc.. */
+#include <QtCore>
+
+#include "../../lxqttaskbartypes.h"
+
+namespace LXQt
+{
+namespace Panel
+{
+class Wayfire;
+class WayfireImpl;
+}
+}
+
+// Strongly-typed wrapper for Wayland IDs
+struct WaylandId
+{
+    uint32_t id;
+    explicit WaylandId(uint32_t id_ = 0) : id(id_)
+    {}
+    operator WId() const
+    {
+        return static_cast<WId>(id);
+    }
+};
+
+
+class LXQt::Panel::WayfireImpl : public QObject, public QRunnable
+{
+    Q_OBJECT;
+
+  public:
+    WayfireImpl();
+
+    /** Stop polling This will terminate the thread and delete this object
+     */
+    void stop();
+
+    /** Request the compositor something */
+    uint32_t request(QJsonDocument req);
+
+    /** One FD for reading, one for writing */
+    struct pollfd wfSock;
+
+    /** The socket address */
+    QString wfSockPath;
+
+    /** Stop the loop flag */
+    volatile bool mTerminate = false;
+
+    /** Flag to check if we're connected or not */
+    volatile bool mConnected = false;
+
+    /** Function to write the json to wayfire socket. */
+    bool writeJson(QJsonDocument j);
+
+    /** Function to read the data from wayfire socket and parse it into json */
+    QJsonDocument readJson();
+
+  private:
+    QList<uint> mPendingRequests;
+    QMutex mutex; // Add a mutex for thread safety
+
+    /** Function to read the json from wayfire socket into a buffer. */
+    bool readExact(char *buf, uint size);
+
+  protected:
+    void run() override;
+
+  Q_SIGNALS:
+    /** We recieved an event from Wayfire */
+    void wayfireEvent(QJsonDocument);
+
+    /** Relay the message received from the server */
+    void response(uint32_t, QJsonDocument);
+
+    /** Inform the rest that polling has started */
+    void started();
+};
+
+
+class LXQt::Panel::Wayfire : public QObject
+{
+    Q_OBJECT
+
+  public:
+    Wayfire(QString wfSock = QString());
+    ~Wayfire();
+
+    /** Connect to Wayfire */
+    bool connectToServer() const;
+
+    /* ========== Specific requests ========== */
+
+    /** Request the compositor to send us the outputs information */
+    QJsonArray listOutputs() const;
+
+    /** Request the compositor to send us the outputs information */
+    WaylandId getActiveOutput() const;
+
+    /** Request the compositor to focus a given output */
+    bool focusOutput(WaylandId opId) const;
+
+    /** Request the compositor to trigger show-desktop a given output */
+    bool showDesktop(WaylandId opId) const;
+
+    /** Request the compositor to send us the wsets information */
+    QJsonObject getWorkspaceSetsInfo() const;
+
+    /** Request the compositor to send us the wsets information */
+    QJsonObject getWorkspaceName(int) const;
+    bool setWorkspaceName(int, QString) const;
+
+    /** Request the compositor to change the current workspace */
+    bool switchToWorkspace(WaylandId opId, int64_t nth) const;
+
+    /** Request the compositor to send us the list of views */
+    QJsonArray listViews() const;
+
+    /** Request the compositor to send us the info of the given view */
+    WaylandId getActiveView() const;
+
+    /** Request the compositor to send us the info of the given view */
+    QJsonObject getViewInfo(WaylandId viewId) const;
+
+    /** Request the compositor to focus a given view */
+    bool focusView(WaylandId viewId) const;
+
+    /** Request the compositor to minimize/restore a given view */
+    bool minimizeView(WaylandId viewId, bool) const;
+
+    /** Request the compositor to maximize/restore a given view */
+    bool maximizeView(WaylandId viewId, int edges) const;
+
+    /** Request the compositor to fullscreen a given view */
+    bool fullscreenView(WaylandId viewId, bool) const;
+
+    /** Request the compositor to focus a given view */
+    bool restoreView(WaylandId viewId) const;
+
+    /** Request the compositor to focus a given view */
+    bool closeView(WaylandId viewId) const;
+
+    /** This is a generic request */
+    QJsonDocument genericRequest(QJsonDocument) const;
+
+    /* ========== WAYFIRE EVENTS ========== */
+
+    /**
+     * A new output was added.
+     */
+    Q_SIGNAL void outputAdded(QJsonDocument);
+
+    /**
+     * An existing output was removed.
+     */
+    Q_SIGNAL void outputRemoved(QJsonDocument);
+
+    /**
+     * A particular output has gained focus. Only one output can have focus at any given time. This outupt can
+     * be used to calculate the focused view.
+     */
+    Q_SIGNAL void outputFocused(QJsonDocument);
+
+    /**
+     * Current workspace set of a given output was changed When the wset of an output changes, always query
+     * the workspace
+     */
+    Q_SIGNAL void workspaceSetChanged(QJsonDocument);
+
+    /**
+     * The active workspace of a given wset changed. Because wsets of different outputs are independent,
+     * workspace change on one output will not affect the other.
+     */
+    Q_SIGNAL void workspaceChanged(QJsonDocument);
+
+    /**
+     * A view was just mapped. This view does not have an output nor a wset. Even the title and app-id will be
+     * unset. Only the view id is valid.
+     */
+    Q_SIGNAL void viewMapped(QJsonDocument);
+
+    /**
+     * A view on a particular outupt gained focus Since wayfire supports independent outputs, each output can
+     * have a view with focus. The focused view of the active outupt will be the one with keyboard focus.
+     */
+    Q_SIGNAL void viewFocused(QJsonDocument);
+
+    /**
+     * The title of a view changed. The title can be "nil" or null. In such cases, the user can safely ignore
+     * it.
+     */
+    Q_SIGNAL void viewTitleChanged(QJsonDocument);
+
+    /**
+     * The app-id of a view changed. The app-id can be "nil" or null. In such cases, the user can safely
+     * ignore it.
+     */
+    Q_SIGNAL void viewAppIdChanged(QJsonDocument);
+
+    /**
+     * The geometry of a view changed.
+     */
+    Q_SIGNAL void viewGeometryChanged(QJsonDocument);
+
+    /**
+     * The tiled status of a view has changed.
+     */
+    Q_SIGNAL void viewTiled(QJsonDocument);
+
+    /**
+     * A view was minimized.
+     */
+    Q_SIGNAL void viewMinimized(QJsonDocument);
+
+    /**
+     * The output of a view changed. When the view gets mapped, the output will be null.
+     */
+    Q_SIGNAL void viewOutputChanged(QJsonDocument);
+
+    /**
+     * The workspace of a view changed.
+     */
+    Q_SIGNAL void viewWorkspaceChanged(QJsonDocument);
+
+    /**
+     * An existing view was unmapped. The output, wset etc of this view are invalid as of now.
+     */
+    Q_SIGNAL void viewUnmapped(QJsonDocument);
+
+    /**
+     * A generic wayfire event. This signal is always emitted for all events. Specific signals are emitted by
+     * parsing this event.
+     */
+    Q_SIGNAL void genericEvent(QJsonDocument);
+
+    /**
+     * Inform the user tha there was an error. Currently used to indicate failure in watching for wayfire
+     * events.
+     */
+    Q_SIGNAL void error();
+
+  private:
+    /** Implementation class pointer */
+    QScopedPointer<WayfireImpl> impl;
+
+    /** Partially parse the events to emit the correct signals */
+    void parseEvents(QJsonDocument);
+};

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -241,7 +241,7 @@ int LXQtTaskbarWlrootsBackend::getWorkspacesCount() const
     return 1;
 }
 
-QString LXQtTaskbarWlrootsBackend::getWorkspaceName(int) const
+QString LXQtTaskbarWlrootsBackend::getWorkspaceName(int, QString) const
 {
     return QStringLiteral("Desktop 1");
 }

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -45,7 +45,7 @@ public:
 
     // Workspaces
     virtual int getWorkspacesCount() const override;
-    virtual QString getWorkspaceName(int idx) const override;
+    virtual QString getWorkspaceName(int idx, QString sceenName = QString()) const override;
 
     virtual int getCurrentWorkspace() const override;
     virtual bool setCurrentWorkspace(int idx) override;

--- a/panel/backends/xcb/lxqtwmbackend_x11.cpp
+++ b/panel/backends/xcb/lxqtwmbackend_x11.cpp
@@ -57,7 +57,9 @@ LXQtWMBackendX11::LXQtWMBackendX11(QObject *parent)
     connect(KX11Extras::self(), &KX11Extras::windowRemoved, this, &LXQtWMBackendX11::onWindowRemoved);
 
     connect(KX11Extras::self(), &KX11Extras::numberOfDesktopsChanged, this, &ILXQtAbstractWMInterface::workspacesCountChanged);
-    connect(KX11Extras::self(), &KX11Extras::currentDesktopChanged, this, &ILXQtAbstractWMInterface::currentWorkspaceChanged);
+    connect(KX11Extras::self(), &KX11Extras::currentDesktopChanged, this, [this](int x) {
+        emit currentWorkspaceChanged(x, QString()); // without specifying an output name
+    });
     connect(KX11Extras::self(), &KX11Extras::desktopNamesChanged, this, [this]() {
         emit workspaceNameChanged(-1); // without specifying an index
     });
@@ -477,7 +479,7 @@ int LXQtWMBackendX11::getWorkspacesCount() const
     return KX11Extras::numberOfDesktops();
 }
 
-QString LXQtWMBackendX11::getWorkspaceName(int idx) const
+QString LXQtWMBackendX11::getWorkspaceName(int idx, QString) const
 {
     return KX11Extras::desktopName(idx);
 }

--- a/panel/backends/xcb/lxqtwmbackend_x11.h
+++ b/panel/backends/xcb/lxqtwmbackend_x11.h
@@ -70,7 +70,7 @@ public:
 
     // Workspaces
     virtual int getWorkspacesCount() const override;
-    virtual QString getWorkspaceName(int idx) const override;
+    virtual QString getWorkspaceName(int idx, QString screenName = QString()) const override;
 
     virtual int getCurrentWorkspace() const override;
     virtual bool setCurrentWorkspace(int idx) override;


### PR DESCRIPTION
What works
- [x] Listing tasks
- [x] Listing tasks per workspace
- [x] Moving windows from one workspace to another (menu)
- [x] Closing a view (menu and close button)
- [x] Minimizing and restoring a view (menu)
- [x] Maximizing a view (menu)
- [x] Listing workspaces
- [x] Switching workspaces
- [x] Show/hide Desktop

What does not work, but can (eventually :wink:)
- [ ] Proper minimize/restore using task button - requires double clicks
- [ ] Pin to top/bottom - unimplemented from my side (currently)
- [ ] Workspace names (LXQt support missing) - Since workspaces on wayfire are per-output, workspace names too are per-output. This means that we need to provide the output name when calling the getyWorkspaceName(...) function. I lack the proper knowledge to make this work. @tsujan Perhaps, you can have a look?
- [ ] Restoring a view when maximized (This might be a wayfire bug)
- [ ] Vertical/Horizontal maximize (No support from Wayfire, I am working on it)

What should work, but does not.
- [ ] Send to previous/next monitor - I am not very sure how LXQt identified "previous" or "next". However, the code exists, and am yet to debug the issue.

Unsupported
- [x] Shade/Roll-up
- [x] Urgency
- [x] Pin view below.


All other features are currently untested or not implemented.