### PR TITLE
Added Niri/smithay backend

### DIFF
--- a/panel/backends/wayland/CMakeLists.txt
+++ b/panel/backends/wayland/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(kwin_wayland)
 add_subdirectory(wlroots)
+add_subdirectory(niri)

--- a/panel/backends/wayland/niri/CMakeLists.txt
+++ b/panel/backends/wayland/niri/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(PLATFORM_NAME niri)
+
+set(PREFIX_NAME wmbackend)
+set(PROGRAM "lxqt-panel")
+set(BACKEND "backend")
+set(NAME ${PREFIX_NAME}_${PLATFORM_NAME})
+project(${PROGRAM}_${BACKEND}_${NAME})
+
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS WaylandClient Concurrent)
+find_package(Qt6Xdg)
+
+set(PROG_SHARE_DIR ${CMAKE_INSTALL_FULL_DATAROOTDIR}/lxqt/${PROGRAM}/${BACKEND})
+set(PLUGIN_SHARE_DIR ${PROG_SHARE_DIR}/${BACKEND}/${NAME})
+#************************************************
+
+if (NOT DEFINED PLUGIN_DIR)
+    set (PLUGIN_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/${PROGRAM})
+endif (NOT DEFINED PLUGIN_DIR)
+
+set(QTX_LIBRARIES Qt6::Gui Qt6::GuiPrivate)
+
+set(
+    SRC
+    lxqtwmbackend_niri.cpp lxqtwmbackend_niri.h
+    lxqttaskbarniriwm.cpp lxqttaskbarniriwm.h
+)
+
+add_library(${NAME} MODULE ${SRC}) # build dynamically loadable modules
+install(TARGETS ${NAME} DESTINATION ${PLUGIN_DIR}/${BACKEND}) # install the *.so file
+
+target_link_libraries(${NAME} ${QTX_LIBRARIES} Qt6::Concurrent Qt6::WaylandClient Qt6Xdg)
+
+qt6_generate_wayland_protocol_client_sources(${NAME} FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/wlr-foreign-toplevel-management-unstable-v1.xml
+)

--- a/panel/backends/wayland/niri/lxqttaskbarniriwm.cpp
+++ b/panel/backends/wayland/niri/lxqttaskbarniriwm.cpp
@@ -1,0 +1,552 @@
+#include "lxqttaskbarniriwm.h"
+
+#include <QString>
+#include <QFuture>
+#include <QtConcurrent>
+#include <QGuiApplication>
+#include <QMimeData>
+#include <QSet>
+#include <QUrl>
+#include <QUuid>
+#include <QWaylandClientExtension>
+#include <QWindow>
+
+#include <xdgicon.h>
+
+#include <qpa/qplatformnativeinterface.h>
+
+#include <fcntl.h>
+#include <sys/poll.h>
+#include <unistd.h>
+
+#include <filesystem>
+
+QString U8Str( const char *str ) {
+    return QString::fromUtf8( str );
+}
+
+static inline QString getPixmapIcon(QString name)
+{
+    QStringList paths{
+        U8Str("/usr/local/share/pixmaps/"),
+        U8Str("/usr/share/pixmaps/"),
+    };
+
+    QStringList sfxs{
+        U8Str( ".svg" ), U8Str( ".png" ), U8Str( ".xpm" )
+    };
+
+    for (QString path: paths)
+    {
+        for (QString sfx: sfxs)
+        {
+            if (QFile::exists(path + name + sfx))
+            {
+                return path + name + sfx;
+            }
+        }
+    }
+
+    return QString();
+}
+
+
+QIcon getIconForAppId(QString mAppId)
+{
+    if (mAppId.isEmpty() or (mAppId == U8Str("Unknown")))
+    {
+        return QIcon();
+    }
+
+    /** Wine apps */
+    if (mAppId.endsWith(U8Str(".exe")))
+    {
+        return QIcon::fromTheme(U8Str("wine"));
+    }
+
+    /** Check if a theme icon exists called @mAppId */
+    if (QIcon::hasThemeIcon(mAppId))
+    {
+        return QIcon::fromTheme(mAppId);
+    }
+
+    /** Check if the theme icon is @mAppId, but all lower-case letters */
+    else if (QIcon::hasThemeIcon(mAppId.toLower()))
+    {
+        return QIcon::fromTheme(mAppId.toLower());
+    }
+
+    QStringList appDirs = {
+        QDir::home().filePath(U8Str(".local/share/applications/")),
+        U8Str("/usr/local/share/applications/"),
+        U8Str("/usr/share/applications/"),
+    };
+
+    /**
+     * Assume mAppId == desktop-file-name (ideal situation)
+     * or mAppId.toLower() == desktop-file-name (cheap fallback)
+     */
+    QString iconName;
+
+    for (QString path: appDirs)
+    {
+        /** Get the icon name from desktop (mAppId: as it is) */
+        if (QFile::exists(path + mAppId + U8Str(".desktop")))
+        {
+            QSettings desktop(path + mAppId + U8Str(".desktop"), QSettings::IniFormat);
+            iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+        }
+
+        /** Get the icon name from desktop (mAppId: all lower-case letters) */
+        else if (QFile::exists(path + mAppId.toLower() + U8Str(".desktop")))
+        {
+            QSettings desktop(path + mAppId.toLower() + U8Str(".desktop"), QSettings::IniFormat);
+            iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+        }
+
+        /** No icon specified: try else-where */
+        if (iconName.isEmpty())
+        {
+            continue;
+        }
+
+        /** We got an iconName, and it's in the current theme */
+        if (QIcon::hasThemeIcon(iconName))
+        {
+            return QIcon::fromTheme(iconName);
+        }
+
+        /** Not a theme icon, but an absolute path */
+        else if (QFile::exists(iconName))
+        {
+            return QIcon(iconName);
+        }
+
+        /** Not theme icon or absolute path. So check /usr/share/pixmaps/ */
+        else
+        {
+            iconName = getPixmapIcon(iconName);
+
+            if (not iconName.isEmpty())
+            {
+                return QIcon(iconName);
+            }
+        }
+    }
+
+    /* Check all desktop files for @mAppId */
+    for (QString path: appDirs)
+    {
+        QStringList desktops = QDir(path).entryList({ U8Str("*.desktop") });
+        for (QString dskf: desktops)
+        {
+            QSettings desktop(path + dskf, QSettings::IniFormat);
+
+            QString exec = desktop.value(U8Str("Desktop Entry/Exec"), U8Str("abcd1234/-")).toString();
+            QString name = desktop.value(U8Str("Desktop Entry/Name"), U8Str("abcd1234/-")).toString();
+            QString cls  = desktop.value(U8Str("Desktop Entry/StartupWMClass"), U8Str("abcd1234/-")).toString();
+
+            QString execPath = U8Str(std::filesystem::path(exec.toStdString()).filename().c_str());
+
+            if (mAppId.compare(execPath, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            }
+
+            else if (mAppId.compare(name, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            }
+
+            else if (mAppId.compare(cls, Qt::CaseInsensitive) == 0)
+            {
+                iconName = desktop.value(U8Str("Desktop Entry/Icon")).toString();
+            }
+
+            if (not iconName.isEmpty())
+            {
+                if (QIcon::hasThemeIcon(iconName))
+                {
+                    return QIcon::fromTheme(iconName);
+                }
+
+                else if (QFile::exists(iconName))
+                {
+                    return QIcon(iconName);
+                }
+
+                else
+                {
+                    iconName = getPixmapIcon(iconName);
+
+                    if (not iconName.isEmpty())
+                    {
+                        return QIcon(iconName);
+                    }
+                }
+            }
+        }
+    }
+
+    iconName = getPixmapIcon(iconName);
+
+    if (not iconName.isEmpty())
+    {
+        return QIcon(iconName);
+    }
+
+    return QIcon();
+}
+
+
+static inline wl_seat *get_seat()
+{
+    QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
+
+    if (!native)
+    {
+        return nullptr;
+    }
+
+    struct wl_seat *seat = reinterpret_cast<wl_seat *>(native->nativeResourceForIntegration("wl_seat"));
+
+    return seat;
+}
+
+
+/*
+ * LXQtTaskbarNiriWindowManagment
+ */
+
+LXQtTaskbarNiriWindowManagment::LXQtTaskbarNiriWindowManagment() : QWaylandClientExtensionTemplate(version)
+{
+    /** Automatically destroy thie object */
+    connect(
+        this, &QWaylandClientExtension::activeChanged, this, [ this ] {
+        if (!isActive())
+        {
+            zwlr_foreign_toplevel_manager_v1_destroy(object());
+        }
+    });
+}
+
+
+LXQtTaskbarNiriWindowManagment::~LXQtTaskbarNiriWindowManagment()
+{
+    if (isActive())
+    {
+        zwlr_foreign_toplevel_manager_v1_destroy(object());
+    }
+}
+
+
+void LXQtTaskbarNiriWindowManagment::zwlr_foreign_toplevel_manager_v1_toplevel(struct ::zwlr_foreign_toplevel_handle_v1 *toplevel)
+{
+    /**
+     * A window was created.
+     * Wait for the window to become ready, i.e. wait for done() event to be sent by the compositor.
+     * Once we recieve done(), emit the windowReady() signal.
+     */
+
+    auto w = new LXQtTaskbarNiriWindow(toplevel);
+
+    connect(w, &LXQtTaskbarNiriWindow::windowReady, [w, this] () {
+        emit windowCreated(w->getWindowId());
+    });
+}
+
+
+/*
+ * LXQtTaskbarNiriWindow
+ */
+
+LXQtTaskbarNiriWindow::LXQtTaskbarNiriWindow(::zwlr_foreign_toplevel_handle_v1 *id) : zwlr_foreign_toplevel_handle_v1(id)
+{
+    ID = id;
+}
+
+
+LXQtTaskbarNiriWindow::~LXQtTaskbarNiriWindow()
+{
+    destroy();
+}
+
+
+void LXQtTaskbarNiriWindow::activate()
+{
+    /**
+     * Activate on default seat.
+     * TODO: Worry about multi-seat setups, when we have no other worries :P
+     */
+    zwlr_foreign_toplevel_handle_v1::activate(get_seat());
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_title(const QString& title)
+{
+    /** Store the incoming title in pending */
+    m_pendingState.title        = title;
+    m_pendingState.titleChanged = true;
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_app_id(const QString& app_id)
+{
+    /** Store the incoming appId in pending */
+    m_pendingState.appId        = app_id;
+    m_pendingState.appIdChanged = true;
+
+    /** Update the icon */
+    this->icon = getIconForAppId(app_id);
+
+    /** We did not get any icon from app-id. Let's use application-x-executable */
+    if (this->icon.pixmap(64).width() == 0)
+    {
+        this->icon = XdgIcon::fromTheme(QString::fromUtf8("application-x-executable"));
+    }
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_output_enter(struct ::wl_output *output)
+{
+    /** This view was added to an output */
+    m_pendingState.outputs << output;
+    m_pendingState.outputsChanged = true;
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_output_leave(struct ::wl_output *output)
+{
+    /** This view was removed from an output; store it in pending. */
+    m_pendingState.outputsLeft << output;
+
+    if (m_pendingState.outputs.contains(output))
+    {
+        m_pendingState.outputs.removeAll(output);
+    }
+
+    m_pendingState.outputsChanged = true;
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_state(wl_array *state)
+{
+    /** State of this window was changed; store it in pending. */
+    auto *states    = static_cast<uint32_t *>(state->data);
+    int   numStates = static_cast<int>(state->size / sizeof(uint32_t));
+
+    for (int i = 0; i < numStates; i++)
+    {
+        switch ((uint32_t)states[ i ])
+        {
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED: {
+            m_pendingState.maximized = true;
+            break;
+        }
+
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MINIMIZED: {
+            m_pendingState.minimized = true;
+            m_pendingState.activated = false; // a minimized window isn't active
+            break;
+        }
+
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED: {
+            m_pendingState.activated = true;
+            m_pendingState.minimized = false; // an active window isn't minimized
+            break;
+        }
+
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_FULLSCREEN: {
+            m_pendingState.fullscreen = true;
+            break;
+        }
+        }
+    }
+
+    /* WARNING:
+       These are needed with all states, also when "numStates" is zero.
+       Without them, states might be incorrect under some circumstances, e.g.,
+       an active task button might be deactivated if an overlay window is shown.
+    */
+    m_pendingState.activatedChanged  = true;
+    m_pendingState.maximizedChanged  = (windowState.maximized  != m_pendingState.maximized);
+    m_pendingState.minimizedChanged  = (windowState.minimized  != m_pendingState.minimized);
+    m_pendingState.fullscreenChanged = (windowState.fullscreen != m_pendingState.fullscreen);
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_done()
+{
+    /**
+     * All the states/properties have been sent.
+     * We can now emit the signals and clear the pending state:
+     * 1. Update all the variables first.
+     * 2. Then clear the m_pendingState.<variable>
+     * 3. Emit the changed signals.
+     * 4. Finally, clean the m_pendingState.<variable>Changed flags.
+     */
+
+    // (1) title, if it changed
+    if (m_pendingState.titleChanged)
+    {
+        windowState.title = m_pendingState.title;
+    }
+
+    // (2) appId, if it changed
+    if (m_pendingState.appIdChanged)
+    {
+        windowState.appId = m_pendingState.appId;
+    }
+
+    // (3) outputs, if they changed
+    if (m_pendingState.outputsChanged)
+    {
+        for (::wl_output *op: m_pendingState.outputsLeft)
+        {
+            if (windowState.outputs.contains(op))
+            {
+                windowState.outputs.removeAll(op);
+            }
+        }
+
+        for (::wl_output *op: m_pendingState.outputs)
+        {
+            if (!windowState.outputs.contains(op))
+            {
+                windowState.outputs << op;
+            }
+        }
+    }
+
+    // (4) states, if they changed.
+    if (m_pendingState.maximizedChanged)
+    {
+        windowState.maximized = m_pendingState.maximized;
+    }
+
+    if (m_pendingState.minimizedChanged)
+    {
+        windowState.minimized = m_pendingState.minimized;
+    }
+
+    if (m_pendingState.activatedChanged)
+    {
+        windowState.activated = m_pendingState.activated;
+    }
+
+    if (m_pendingState.fullscreenChanged)
+    {
+        windowState.fullscreen = m_pendingState.fullscreen;
+    }
+
+    // (5) parent, if it changed.
+    if (m_pendingState.parentChanged)
+    {
+        if (m_pendingState.parent)
+        {
+            setParentWindow(new LXQtTaskbarNiriWindow(m_pendingState.parent));
+        }
+
+        else
+        {
+            setParentWindow(nullptr);
+        }
+    }
+
+    /** 2. Clear all m_pendingState.<variables> for next run */
+    m_pendingState.title = QString();
+    m_pendingState.appId = QString();
+    m_pendingState.outputs.clear();
+    m_pendingState.maximized  = false;
+    m_pendingState.minimized  = false;
+    m_pendingState.activated  = false;
+    m_pendingState.fullscreen = false;
+    m_pendingState.parent     = nullptr;
+
+    /**
+     * 3. Emit signals
+     *    (a) First time done was emitted after the window was created.
+     *    (b) Other times.
+     */
+
+    /** (a) First time done was emitted */
+    if (initDone == false)
+    {
+        /**
+         * All the states/properties are already set.
+         * Any query will give valid results.
+         */
+        initDone = true;
+        emit windowReady();
+    }
+
+    /** (b) All the subsequent times */
+    else
+    {
+        if (m_pendingState.titleChanged)
+            emit titleChanged();
+        if (m_pendingState.appIdChanged)
+            emit appIdChanged();
+        if (m_pendingState.outputsChanged)
+            emit outputsChanged();
+        if (m_pendingState.maximizedChanged)
+            emit maximizedChanged();
+        if (m_pendingState.minimizedChanged)
+            emit minimizedChanged();
+        if (m_pendingState.fullscreenChanged)
+            emit fullscreenChanged();
+        // NOTE: parentChanged is emitted before activatedChanged
+        // to guarantee correct activation states of child windows later
+        if (m_pendingState.parentChanged)
+            emit parentChanged();
+        if (m_pendingState.activatedChanged)
+            emit activatedChanged();
+
+        emit stateChanged();
+    }
+
+    /** 4. Clear m+m_pendingState.<variable>Changed flags */
+    m_pendingState.titleChanged      = false;
+    m_pendingState.appIdChanged      = false;
+    m_pendingState.outputsChanged    = false;
+    m_pendingState.maximizedChanged  = false;
+    m_pendingState.minimizedChanged  = false;
+    m_pendingState.activatedChanged  = false;
+    m_pendingState.fullscreenChanged = false;
+    m_pendingState.parentChanged     = false;
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_closed()
+{
+    /** This window was closed */
+    emit closed();
+}
+
+
+void LXQtTaskbarNiriWindow::zwlr_foreign_toplevel_handle_v1_parent(struct ::zwlr_foreign_toplevel_handle_v1 *parent)
+{
+    /** Parent of this window changed; store it in pending. */
+    m_pendingState.parent        = parent;
+    m_pendingState.parentChanged = true;
+}
+
+
+void LXQtTaskbarNiriWindow::setParentWindow(LXQtTaskbarNiriWindow *parent)
+{
+    QObject::disconnect(parentWindowUnmappedConnection);
+
+    if (parent)
+    {
+        parentWindow = parent->getWindowId();
+        parentWindowUnmappedConnection = QObject::connect(
+            parent, &LXQtTaskbarNiriWindow::closed, this, [ this ] {
+            setParentWindow(nullptr);
+        });
+    }
+    else
+    {
+        parentWindow = 0;
+        parentWindowUnmappedConnection = QMetaObject::Connection();
+    }
+}

--- a/panel/backends/wayland/niri/lxqttaskbarniriwm.h
+++ b/panel/backends/wayland/niri/lxqttaskbarniriwm.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <QIcon>
+#include <QPointer>
+#include <QtWaylandClient/QWaylandClientExtensionTemplate>
+
+#include "qwayland-wlr-foreign-toplevel-management-unstable-v1.h"
+#include "wayland-wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
+
+typedef quintptr WId;
+
+class LXQtTaskbarNiriWindow;
+
+class LXQtTaskbarNiriWindowManagment : public QWaylandClientExtensionTemplate<LXQtTaskbarNiriWindowManagment>,
+                                         public QtWayland::zwlr_foreign_toplevel_manager_v1
+{
+    Q_OBJECT
+public:
+    static constexpr int version = 16;
+
+    LXQtTaskbarNiriWindowManagment();
+    ~LXQtTaskbarNiriWindowManagment();
+
+    inline bool isShowingDesktop() const { return m_isShowingDesktop; }
+    inline void setShowingDesktop(bool show) { m_isShowingDesktop = show; }
+
+protected:
+    void zwlr_foreign_toplevel_manager_v1_toplevel(struct ::zwlr_foreign_toplevel_handle_v1 *toplevel);
+    void zwlr_foreign_toplevel_manager_v1_finished() {};
+
+Q_SIGNALS:
+    void windowCreated(WId wid);
+
+private:
+    bool m_isShowingDesktop = false;
+};
+
+using WindowState = QtWayland::zwlr_foreign_toplevel_handle_v1::state;
+
+class WindowProperties {
+    public:
+        /** Title of the window */
+        QString title = QString::fromUtf8( "untitled" );
+        bool titleChanged = false;
+
+        /** appId of the window */
+        QString appId = QString::fromUtf8( "unidentified" );
+        bool appIdChanged = false;
+
+        /** List of outputs which the window is currently on */
+        QList<::wl_output *> outputs;
+        bool outputsChanged = false;
+
+        /** Is maximized */
+        bool maximized = false;
+        bool maximizedChanged = false;
+
+        /** Is minimized */
+        bool minimized = false;
+        bool minimizedChanged = false;
+
+        /** Is active */
+        bool activated = false;
+        bool activatedChanged = false;
+
+        /** Is fullscreen */
+        bool fullscreen = false;
+        bool fullscreenChanged = false;
+
+        /** Parent of this view, can be null */
+        ::zwlr_foreign_toplevel_handle_v1 * parent = nullptr;
+        bool parentChanged = false;
+
+        /** List of outputs from which window has left */
+        QList<::wl_output *> outputsLeft;
+};
+
+class LXQtTaskbarNiriWindow : public QObject,
+                                public QtWayland::zwlr_foreign_toplevel_handle_v1
+{
+    Q_OBJECT
+public:
+    LXQtTaskbarNiriWindow(::zwlr_foreign_toplevel_handle_v1 *id);
+    ~LXQtTaskbarNiriWindow();
+
+    inline WId getWindowId() const { return reinterpret_cast<WId>(this); }
+
+    void activate();
+
+    QIcon icon;
+    WindowProperties windowState;
+    WId parentWindow = 0;
+    ::zwlr_foreign_toplevel_handle_v1 *ID = nullptr;
+
+Q_SIGNALS:
+    void titleChanged();
+    void appIdChanged();
+    void outputsChanged();
+
+    /** Individual state change signals */
+    void maximizedChanged();
+    void minimizedChanged();
+    void activatedChanged();
+    void fullscreenChanged();
+
+    void parentChanged();
+
+    /** Bulk state change signal */
+    void stateChanged();
+
+    /** First state change signal: Before this, the window did not have a valid state */
+    void windowReady();
+
+    /** All state changes have been sent. */
+    void done();
+
+    /** Window closed signal */
+    void closed();
+
+protected:
+    void zwlr_foreign_toplevel_handle_v1_title(const QString &title);
+    void zwlr_foreign_toplevel_handle_v1_app_id(const QString &app_id);
+    void zwlr_foreign_toplevel_handle_v1_output_enter(struct ::wl_output *output);
+    void zwlr_foreign_toplevel_handle_v1_output_leave(struct ::wl_output *output);
+    void zwlr_foreign_toplevel_handle_v1_state(wl_array *state);
+    void zwlr_foreign_toplevel_handle_v1_done();
+    void zwlr_foreign_toplevel_handle_v1_closed();
+    void zwlr_foreign_toplevel_handle_v1_parent(struct ::zwlr_foreign_toplevel_handle_v1 *parent);
+
+private:
+    void setParentWindow(LXQtTaskbarNiriWindow *parent);
+
+    QMetaObject::Connection parentWindowUnmappedConnection;
+
+    WindowProperties m_pendingState;
+
+    bool initDone = false;
+};

--- a/panel/backends/wayland/niri/lxqtwmbackend_niri.cpp
+++ b/panel/backends/wayland/niri/lxqtwmbackend_niri.cpp
@@ -661,41 +661,11 @@ void LXQtTaskbarNiriBackend::setLastActivated(WId id)
 
 int LXQtWMBackendNiriLibrary::getBackendScore(const QString& key) const
 {
-    if (key == QStringLiteral("smithay"))
+    // Only Niri is supported
+    if ((key == QSL("niri")) || (key == QSL("Niri")))
     {
-        return 50;
+        return 100;
     }
-
-    if (key == QStringLiteral("niri"))
-    {
-        return 50;
-    }
-
-    else if (key == QStringLiteral("wayfire"))
-    {
-        return 30;
-    }
-
-    else if (key == QStringLiteral("sway"))
-    {
-        return 30;
-    }
-
-    else if (key == QStringLiteral("hyprland"))
-    {
-        return 30;
-    }
-
-    else if (key == QStringLiteral("labwc"))
-    {
-        return 30;
-    }
-
-    else if (key == QStringLiteral("river"))
-    {
-        return 30;
-    }
-
     // Unsupported
     return 0;
 }

--- a/panel/backends/wayland/niri/lxqtwmbackend_niri.cpp
+++ b/panel/backends/wayland/niri/lxqtwmbackend_niri.cpp
@@ -1,0 +1,707 @@
+#include "lxqttaskbarniriwm.h"
+#include "lxqtwmbackend_niri.h"
+
+#include <QIcon>
+#include <QDateTime>
+#include <QScreen>
+#include <algorithm>
+
+// Function to erase a window from the vector
+void eraseWindow(std::vector<WId>& windows, WId tgt) {
+    // Use std::vector::iterator to find the window
+    auto it = std::find(windows.begin(), windows.end(), tgt);
+
+    // Check if the window was found
+    if (it != windows.end()) {
+        // If found, erase the element pointed to by the iterator
+        windows.erase(it);
+    }
+}
+
+LXQtTaskbarNiriBackend::LXQtTaskbarNiriBackend(QObject *parent) :
+    ILXQtAbstractWMInterface(parent)
+{
+    m_managment.reset(new LXQtTaskbarNiriWindowManagment);
+
+    connect(m_managment.get(), &LXQtTaskbarNiriWindowManagment::windowCreated, this, &LXQtTaskbarNiriBackend::addWindow);
+}
+
+bool LXQtTaskbarNiriBackend::supportsAction(WId, LXQtTaskBarBackendAction action) const
+{
+    switch (action)
+    {
+    case LXQtTaskBarBackendAction::Maximize:
+        return true;
+
+    case LXQtTaskBarBackendAction::Minimize:
+        return true;
+
+    case LXQtTaskBarBackendAction::FullScreen:
+        return true;
+
+    default:
+        return false;
+    }
+
+    return false;
+}
+
+bool LXQtTaskbarNiriBackend::reloadWindows()
+{
+    const QVector<WId> wids = getCurrentWindows();
+
+    // Force removal and re-adding
+    for(WId windowId : wids)
+    {
+        emit windowRemoved(windowId);
+    }
+    for(WId windowId : wids)
+    {
+        emit windowAdded(windowId);
+    }
+
+    return true;
+}
+
+QVector<WId> LXQtTaskbarNiriBackend::getCurrentWindows() const
+{
+    QVector<WId> wids;
+
+    for( WId wid: windows ){
+        wids << wid;
+    }
+
+    return wids;
+}
+
+QString LXQtTaskbarNiriBackend::getWindowTitle(WId windowId) const
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return QString();
+
+    return window->windowState.title;
+}
+
+bool LXQtTaskbarNiriBackend::applicationDemandsAttention(WId) const
+{
+    return false;
+}
+
+QIcon LXQtTaskbarNiriBackend::getApplicationIcon(WId windowId, int devicePixels) const
+{
+    Q_UNUSED(devicePixels)
+
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return QIcon();
+
+    return window->icon;
+}
+
+QString LXQtTaskbarNiriBackend::getWindowClass(WId windowId) const
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return QString();
+    return window->windowState.appId;
+}
+
+LXQtTaskBarWindowLayer LXQtTaskbarNiriBackend::getWindowLayer(WId) const
+{
+    return LXQtTaskBarWindowLayer::Normal;
+}
+
+bool LXQtTaskbarNiriBackend::setWindowLayer(WId, LXQtTaskBarWindowLayer)
+{
+    return false;
+}
+
+LXQtTaskBarWindowState LXQtTaskbarNiriBackend::getWindowState(WId windowId) const
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return LXQtTaskBarWindowState::Normal;
+
+    if(window->windowState.minimized)
+        return LXQtTaskBarWindowState::Minimized;
+
+    if(window->windowState.maximized)
+        return LXQtTaskBarWindowState::Maximized;
+
+    if(window->windowState.fullscreen)
+        return LXQtTaskBarWindowState::FullScreen;
+
+    return LXQtTaskBarWindowState::Normal;
+}
+
+bool LXQtTaskbarNiriBackend::setWindowState(WId windowId, LXQtTaskBarWindowState state, bool set)
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return false;
+
+    switch (state)
+    {
+    case LXQtTaskBarWindowState::Minimized:
+    {
+        if ( set ) {
+            window->set_minimized();
+        }
+
+        else {
+            window->unset_minimized();
+        }
+
+        break;
+    }
+    case LXQtTaskBarWindowState::Maximized:
+    case LXQtTaskBarWindowState::MaximizedVertically:
+    case LXQtTaskBarWindowState::MaximizedHorizontally:
+    {
+        if ( set ) {
+            window->set_maximized();
+        }
+
+        else {
+            window->unset_maximized();
+        }
+
+        break;
+    }
+    case LXQtTaskBarWindowState::Normal:
+    {
+        if (set)
+        {
+            if ( window->windowState.maximized) {
+                window->unset_maximized();
+            }
+        }
+
+        break;
+    }
+
+    case LXQtTaskBarWindowState::FullScreen:
+    {
+        if ( set ) {
+            window->set_fullscreen(nullptr);
+        }
+
+        else {
+            window->unset_fullscreen();
+        }
+        break;
+    }
+
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+bool LXQtTaskbarNiriBackend::isWindowActive(WId windowId) const
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return false;
+
+    return activeWindow == windowId || window->windowState.activated;
+}
+
+bool LXQtTaskbarNiriBackend::raiseWindow(WId windowId, bool onCurrentWorkSpace)
+{
+    Q_UNUSED(onCurrentWorkSpace) // Cannot be done on a generic wlroots-based compositor!
+
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return false;
+
+    window->activate();
+    return true;
+}
+
+bool LXQtTaskbarNiriBackend::closeWindow(WId windowId)
+{
+    LXQtTaskbarNiriWindow *window = getWindow(windowId);
+    if(!window)
+        return false;
+
+    window->close();
+    return true;
+}
+
+WId LXQtTaskbarNiriBackend::getActiveWindow() const
+{
+    return activeWindow;
+}
+
+int LXQtTaskbarNiriBackend::getWorkspacesCount() const
+{
+    return 1;
+}
+
+QString LXQtTaskbarNiriBackend::getWorkspaceName(int) const
+{
+    return QStringLiteral("Desktop 1");
+}
+
+int LXQtTaskbarNiriBackend::getCurrentWorkspace() const
+{
+    return 1;
+}
+
+bool LXQtTaskbarNiriBackend::setCurrentWorkspace(int)
+{
+    return false;
+}
+
+int LXQtTaskbarNiriBackend::getWindowWorkspace(WId) const
+{
+    return 1;
+}
+
+bool LXQtTaskbarNiriBackend::setWindowOnWorkspace(WId, int)
+{
+    return true;
+}
+
+void LXQtTaskbarNiriBackend::moveApplicationToPrevNextMonitor(WId, bool, bool)
+{
+}
+
+bool LXQtTaskbarNiriBackend::isWindowOnScreen(QScreen *, WId) const
+{
+    // TODO: Manage based on output-enter/output-leave
+    return true;
+}
+
+bool LXQtTaskbarNiriBackend::setDesktopLayout(Qt::Orientation, int, int, bool) {
+    // Niri has no support for workspace as of 2024-August-20
+    return false;
+}
+
+void LXQtTaskbarNiriBackend::moveApplication(WId)
+{
+}
+
+void LXQtTaskbarNiriBackend::resizeApplication(WId)
+{
+}
+
+void LXQtTaskbarNiriBackend::refreshIconGeometry(WId, const QRect &)
+{
+
+}
+
+bool LXQtTaskbarNiriBackend::isAreaOverlapped(const QRect &) const
+{
+    return false;
+}
+
+bool LXQtTaskbarNiriBackend::isShowingDesktop() const
+{
+    return m_managment->isShowingDesktop();
+}
+
+bool LXQtTaskbarNiriBackend::showDesktop(bool value)
+{
+    if (isShowingDesktop() == value)
+        return false;
+
+    // If the windows are going to be restored but all of them are already restored,
+    // removed or closed (e.g., by the user), show the desktop instead.
+    if (!value)
+    {
+        bool hasMinimized = false;
+        for (auto windowId : std::as_const(showDesktopWins))
+        {
+            if (getWindowState(windowId) == LXQtTaskBarWindowState::Minimized
+                && std::find(windows.begin(), windows.end(), windowId) != windows.end())
+            {
+                hasMinimized = true;
+                break;
+            }
+        }
+        if (!hasMinimized)
+            value = true;
+    }
+
+    if (value)
+    {
+        showDesktopWins.clear();
+        QVector<WId> wids = getCurrentWindows();
+        std::sort(wids.begin(), wids.end(), [this](WId id1, WId id2) {
+            // sort the list by activation time to keep the z-order on restoring
+            return (lastActivated.value(id1) < lastActivated.value(id2));
+        });
+        for (auto windowId : std::as_const(wids))
+        {
+            if (getWindowState(windowId) == LXQtTaskBarWindowState::Minimized)
+            { // was minimized before showing the desktop and so, should not be restored later
+                continue;
+            }
+            setWindowState(windowId, LXQtTaskBarWindowState::Minimized, true);
+            showDesktopWins.push_back(windowId);
+        }
+    }
+    else
+    {
+        for (auto windowId : std::as_const(showDesktopWins))
+            setWindowState(windowId, LXQtTaskBarWindowState::Minimized, false);
+        showDesktopWins.clear();
+    }
+    m_managment->setShowingDesktop(!showDesktopWins.empty());
+    return true;
+}
+
+WId LXQtTaskbarNiriBackend::findWindow(WId tgt) const
+{
+    for (auto id : std::as_const(windows)) {
+        if (equalIds(id, tgt)) {
+            return id;
+        }
+    }
+    return 0;
+}
+
+WId LXQtTaskbarNiriBackend::findTopParent(WId winId) const
+{
+    while (getWindow(winId)->parentWindow)
+    {
+        winId = getWindow(winId)->parentWindow;
+        // first search in transients because this may be a child window of another one
+        WId window = 0;
+        for (auto i = transients.cbegin(), end = transients.cend(); i != end; ++i)
+        {
+            if (equalIds(i.key(), winId))
+            {
+                window = i.key();
+                break;
+            }
+        }
+        if (window)
+            winId = window;
+        else
+        {
+            window = findWindow(winId);
+            if (window)
+                winId = window;
+        }
+    }
+    return winId;
+}
+
+void LXQtTaskbarNiriBackend::addWindow(WId winId)
+{
+    for (auto id : std::as_const(windows))
+    {
+        if (id == winId)
+        {
+            return;
+        }
+    }
+
+    if (transients.contains(winId))
+    {
+        return;
+    }
+
+    LXQtTaskbarNiriWindow *window = getWindow(winId);
+    if (window == nullptr) {
+        return;
+    }
+
+    if (window->windowState.activated) {
+        WId pId = findTopParent(winId);
+        setLastActivated(pId);
+        activeWindow = pId;
+        emit activeWindowChanged(activeWindow);
+    }
+
+    connect(window, &LXQtTaskbarNiriWindow::activatedChanged, this, &LXQtTaskbarNiriBackend::onActivatedChanged);
+    connect(window, &LXQtTaskbarNiriWindow::parentChanged, this, &LXQtTaskbarNiriBackend::onParentChanged);
+
+    // add it either to transients or windows
+    if (WId leader = window->parentWindow)
+    {
+        transients.insert(winId, leader);
+        connect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeTransient);
+    }
+    else
+    {
+        addToWindows(winId);
+    }
+}
+
+void LXQtTaskbarNiriBackend::addToWindows(WId winId)
+{
+    LXQtTaskbarNiriWindow *window = getWindow(winId);
+    if (window == nullptr) {
+        return;
+    }
+
+    windows.push_back(winId);
+
+    connect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeWindow);
+    connect(window, &LXQtTaskbarNiriWindow::titleChanged, this, &LXQtTaskbarNiriBackend::onTitleChanged);
+    connect(window, &LXQtTaskbarNiriWindow::appIdChanged, this, &LXQtTaskbarNiriBackend::onAppIdChanged);
+    connect(window, &LXQtTaskbarNiriWindow::fullscreenChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+    connect(window, &LXQtTaskbarNiriWindow::maximizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+    connect(window, &LXQtTaskbarNiriWindow::minimizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+
+    emit windowAdded( winId );
+    emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::WindowClass));
+    emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::Title));
+    emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::Icon));
+    emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::State));
+}
+
+void LXQtTaskbarNiriBackend::removeWindow()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+    {
+        disconnect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeWindow);
+        disconnect(window, &LXQtTaskbarNiriWindow::parentChanged, this, &LXQtTaskbarNiriBackend::onParentChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::activatedChanged, this, &LXQtTaskbarNiriBackend::onActivatedChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::titleChanged, this, &LXQtTaskbarNiriBackend::onTitleChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::appIdChanged, this, &LXQtTaskbarNiriBackend::onAppIdChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::fullscreenChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::maximizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::minimizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+
+        WId winId = window->getWindowId();
+        eraseWindow(windows, winId);
+        lastActivated.remove(winId);
+
+        if (activeWindow == winId)
+        {
+            activeWindow = 0;
+            emit activeWindowChanged(0);
+        }
+
+        emit windowRemoved(winId);
+    }
+}
+
+void LXQtTaskbarNiriBackend::removeTransient()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+    {
+        disconnect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeTransient);
+        disconnect(window, &LXQtTaskbarNiriWindow::parentChanged, this, &LXQtTaskbarNiriBackend::onParentChanged);
+        disconnect(window, &LXQtTaskbarNiriWindow::activatedChanged, this, &LXQtTaskbarNiriBackend::onActivatedChanged);
+        transients.remove(window->getWindowId());
+    }
+}
+
+void LXQtTaskbarNiriBackend::onActivatedChanged()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+    {
+        WId effectiveWindow = findTopParent(window->getWindowId());
+
+        if (window->windowState.activated)
+        {
+            setLastActivated(effectiveWindow);
+
+            if (activeWindow != effectiveWindow)
+            {
+                activeWindow = effectiveWindow;
+                emit activeWindowChanged(activeWindow);
+            }
+        }
+        else
+        {
+            // First check if it has an active child (transient) window.
+            for (auto i = transients.cbegin(), end = transients.cend(); i != end; ++i)
+            {
+                if (window->getWindowId() != i.key() && equalIds(findTopParent(i.key()), effectiveWindow))
+                {
+                    if (auto win = getWindow(i.key()))
+                    {
+                        if (win->windowState.activated)
+                            return;
+                    }
+                }
+            }
+
+            if (activeWindow == effectiveWindow)
+            {
+                activeWindow = 0;
+                emit activeWindowChanged(0);
+            }
+        }
+    }
+}
+
+void LXQtTaskbarNiriBackend::onParentChanged()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+    {
+       WId leader = window->parentWindow;
+
+        /** Basically, check if this window is a transient */
+        if (transients.remove(window->getWindowId()))
+        {
+            if (leader)
+            {
+                // leader change.
+                transients.insert(window->getWindowId(), leader);
+            }
+            else
+            {
+                // lost a leader, add to regular windows list.
+                Q_ASSERT(findWindow(leader) == 0);
+
+                disconnect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeTransient);
+                addToWindows(window->getWindowId());
+
+                // Correct the activation state if an active window that has lost its leader was active before,
+                // because "LXQtTaskbarNiriWindow::activatedChanged" might not be emitted for it.
+                if (window->windowState.activated)
+                {
+                    setLastActivated(window->getWindowId());
+                    activeWindow = window->getWindowId();
+                    emit activeWindowChanged(activeWindow);
+                }
+            }
+        }
+        else if (leader)
+        {
+            // remove it from regular windows list
+            disconnect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeWindow);
+            disconnect(window, &LXQtTaskbarNiriWindow::titleChanged, this, &LXQtTaskbarNiriBackend::onTitleChanged);
+            disconnect(window, &LXQtTaskbarNiriWindow::appIdChanged, this, &LXQtTaskbarNiriBackend::onAppIdChanged);
+            disconnect(window, &LXQtTaskbarNiriWindow::fullscreenChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarNiriWindow::maximizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarNiriWindow::minimizedChanged, this, &LXQtTaskbarNiriBackend::onStateChanged);
+            eraseWindow(windows, window->getWindowId());
+            lastActivated.remove(window->getWindowId());
+            // announce that it's removed
+            emit windowRemoved(window->getWindowId());
+
+            // add it to transients
+            transients.insert(window->getWindowId(), leader);
+            connect(window, &LXQtTaskbarNiriWindow::closed, this, &LXQtTaskbarNiriBackend::removeTransient);
+
+            // Correct the activation state if a window that has got a leader was active before.
+            if (activeWindow == window->getWindowId())
+            {
+                WId pId = findTopParent(window->getWindowId());
+                setLastActivated(pId);
+                activeWindow = pId;
+                emit activeWindowChanged(activeWindow);
+            }
+        }
+    }
+}
+
+void LXQtTaskbarNiriBackend::onTitleChanged()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+        emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::Title));
+}
+
+void LXQtTaskbarNiriBackend::onAppIdChanged()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+        emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::WindowClass));
+}
+
+void LXQtTaskbarNiriBackend::onStateChanged()
+{
+    if (auto window = qobject_cast<LXQtTaskbarNiriWindow *>(QObject::sender()))
+        emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::State));
+}
+
+bool LXQtTaskbarNiriBackend::acceptWindow(WId window) const
+{
+    if(transients.contains(window))
+        return false;
+
+    return true;
+}
+
+LXQtTaskbarNiriWindow *LXQtTaskbarNiriBackend::getWindow(WId windowId) const
+{
+    /** Easiest way is to convert the quintptr to the actual pointer */
+    LXQtTaskbarNiriWindow *win = reinterpret_cast<LXQtTaskbarNiriWindow *>( windowId );
+    if ( win ) {
+        return win;
+    }
+
+    return nullptr;
+}
+
+bool LXQtTaskbarNiriBackend::equalIds(WId windowId1, WId windowId2) const
+{
+    if (windowId1 == windowId2) {
+        return true;
+    }
+    LXQtTaskbarNiriWindow *win1 = reinterpret_cast<LXQtTaskbarNiriWindow *>( windowId1 );
+    LXQtTaskbarNiriWindow *win2 = reinterpret_cast<LXQtTaskbarNiriWindow *>( windowId2 );
+    if (win1 == nullptr && win2 == nullptr) {
+        return true;
+    }
+    if (win1 != nullptr && win2 != nullptr) {
+        return win1->ID == win2->ID;
+    }
+    return false;
+}
+
+void LXQtTaskbarNiriBackend::setLastActivated(WId id)
+{
+    auto t = QDateTime::currentMSecsSinceEpoch();
+    while (lastActivated.key(t) != 0)
+        ++t; // make sure the times are not equal
+    lastActivated[id] = t;
+}
+
+
+int LXQtWMBackendNiriLibrary::getBackendScore(const QString& key) const
+{
+    if (key == QStringLiteral("smithay"))
+    {
+        return 50;
+    }
+
+    if (key == QStringLiteral("niri"))
+    {
+        return 50;
+    }
+
+    else if (key == QStringLiteral("wayfire"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("sway"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("hyprland"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("labwc"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("river"))
+    {
+        return 30;
+    }
+
+    // Unsupported
+    return 0;
+}
+
+
+ILXQtAbstractWMInterface *LXQtWMBackendNiriLibrary::instance() const
+{
+    return new LXQtTaskbarNiriBackend(nullptr);
+}

--- a/panel/backends/wayland/niri/lxqtwmbackend_niri.h
+++ b/panel/backends/wayland/niri/lxqtwmbackend_niri.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "../../ilxqtabstractwmiface.h"
+
+#include <QTime>
+#include <QHash>
+#include <vector>
+
+class LXQtTaskbarNiriWindow;
+class LXQtTaskbarNiriWindowManagment;
+class LXQtNiriWaylandWorkspaceInfo;
+
+
+class LXQtTaskbarNiriBackend : public ILXQtAbstractWMInterface
+{
+    Q_OBJECT
+
+public:
+    explicit LXQtTaskbarNiriBackend(QObject *parent = nullptr);
+
+    // Backend
+    virtual bool supportsAction(WId windowId, LXQtTaskBarBackendAction action) const override;
+
+    // Windows
+    virtual bool reloadWindows() override;
+
+    virtual QVector<WId> getCurrentWindows() const override;
+    virtual QString getWindowTitle(WId windowId) const override;
+    virtual bool applicationDemandsAttention(WId windowId) const override;
+    virtual QIcon getApplicationIcon(WId windowId, int devicePixels) const override;
+    virtual QString getWindowClass(WId windowId) const override;
+
+    virtual LXQtTaskBarWindowLayer getWindowLayer(WId windowId) const override;
+    virtual bool setWindowLayer(WId windowId, LXQtTaskBarWindowLayer layer) override;
+
+    virtual LXQtTaskBarWindowState getWindowState(WId windowId) const override;
+    virtual bool setWindowState(WId windowId, LXQtTaskBarWindowState state, bool set) override;
+
+    virtual bool isWindowActive(WId windowId) const override;
+    virtual bool raiseWindow(WId windowId, bool onCurrentWorkSpace) override;
+
+    virtual bool closeWindow(WId windowId) override;
+
+    virtual WId getActiveWindow() const override;
+
+    // Workspaces
+    virtual int getWorkspacesCount() const override;
+    virtual QString getWorkspaceName(int idx) const override;
+
+    virtual int getCurrentWorkspace() const override;
+    virtual bool setCurrentWorkspace(int idx) override;
+
+    virtual int getWindowWorkspace(WId windowId) const override;
+    virtual bool setWindowOnWorkspace(WId windowId, int idx) override;
+
+    virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next, bool raiseOnCurrentDesktop) override;
+
+    virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
+
+    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft);
+
+    // X11 Specific
+    virtual void moveApplication(WId windowId) override;
+    virtual void resizeApplication(WId windowId) override;
+
+    virtual void refreshIconGeometry(WId windowId, const QRect &geom) override;
+
+    // Panel internal
+    virtual bool isAreaOverlapped(const QRect& area) const override;
+
+    // Show Destop
+    virtual bool isShowingDesktop() const override;
+    virtual bool showDesktop(bool value) override;
+
+private slots:
+    void addWindow(WId wid);
+    void removeWindow();
+    void removeTransient();
+    void onActivatedChanged();
+    void onParentChanged();
+    void onTitleChanged();
+    void onAppIdChanged();
+    void onStateChanged();
+
+private:
+    void addToWindows(WId winId);
+    bool acceptWindow(WId wid) const;
+    WId findWindow(WId tgt) const;
+    WId findTopParent(WId winId) const;
+    bool equalIds(WId windowId1, WId windowId2) const;
+    void setLastActivated(WId id);
+
+    /** Convert WId (i.e. quintptr into LXQtTaskbarNiriWindow*) */
+    LXQtTaskbarNiriWindow *getWindow(WId windowId) const;
+
+    std::unique_ptr<LXQtTaskbarNiriWindowManagment> m_managment;
+
+    QHash<WId, qint64> lastActivated;
+    WId activeWindow = 0;
+    std::vector<WId> windows;
+
+    // for showing desktop
+    std::vector<WId> showDesktopWins;
+
+    // key=transient child, value=leader
+    QHash<WId, WId> transients;
+};
+
+
+class LXQtWMBackendNiriLibrary: public QObject, public ILXQtWMBackendLibrary
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "lxqt.org/Panel/WMInterface/1.0")
+    Q_INTERFACES(ILXQtWMBackendLibrary)
+public:
+    int getBackendScore(const QString& key) const override;
+
+    ILXQtAbstractWMInterface* instance() const override;
+};

--- a/panel/backends/wayland/niri/wlr-foreign-toplevel-management-unstable-v1.xml
+++ b/panel/backends/wayland/niri/wlr-foreign-toplevel-management-unstable-v1.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_foreign_toplevel_management_unstable_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_foreign_toplevel_manager_v1" version="3">
+    <description summary="list and control opened apps">
+      The purpose of this protocol is to enable the creation of taskbars
+      and docks by providing them with a list of opened applications and
+      letting them request certain actions on them, like maximizing, etc.
+
+      After a client binds the zwlr_foreign_toplevel_manager_v1, each opened
+      toplevel window will be sent via the toplevel event
+    </description>
+
+    <event name="toplevel">
+      <description summary="a toplevel has been created">
+        This event is emitted whenever a new toplevel window is created. It
+        is emitted for all toplevels, regardless of the app that has created
+        them.
+
+        All initial details of the toplevel(title, app_id, states, etc.) will
+        be sent immediately after this event via the corresponding events in
+        zwlr_foreign_toplevel_handle_v1.
+      </description>
+      <arg name="toplevel" type="new_id" interface="zwlr_foreign_toplevel_handle_v1"/>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new toplevels.
+        However the compositor may emit further toplevel_created events, until
+        the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events to the
+        zwlr_foreign_toplevel_manager_v1. The server will destroy the object
+        immediately after sending this request, so it will become invalid and
+        the client should free any resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_foreign_toplevel_handle_v1" version="3">
+    <description summary="an opened toplevel">
+      A zwlr_foreign_toplevel_handle_v1 object represents an opened toplevel
+      window. Each app may have multiple opened toplevels.
+
+      Each toplevel has a list of outputs it is visible on, conveyed to the
+      client with the output_enter and output_leave events.
+    </description>
+
+    <event name="title">
+      <description summary="title change">
+        This event is emitted whenever the title of the toplevel changes.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id">
+      <description summary="app-id change">
+        This event is emitted whenever the app-id of the toplevel changes.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="toplevel entered an output">
+        This event is emitted whenever the toplevel becomes visible on
+        the given output. A toplevel may be visible on multiple outputs.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="toplevel left an output">
+        This event is emitted whenever the toplevel stops being visible on
+        the given output. It is guaranteed that an entered-output event
+        with the same output has been emitted before this event.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <request name="set_maximized">
+      <description summary="requests that the toplevel be maximized">
+        Requests that the toplevel be maximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="requests that the toplevel be unmaximized">
+        Requests that the toplevel be unmaximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="requests that the toplevel be minimized">
+        Requests that the toplevel be minimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_minimized">
+      <description summary="requests that the toplevel be unminimized">
+        Requests that the toplevel be unminimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the toplevel">
+        Request that this toplevel be activated on the given seat.
+        There is no guarantee the toplevel will be actually activated.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of states on the toplevel">
+        The different states that a toplevel can have. These have the same meaning
+        as the states with the same names defined in xdg-toplevel
+      </description>
+
+      <entry name="maximized"  value="0" summary="the toplevel is maximized"/>
+      <entry name="minimized"  value="1" summary="the toplevel is minimized"/>
+      <entry name="activated"  value="2" summary="the toplevel is active"/>
+      <entry name="fullscreen" value="3" summary="the toplevel is fullscreen" since="2"/>
+    </enum>
+
+    <event name="state">
+      <description summary="the toplevel state changed">
+        This event is emitted immediately after the zlw_foreign_toplevel_handle_v1
+        is created and each time the toplevel state changes, either because of a
+        compositor action or because of a request in this protocol.
+      </description>
+
+      <arg name="state" type="array"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have been
+        sent.
+
+        This allows changes to the zwlr_foreign_toplevel_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <request name="close">
+      <description summary="request that the toplevel be closed">
+        Send a request to the toplevel to close itself. The compositor would
+        typically use a shell-specific method to carry out this request, for
+        example by sending the xdg_toplevel.close event. However, this gives
+        no guarantees the toplevel will actually be destroyed. If and when
+        this happens, the zwlr_foreign_toplevel_handle_v1.closed event will
+        be emitted.
+      </description>
+    </request>
+
+    <request name="set_rectangle">
+      <description summary="the rectangle which represents the toplevel">
+        The rectangle of the surface specified in this request corresponds to
+        the place where the app using this protocol represents the given toplevel.
+        It can be used by the compositor as a hint for some operations, e.g
+        minimizing. The client is however not required to set this, in which
+        case the compositor is free to decide some default value.
+
+        If the client specifies more than one rectangle, only the last one is
+        considered.
+
+        The dimensions are given in surface-local coordinates.
+        Setting width=height=0 removes the already-set rectangle.
+      </description>
+
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <enum name="error">
+      <entry name="invalid_rectangle" value="0"
+        summary="the provided rectangle is invalid"/>
+    </enum>
+
+    <event name="closed">
+      <description summary="this toplevel has been destroyed">
+        This event means the toplevel has been destroyed. It is guaranteed there
+        won't be any more events for this zwlr_foreign_toplevel_handle_v1. The
+        toplevel itself becomes inert so any requests will be ignored except the
+        destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zwlr_foreign_toplevel_handle_v1 object">
+        Destroys the zwlr_foreign_toplevel_handle_v1 object.
+
+        This request should be called either when the client does not want to
+        use the toplevel anymore or after the closed event to finalize the
+        destruction of the object.
+      </description>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_fullscreen" since="2">
+      <description summary="request that the toplevel be fullscreened">
+        Requests that the toplevel be fullscreened on the given output. If the
+        fullscreen state and/or the outputs the toplevel is visible on actually
+        change, this will be indicated by the state and output_enter/leave
+        events.
+
+        The output parameter is only a hint to the compositor. Also, if output
+        is NULL, the compositor should decide which output the toplevel will be
+        fullscreened on, if at all.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen" since="2">
+      <description summary="request that the toplevel be unfullscreened">
+        Requests that the toplevel be unfullscreened. If the fullscreen state
+        actually changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <event name="parent" since="3">
+      <description summary="parent change">
+        This event is emitted whenever the parent of the toplevel changes.
+
+        No event is emitted when the parent handle is destroyed by the client.
+      </description>
+      <arg name="parent" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="true"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
This is a simple rebranding of the existing wlroots backend with no new functions.  With it `XDG_CURRENT_DESKTOP=LXQt:niri:smithay` could be set in `startlxqtwayland`.

```
[user@archlinux ~]$ env |grep CURR
XDG_CURRENT_DESKTOP=LXQt:niri:wlroots
[user@archlinux ~]$ lxqt-panel
No user preferences available. Attempting auto-detection.

Panel backend: "libwmbackend_niri.so" 

Currently tray plugin supports X11 only. Skipping.
"Can't load plugin \"tray\". Plugin can't build ILXQtPanelPlugin."
Supplied protocol version to QWaylandClientExtensionTemplate is higher than the version of the protocol, using protocol version instead.
 interface.name: zwlr_foreign_toplevel_manager_v1
StatusNotifierProxy, services: QList()
^C

[user@archlinux ~]export XDG_CURRENT_DESKTOP=LXQt:niri:smithay
[user@archlinux ~]$ env |grep CURR
XDG_CURRENT_DESKTOP=LXQt:niri:smithay
[user@archlinux ~]$ lxqt-panel
No user preferences available. Attempting auto-detection.

Panel backend: "libwmbackend_niri.so" 

...                                                                                         
```