### PR TITLE
Completed showing current screen windows in wlroots taskbar

### DIFF
--- a/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
+++ b/panel/backends/wayland/wlroots/lxqttaskbarwlrwm.cpp
@@ -457,6 +457,7 @@ void LXQtTaskbarWlrootsWindow::zwlr_foreign_toplevel_handle_v1_done()
     m_pendingState.title = QString();
     m_pendingState.appId = QString();
     m_pendingState.outputs.clear();
+    m_pendingState.outputsLeft.clear();
     m_pendingState.maximized  = false;
     m_pendingState.minimized  = false;
     m_pendingState.activated  = false;

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -278,12 +278,12 @@ bool LXQtTaskbarWlrootsBackend::isWindowOnScreen(QScreen *screen, WId windowId) 
     if(window)
     {
         QtWaylandClient::QWaylandScreen *waylandScreen = dynamic_cast<QtWaylandClient::QWaylandScreen*>(screen->handle());
-        if (waylandScreen) {
+        if (waylandScreen)
+        {
             wl_output *output = waylandScreen->output();
-            return window->windowState.outputs.contains( output );
+            return window->windowState.outputs.contains(output);
         }
     }
-
     return false;
 }
 
@@ -481,6 +481,7 @@ void LXQtTaskbarWlrootsBackend::removeWindow()
         disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
         disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
         disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this, &LXQtTaskbarWlrootsBackend::onOutputsChanged);
 
         WId winId = window->getWindowId();
         eraseWindow(windows, winId);
@@ -588,6 +589,7 @@ void LXQtTaskbarWlrootsBackend::onParentChanged()
             disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
             disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
             disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this, &LXQtTaskbarWlrootsBackend::onOutputsChanged);
             eraseWindow(windows, window->getWindowId());
             lastActivated.remove(window->getWindowId());
             // announce that it's removed
@@ -630,7 +632,7 @@ void LXQtTaskbarWlrootsBackend::onStateChanged()
 void LXQtTaskbarWlrootsBackend::onOutputsChanged()
 {
     if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
-        emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::Workspace));
+        emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::Geometry));
 }
 
 bool LXQtTaskbarWlrootsBackend::acceptWindow(WId window) const

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -204,7 +204,7 @@ void LXQtTaskGroup::onActiveWindowChanged(WId window)
         if (button->hasUrgencyHint())
             button->setUrgencyHint(false);
     }
-    setChecked(nullptr != button);
+    setChecked(nullptr != button && button->isVisibleTo(mPopup));
 }
 
 /************************************************
@@ -393,6 +393,9 @@ void LXQtTaskGroup::refreshVisibility()
         visible &= taskbar->isShowOnlyMinimizedTasks() ? btn->isMinimized() : true;
         btn->setVisible(visible);
         will |= visible;
+        // correct the checked state if this button is checked
+        if (btn->isChecked())
+            setChecked(visible);
     }
 
     bool is = isVisible();


### PR DESCRIPTION
In addition, the task-bar code had a problem that is fixed here:

When window grouping was enabled and only windows from the current screen/desktop were shown, the checked state of task buttons could be wrong if one window inside a group was sent to another screen/desktop.

I think this issue was very old and existed on X11 too but never reported. Anyway, a thorough test under X11 is really needed.

Closes https://github.com/lxqt/lxqt-panel/issues/2091