### PR TITLE
Disabled automatic showing of mount popup on Wayland

### DIFF
--- a/plugin-mount/configuration.cpp
+++ b/plugin-mount/configuration.cpp
@@ -57,7 +57,12 @@ Configuration::Configuration(PluginSettings *settings, QWidget *parent) :
     ui->ejectPressedCombo->setSizePolicy(sp);
 
     // Fill combo boxes
-    ui->devAddedCombo->addItem(tr("Popup menu"), QLatin1String(ACT_SHOW_MENU));
+    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+    {
+        // WARNING: The popup menu does not work consistently under Wayland.
+        // See LXQtMountPlugin::settingsChanged() for an explanation.
+        ui->devAddedCombo->addItem(tr("Popup menu"), QLatin1String(ACT_SHOW_MENU));
+    }
     ui->devAddedCombo->addItem(tr("Show info"),  QLatin1String(ACT_SHOW_INFO));
     ui->devAddedCombo->addItem(tr("Do nothing"), QLatin1String(ACT_NOTHING));
 
@@ -83,11 +88,13 @@ void Configuration::loadSettings()
 {
     mLockSettingChanges = true;
 
+    int defaultIndex = QGuiApplication::platformName() == QStringLiteral("wayland") ? 0 : 1;
+
     QVariant value = settings().value(QLatin1String(CFG_KEY_ACTION), QLatin1String(ACT_SHOW_INFO));
-    setComboboxIndexByData(ui->devAddedCombo, value, 1);
+    setComboboxIndexByData(ui->devAddedCombo, value, defaultIndex);
 
     value = settings().value(QLatin1String(CFG_EJECT_ACTION), QLatin1String(ACT_NOTHING));
-    setComboboxIndexByData(ui->ejectPressedCombo, value, 1);
+    setComboboxIndexByData(ui->ejectPressedCombo, value, defaultIndex);
 
     mLockSettingChanges = false;
 }

--- a/plugin-mount/lxqtmountplugin.cpp
+++ b/plugin-mount/lxqtmountplugin.cpp
@@ -47,7 +47,7 @@ LXQtMountPlugin::LXQtMountPlugin(const ILXQtPanelPluginStartupInfo &startupInfo)
     mKeyEject(nullptr)
 {
     mButton = new Button;
-    mPopup = new Popup(this, mButton);
+    mPopup = new Popup(this);
 
     connect(mButton, &QToolButton::clicked, mPopup, &Popup::showHide);
     connect(mPopup, &Popup::visibilityChanged, mButton, &QToolButton::setDown);
@@ -58,6 +58,7 @@ LXQtMountPlugin::LXQtMountPlugin(const ILXQtPanelPluginStartupInfo &startupInfo)
 LXQtMountPlugin::~LXQtMountPlugin()
 {
     delete mButton;
+    delete mPopup;
 }
 
 


### PR DESCRIPTION
In other words, the option "Popup menu" is removed under Wayland. If it's selected on X11 or by editing the config file manually, the selection won't change, but it will be treated as "Show info" and displayed as such by the config dialog.

The reason is an old problem of Qt+Wayland: Before the first input (mouse) interaction with the app, Wayland displays its popup as a standalone window, e.g., decorated under stacking compositors. Worse than that, if the user lets the popup disappear by itself without clicking anywhere (the code has a timer for it), the first click on the mount button will cause a crash (without backtrace).

NOTE:

I've encountered similar Wayland issues elsewhere, e.g., in `QClipboard`. Their common denominator has been QtWayland's dumbness before the first input interaction.

So, this is the rule of thumb: Under Wayland, don't show a popup of a Qt app and don't rely on `QClipboard` *without a input interaction*.