### PR TITLE
Added a missing removal signal to kwin_wayland backend

### DIFF
--- a/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
+++ b/panel/backends/wayland/kwin_wayland/lxqtwmbackend_kwinwayland.cpp
@@ -741,6 +741,8 @@ void LXQtWMBackend_KWinWayland::addWindow(LXQtTaskBarPlasmaWindow *window)
             auto it = findWindow(windows, window);
             Q_ASSERT(it != windows.end());
 
+            if(window->acceptedInTaskBar)
+                emit windowRemoved(window->getWindowId());
             windows.erase(it);
             lastActivated.remove(window->getWindowId());
         }


### PR DESCRIPTION
In a rare case, its absence created a permanent task-button that had no window.