### PR TITLE
Prevent showing of backlight slider from changing backlight

### DIFF
--- a/plugin-backlight/sliderdialog.cpp
+++ b/plugin-backlight/sliderdialog.cpp
@@ -58,7 +58,7 @@ SliderDialog::SliderDialog(QWidget *parent) : QDialog(parent, Qt::Dialog | Qt::W
 
     if(m_backlight->isBacklightAvailable() || m_backlight->isBacklightOff()) {
         // Set the minimum to 5% of the maximum to prevent a black screen
-        int minBacklight = std::max(std::round((qreal)(m_backlight->getMaxBacklight())*0.05), 1.0);
+        int minBacklight = std::max(std::round(static_cast<double>(m_backlight->getMaxBacklight())*0.05), 1.0);
         int maxBacklight = m_backlight->getMaxBacklight();
         int interval = maxBacklight - minBacklight;
         if(interval <= 100) {
@@ -69,7 +69,7 @@ SliderDialog::SliderDialog(QWidget *parent) : QDialog(parent, Qt::Dialog | Qt::W
             m_slider->setMaximum(100);
             // Set the minimum to 5% of the maximum to prevent a black screen
             m_slider->setMinimum(5);
-            m_slider->setValue( (m_backlight->getBacklight() * 100) / maxBacklight);
+            m_slider->setValue(std::round(static_cast<double>(m_backlight->getBacklight() * 100) / maxBacklight));
         }
     } else {
         m_slider->setValue(0);
@@ -87,7 +87,7 @@ SliderDialog::SliderDialog(QWidget *parent) : QDialog(parent, Qt::Dialog | Qt::W
 void SliderDialog::sliderValueChanged(int value)
 {
     // Set the minimum to 5% of the maximum to prevent a black screen
-    int minBacklight = std::max(std::round((qreal)(m_backlight->getMaxBacklight())*0.05), 1.0);
+    int minBacklight = std::max(std::round(static_cast<double>(m_backlight->getMaxBacklight())*0.05), 1.0);
     int maxBacklight = m_backlight->getMaxBacklight();
     int interval = maxBacklight - minBacklight;
     if(interval > 100)
@@ -99,13 +99,15 @@ void SliderDialog::sliderValueChanged(int value)
 void SliderDialog::updateBacklight()
 {
     // Set the minimum to 5% of the maximum to prevent a black screen
-    int minBacklight = std::max(std::round((qreal)(m_backlight->getMaxBacklight())*0.05), 1.0);
+    int minBacklight = std::max(std::round(static_cast<double>(m_backlight->getMaxBacklight())*0.05), 1.0);
     int maxBacklight = m_backlight->getMaxBacklight();
     int interval = maxBacklight - minBacklight;
+    disconnect(m_slider, &QSlider::valueChanged, this, &SliderDialog::sliderValueChanged);
     if(interval <= 100)
         m_slider->setValue(m_backlight->getBacklight());
     else
-        m_slider->setValue( (m_backlight->getBacklight() * 100) / maxBacklight);
+        m_slider->setValue(std::round(static_cast<double>(m_backlight->getBacklight() * 100) / maxBacklight));
+    connect(m_slider, &QSlider::valueChanged, this, &SliderDialog::sliderValueChanged);
 }
 
 void SliderDialog::downButtonClicked(bool)

--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -311,7 +311,7 @@ void DesktopSwitchWidget::wheelEvent(QWheelEvent *e)
     m_mouseWheelThresholdCounter -= rotationSteps;
 
     // If the user hasn't scrolled far enough in one direction (positive or negative): do nothing
-    if(abs(m_mouseWheelThresholdCounter) < 100)
+    if(std::abs(m_mouseWheelThresholdCounter) < 100)
         return;
 
     LXQtPanelApplication *a = reinterpret_cast<LXQtPanelApplication*>(qApp);


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-panel/issues/2320

Also, added a missing `std::` to `desktopswitch.cpp` — its absence was harmless though.