### PR TITLE
Improved scoring for Hyprland and Niri

### DIFF
--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -661,38 +661,53 @@ void LXQtTaskbarWlrootsBackend::setLastActivated(WId id)
 
 int LXQtWMBackendWlrootsLibrary::getBackendScore(const QString& key) const
 {
-	if (key == QStringLiteral("wlroots"))
-	{
-		return 50;
-	}
+    if (key == QStringLiteral("wlroots"))
+    {
+        return 50;
+    }
 
-	else if (key == QStringLiteral("wayfire"))
-	{
-		return 30;
-	}
+    if (key == QStringLiteral("smithay"))
+    {
+        return 50;
+    }
 
-	else if (key == QStringLiteral("sway"))
-	{
-		return 30;
-	}
+    if (key == QStringLiteral("aquamarine"))
+    {
+        return 50;
+    }
 
-	else if (key == QStringLiteral("hyprland"))
-	{
-		return 30;
-	}
+    else if (key == QStringLiteral("wayfire"))
+    {
+        return 30;
+    }
 
-	else if (key == QStringLiteral("labwc"))
-	{
-		return 30;
-	}
+    else if (key == QStringLiteral("sway"))
+    {
+        return 30;
+    }
 
-	else if (key == QStringLiteral("river"))
-	{
-		return 30;
-	}
+    else if (key == QStringLiteral("Hyprland"))
+    {
+        return 30;
+    }
 
-	// Unsupported
-	return 0;
+    else if (key == QStringLiteral("labwc"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("river"))
+    {
+        return 30;
+    }
+
+    else if (key == QStringLiteral("niri"))
+    {
+        return 30;
+    }
+
+    // Unsupported
+    return 0;
 }
 
 


### PR DESCRIPTION
Needs https://github.com/lxqt/lxqt-wayland-session/pull/71

Basically Niri and Hyprland had a score of 50 only  by chance of "wlroots", so https://github.com/lxqt/lxqt/discussions/2723 happened when the panel is used outside of `lxqt-session`. 

A similar issue can be seen if` lxqt-panel` is run outside of Hyprland: it wasn't catched as it uses capitalized Hyprland env var.

Tested both niri and hyprland "vanilla" with default configs  and the wlroots backend is loaded fine now.