### PR TITLE
Added a 50-ms delay before making desktop switcher urgent

### DIFF
--- a/plugin-desktopswitch/desktopswitchbutton.cpp
+++ b/plugin-desktopswitch/desktopswitchbutton.cpp
@@ -29,6 +29,7 @@
 #include <QToolButton>
 #include <QStyle>
 #include <QVariant>
+#include <QTimer>
 #include <lxqt-globalkeys.h>
 
 #include "desktopswitchbutton.h"
@@ -74,12 +75,16 @@ void DesktopSwitchButton::setUrgencyHint(WId id, bool urgent)
     else
         mUrgentWIds.remove(id);
 
-    if (mUrgencyHint != !mUrgentWIds.empty())
-    {
-        mUrgencyHint = !mUrgentWIds.empty();
-        setProperty("urgent", mUrgencyHint);
-        style()->unpolish(this);
-        style()->polish(this);
-        QToolButton::update();
-    }
+    // Add a small delay because, under some circumstances, urgencies may
+    // be added and removed instantly, while repolishing can be costly.
+    QTimer::singleShot(50, this, [this]() {
+        if (mUrgencyHint != !mUrgentWIds.empty())
+        {
+            mUrgencyHint = !mUrgentWIds.empty();
+            setProperty("urgent", mUrgencyHint);
+            style()->unpolish(this);
+            style()->polish(this);
+            QToolButton::update();
+        }
+    });
 }


### PR DESCRIPTION
The reason is that urgencies may be added and removed instantly, while repolishing can be expensive and cause blinking.

Closes https://github.com/lxqt/lxqt-panel/issues/2294