### PR TITLE
cmake: fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ find_package(lxqt-menu-data ${LXQT_MINIMUM_VERSION} REQUIRED)
 
 find_package(LayerShellQt REQUIRED)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate REQUIRED)
+    find_package(Qt6WaylandClientPrivate REQUIRED)
+endif()
+
 # Patch Version
 set(LXQT_PANEL_PATCH_VERSION 2)
 set(LXQT_PANEL_VERSION ${LXQT_MAJOR_VERSION}.${LXQT_MINOR_VERSION}.${LXQT_PANEL_PATCH_VERSION})


### PR DESCRIPTION
The 'Qt6FooPrivate' targets have been split into separate CMake files in Qt 6.9, and require a 'find_package(Qt6FooPrivate)' call starting with Qt 6.10.

See also: https://bugreports.qt.io/browse/QTBUG-87776
