### PR TITLE
plugin-mainmenu: Use groupbox and simplify config GUI

### DIFF
--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -76,25 +76,25 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
     connect(ui->shortcutEd->addMenuAction(tr("Reset")), &QAction::triggered, this, &LXQtMainMenuConfiguration::shortcutReset);
 
     connect(ui->customFontCB, &QAbstractButton::toggled, this, &LXQtMainMenuConfiguration::customFontChanged);
-    connect(ui->customFontSizeSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &LXQtMainMenuConfiguration::customFontSizeChanged);
+    connect(ui->customFontSizeSB, &QSpinBox::valueChanged, this, &LXQtMainMenuConfiguration::customFontSizeChanged);
 
     connect(mShortcut, &GlobalKeyShortcut::Action::shortcutChanged, this, &LXQtMainMenuConfiguration::globalShortcutChanged);
 
     connect(ui->filterMenuCB, &QCheckBox::toggled, this, [this] (bool value) {
-        ui->filterClearCB->setEnabled(value || ui->filterShowCB->isChecked());
+        ui->filterClearCB->setEnabled(value || ui->filterShowGB->isChecked());
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterMenu"), value);
     });
-    connect(ui->filterShowCB, &QCheckBox::toggled, this, [this] (bool value) {
+    connect(ui->filterShowGB, &QGroupBox::toggled, this, [this] (bool value) {
         ui->filterClearCB->setEnabled(value || ui->filterMenuCB->isChecked());
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShow"), value);
     });
-    connect(ui->filterShowMaxItemsSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+    connect(ui->filterShowMaxItemsSB, &QSpinBox::valueChanged, this, [this] (int value) {
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShowMaxItems"), value);
     });
-    connect(ui->filterShowMaxWidthSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+    connect(ui->filterShowMaxWidthSB, &QSpinBox::valueChanged, this, [this] (int value) {
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShowMaxWidth"), value);
     });
@@ -140,14 +140,9 @@ void LXQtMainMenuConfiguration::loadSettings()
     const bool filter_menu = settings().value(QStringLiteral("filterMenu"), true).toBool();
     ui->filterMenuCB->setChecked(filter_menu);
     const bool filter_show = settings().value(QStringLiteral("filterShow"), true).toBool();
-    ui->filterShowCB->setChecked(filter_show);
-    ui->filterShowMaxItemsL->setEnabled(filter_show);
-    ui->filterShowMaxItemsSB->setEnabled(filter_show);
+    ui->filterShowGB->setChecked(filter_show);
     ui->filterShowMaxItemsSB->setValue(settings().value(QStringLiteral("filterShowMaxItems"), 10).toInt());
-    ui->filterShowMaxWidthL->setEnabled(filter_show);
-    ui->filterShowMaxWidthSB->setEnabled(filter_show);
     ui->filterShowMaxWidthSB->setValue(settings().value(QStringLiteral("filterShowMaxWidth"), 300).toInt());
-    ui->filterShowHideMenuCB->setEnabled(filter_show);
     ui->filterShowHideMenuCB->setChecked(settings().value(QStringLiteral("filterShowHideMenu"), true).toBool());
     ui->filterClearCB->setChecked(settings().value(QStringLiteral("filterClear"), false).toBool());
     ui->filterClearCB->setEnabled(filter_menu || filter_show);

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.ui
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.ui
@@ -256,64 +256,24 @@
    <signal>toggled(bool)</signal>
    <receiver>customFontSizeSB</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>60</x>
-     <y>249</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>280</x>
-     <y>277</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>showTextCB</sender>
    <signal>toggled(bool)</signal>
    <receiver>textLE</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>239</x>
-     <y>39</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>313</x>
-     <y>68</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>iconCB</sender>
    <signal>toggled(bool)</signal>
    <receiver>iconLE</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>91</x>
-     <y>53</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>284</x>
-     <y>53</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>iconCB</sender>
    <signal>toggled(bool)</signal>
    <receiver>iconPB</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>91</x>
-     <y>53</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>431</x>
-     <y>53</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.ui
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.ui
@@ -154,52 +154,57 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="filterShowCB">
-        <property name="text">
+      <item row="1" column="0" colspan="3">
+       <widget class="QGroupBox" name="filterShowGB">
+        <property name="title">
          <string>Show matching entries:</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="filterShowMaxItemsL">
-        <property name="text">
-         <string>Maximum visible items:</string>
+        <property name="checkable">
+         <bool>true</bool>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="filterShowMaxItemsSB">
-        <property name="maximum">
-         <number>20</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="filterShowMaxWidthL">
-        <property name="text">
-         <string>Max. item width:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="filterShowMaxWidthSB">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-        <property name="minimum">
-         <number>40</number>
-        </property>
-        <property name="maximum">
-         <number>1000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QCheckBox" name="filterShowHideMenuCB">
-        <property name="text">
-         <string>Hide menu entries while searching</string>
-        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="filterShowMaxItemsL">
+           <property name="text">
+            <string>Maximum visible items:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="filterShowMaxItemsSB">
+           <property name="maximum">
+            <number>20</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="filterShowMaxWidthL">
+           <property name="text">
+            <string>Max. item width:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="filterShowMaxWidthSB">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="minimum">
+            <number>40</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="filterShowHideMenuCB">
+           <property name="text">
+            <string>Hide menu entries while searching</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item row="4" column="0" colspan="3">
@@ -307,86 +312,6 @@
     <hint type="destinationlabel">
      <x>431</x>
      <y>53</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterShowCB</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>filterShowMaxItemsSB</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>172</x>
-     <y>374</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>393</x>
-     <y>374</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterShowCB</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>filterShowMaxItemsL</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>374</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>269</x>
-     <y>374</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterShowCB</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>filterShowMaxWidthSB</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>352</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>396</x>
-     <y>378</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterShowCB</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>filterShowMaxWidthL</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>352</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>269</x>
-     <y>378</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterShowCB</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>filterShowHideMenuCB</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>110</x>
-     <y>374</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>332</x>
-     <y>437</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This is somewhat unimportant due to Fancy Menu being the new default, but it reduces GUI code and should speed up builds.

Arguably it makes the GUI more clear, unless nested groupboxes are a point of confusion.