### PR TITLE
showdesktop: Add show/hide desktop action on drag&drop

### DIFF
--- a/plugin-showdesktop/showdesktop.cpp
+++ b/plugin-showdesktop/showdesktop.cpp
@@ -26,6 +26,8 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include <QAction>
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
 #include <lxqt-globalkeys.h>
 #include <XdgIcon>
 #include <LXQt/Notification>
@@ -51,9 +53,32 @@ ShowDesktop::ShowDesktop(const ILXQtPanelPluginStartupInfo &startupInfo) :
     QAction * act = new QAction(XdgIcon::fromTheme(QStringLiteral("user-desktop")), tr("Show Desktop"), this);
     connect(act, &QAction::triggered, this, &ShowDesktop::toggleShowingDesktop);
 
+    mDNDTimer.setSingleShot(true);
+    connect(&mDNDTimer, &QTimer::timeout, this, &ShowDesktop::toggleShowingDesktop, Qt::QueuedConnection);
+    mDNDTimer.setInterval(700);
+
     mButton.setDefaultAction(act);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mButton.setAutoRaise(true);
+    mButton.installEventFilter(this);
+    mButton.setAcceptDrops(true);
+}
+
+bool ShowDesktop::eventFilter(QObject * watched, QEvent * event)
+{
+    if (watched == &mButton)
+    {
+        if (event->type() == QEvent::DragEnter)
+        {
+            static_cast<QDragEnterEvent *>(event)->acceptProposedAction();
+            mDNDTimer.start();
+        } else if (event->type() == QEvent::DragLeave)
+        {
+            mDNDTimer.stop();
+        }
+        return false;
+    }
+    return QObject::eventFilter(watched, event);
 }
 
 void ShowDesktop::shortcutRegistered()

--- a/plugin-showdesktop/showdesktop.h
+++ b/plugin-showdesktop/showdesktop.h
@@ -31,6 +31,7 @@
 
 #include "../panel/ilxqtpanelplugin.h"
 #include <QToolButton>
+#include <QTimer>
 
 
 namespace GlobalKeyShortcut
@@ -45,8 +46,10 @@ class ShowDesktop :  public QObject, public ILXQtPanelPlugin
 public:
     ShowDesktop(const ILXQtPanelPluginStartupInfo &startupInfo);
 
-    virtual QWidget *widget() { return &mButton; }
-    virtual QString themeId() const { return QStringLiteral("ShowDesktop"); }
+    virtual QWidget *widget() override { return &mButton; }
+    virtual QString themeId() const override { return QStringLiteral("ShowDesktop"); }
+
+    virtual bool eventFilter(QObject * watched, QEvent * event) override;
 private:
     GlobalKeyShortcut::Action * m_key;
 
@@ -55,6 +58,7 @@ private slots:
     void shortcutRegistered();
 
 private:
+    QTimer mDNDTimer;
     QToolButton mButton;
 };
 


### PR DESCRIPTION
fixes #2307 

Note: using the same "hardcoded" delay value of 700ms as in taskbar for raising windows