### PR TITLE
ext-workspace-v1 support

### DIFF
--- a/panel/backends/wayland/wlroots/CMakeLists.txt
+++ b/panel/backends/wayland/wlroots/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
     SRC
     lxqtwmbackend_wlr.cpp lxqtwmbackend_wlr.h
     lxqttaskbarwlrwm.cpp lxqttaskbarwlrwm.h
+    workspace.cpp workspace.hpp
 )
 
 add_library(${NAME} MODULE ${SRC}) # build dynamically loadable modules
@@ -32,4 +33,5 @@ target_link_libraries(${NAME} ${QTX_LIBRARIES} Qt6::Concurrent Qt6Xdg)
 
 qt6_generate_wayland_protocol_client_sources(${NAME} FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/wlr-foreign-toplevel-management-unstable-v1.xml
+    ${CMAKE_CURRENT_SOURCE_DIR}/ext-workspace-v1.xml
 )

--- a/panel/backends/wayland/wlroots/ext-workspace-v1.xml
+++ b/panel/backends/wayland/wlroots/ext-workspace-v1.xml
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_workspace_v1">
+  <copyright>
+    Copyright © 2019 Christopher Billington
+    Copyright © 2020 Ilia Bozhinov
+    Copyright © 2022 Victoria Brekenfeld
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="ext_workspace_manager_v1" version="1">
+    <description summary="list and control workspaces">
+      Workspaces, also called virtual desktops, are groups of surfaces. A
+      compositor with a concept of workspaces may only show some such groups of
+      surfaces (those of 'active' workspaces) at a time. 'Activating' a
+      workspace is a request for the compositor to display that workspace's
+      surfaces as normal, whereas the compositor may hide or otherwise
+      de-emphasise surfaces that are associated only with 'inactive' workspaces.
+      Workspaces are grouped by which sets of outputs they correspond to, and
+      may contain surfaces only from those outputs. In this way, it is possible
+      for each output to have its own set of workspaces, or for all outputs (or
+      any other arbitrary grouping) to share workspaces. Compositors may
+      optionally conceptually arrange each group of workspaces in an
+      N-dimensional grid.
+
+      The purpose of this protocol is to enable the creation of taskbars and
+      docks by providing them with a list of workspaces and their properties,
+      and allowing them to activate and deactivate workspaces.
+
+      After a client binds the ext_workspace_manager_v1, each workspace will be
+      sent via the workspace event.
+    </description>
+
+    <event name="workspace_group">
+      <description summary="a workspace group has been created">
+        This event is emitted whenever a new workspace group has been created.
+
+        All initial details of the workspace group (outputs) will be
+        sent immediately after this event via the corresponding events in
+        ext_workspace_group_handle_v1 and ext_workspace_handle_v1.
+      </description>
+      <arg name="workspace_group" type="new_id" interface="ext_workspace_group_handle_v1"/>
+    </event>
+
+    <event name="workspace">
+      <description summary="workspace has been created">
+        This event is emitted whenever a new workspace has been created.
+
+        All initial details of the workspace (name, coordinates, state) will
+        be sent immediately after this event via the corresponding events in
+        ext_workspace_handle_v1.
+
+        Workspaces start off unassigned to any workspace group.
+      </description>
+      <arg name="workspace" type="new_id" interface="ext_workspace_handle_v1"/>
+    </event>
+  
+    <request name="commit">
+      <description summary="all requests about the workspaces have been sent">
+        The client must send this request after it has finished sending other
+        requests. The compositor must process a series of requests preceding a
+        commit request atomically.
+
+        This allows changes to the workspace properties to be seen as atomic,
+        even if they happen via multiple events, and even if they involve
+        multiple ext_workspace_handle_v1 objects, for example, deactivating one
+        workspace and activating another.
+      </description>
+    </request>
+
+    <event name="done">
+      <description summary="all information about the workspaces and workspace groups has been sent">
+        This event is sent after all changes in all workspaces and workspace groups have been
+        sent.
+
+        This allows changes to one or more ext_workspace_group_handle_v1
+        properties and ext_workspace_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events.
+        In particular, an output moving from one workspace group to
+        another sends an output_enter event and an output_leave event to the two
+        ext_workspace_group_handle_v1 objects in question. The compositor sends
+        the done event only after updating the output information in both
+        workspace groups.
+      </description>
+    </event>
+
+    <event name="finished" type="destructor">
+      <description summary="the compositor has finished with the workspace_manager">
+        This event indicates that the compositor is done sending events to the
+        ext_workspace_manager_v1. The server will destroy the object
+        immediately after sending this request.
+      </description>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new
+        workspace groups. However the compositor may emit further workspace
+        events, until the finished event is emitted. The compositor is expected
+        to send the finished event eventually once the stop request has been processed.
+
+        The client must not send any requests after this one, doing so will raise a wl_display
+        invalid_object error.
+      </description>
+    </request>
+
+  </interface>
+
+  <interface name="ext_workspace_group_handle_v1" version="1">
+    <description summary="a workspace group assigned to a set of outputs">
+      A ext_workspace_group_handle_v1 object represents a workspace group
+      that is assigned a set of outputs and contains a number of workspaces.
+
+      The set of outputs assigned to the workspace group is conveyed to the client via
+      output_enter and output_leave events, and its workspaces are conveyed with
+      workspace events.
+
+      For example, a compositor which has a set of workspaces for each output may
+      advertise a workspace group (and its workspaces) per output, whereas a compositor
+      where a workspace spans all outputs may advertise a single workspace group for all
+      outputs.
+    </description>
+
+    <enum name="group_capabilities" bitfield="true">
+      <entry name="create_workspace" value="1" summary="create_workspace request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for creating workspaces, a button
+        triggering the create_workspace request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for creating workspaces will ignore
+        create_workspace requests.
+
+        Compositors must send this event once after creation of an
+        ext_workspace_group_handle_v1. When the capabilities change, compositors
+        must send this event again.
+      </description>
+      <arg name="capabilities" type="uint" summary="capabilities" enum="group_capabilities"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="output assigned to workspace group">
+        This event is emitted whenever an output is assigned to the workspace
+        group or a new `wl_output` object is bound by the client, which was already
+        assigned to this workspace_group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="output removed from workspace group">
+        This event is emitted whenever an output is removed from the workspace
+        group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="workspace_enter">
+      <description summary="workspace added to workspace group">
+        This event is emitted whenever a workspace is assigned to this group.
+        A workspace may only ever be assigned to a single group at a single point
+        in time, but can be re-assigned during it's lifetime.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="workspace_leave">
+      <description summary="workspace removed from workspace group">
+        This event is emitted whenever a workspace is removed from this group.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="removed">
+      <description summary="this workspace group has been removed">
+        This event is send when the group associated with the ext_workspace_group_handle_v1
+        has been removed. After sending this request the compositor will immediately consider
+        the object inert. Any requests will be ignored except the destroy request.
+        It is guaranteed there won't be any more events referencing this
+        ext_workspace_group_handle_v1.
+
+        The compositor must remove all workspaces belonging to a workspace group
+        via a workspace_leave event before removing the workspace group.
+      </description>
+    </event>
+
+    <request name="create_workspace">
+      <description summary="create a new workspace">
+        Request that the compositor create a new workspace with the given name
+        and assign it to this group.
+
+        There is no guarantee that the compositor will create a new workspace,
+        or that the created workspace will have the provided name.
+      </description>
+      <arg name="workspace" type="string"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_workspace_group_handle_v1 object">
+        Destroys the ext_workspace_group_handle_v1 object.
+
+        This request should be send either when the client does not want to
+        use the workspace group object any more or after the removed event to finalize
+        the destruction of the object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_workspace_handle_v1" version="1">
+    <description summary="a workspace handing a group of surfaces">
+      A ext_workspace_handle_v1 object represents a workspace that handles a
+      group of surfaces.
+
+      Each workspace has:
+      - a name, conveyed to the client with the name event
+      - potentially an id conveyed with the id event
+      - a list of states, conveyed to the client with the state event
+      - and optionally a set of coordinates, conveyed to the client with the
+      coordinates event
+      
+      The client may request that the compositor activate or deactivate the workspace.
+
+      Each workspace can belong to only a single workspace group.
+      Depending on the compositor policy, there might be workspaces with
+      the same name in different workspace groups, but these workspaces are still
+      separate (e.g. one of them might be active while the other is not).
+    </description>
+
+    <event name="id">
+      <description summary="workspace id">
+        If this event is emitted, it will be send immediately after the
+        ext_workspace_handle_v1 is created or when an id is assigned to
+        a workspace (at most once during it's lifetime).
+
+        An id will never change during the lifetime of the `ext_workspace_handle_v1`
+        and is guaranteed to be unique during it's lifetime.
+
+        Ids are not human-readable and shouldn't be displayed, use `name` for that purpose.
+
+        Compositors are expected to only send ids for workspaces likely stable across multiple
+        sessions and can be used by clients to store preferences for workspaces. Workspaces without
+        ids should be considered temporary and any data associated with them should be deleted once
+        the respective object is lost.
+      </description>
+      <arg name="id" type="string"/>
+    </event>
+
+    <event name="name">
+      <description summary="workspace name changed">
+        This event is emitted immediately after the ext_workspace_handle_v1 is
+        created and whenever the name of the workspace changes.
+
+        A name is meant to be human-readable and can be displayed to a user.
+        Unlike the id it is neither stable nor unique.
+      </description>
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="coordinates">
+      <description summary="workspace coordinates changed">
+        This event is used to organize workspaces into an N-dimensional grid
+        within a workspace group, and if supported, is emitted immediately after
+        the ext_workspace_handle_v1 is created and whenever the coordinates of
+        the workspace change. Compositors may not send this event if they do not
+        conceptually arrange workspaces in this way. If compositors simply
+        number workspaces, without any geometric interpretation, they may send
+        1D coordinates, which clients should not interpret as implying any
+        geometry. Sending an empty array means that the compositor no longer
+        orders the workspace geometrically.
+
+        Coordinates have an arbitrary number of dimensions N with an uint32
+        position along each dimension. By convention if N > 1, the first
+        dimension is X, the second Y, the third Z, and so on. The compositor may
+        chose to utilize these events for a more novel workspace layout
+        convention, however. No guarantee is made about the grid being filled or
+        bounded; there may be a workspace at coordinate 1 and another at
+        coordinate 1000 and none in between. Within a workspace group, however,
+        workspaces must have unique coordinates of equal dimensionality.
+      </description>
+      <arg name="coordinates" type="array"/>
+    </event>
+
+    <enum name="state" bitfield="true">
+      <description summary="types of states on the workspace">
+        The different states that a workspace can have.
+      </description>
+
+      <entry name="active" value="1" summary="the workspace is active"/>
+      <entry name="urgent" value="2" summary="the workspace requests attention"/>
+      <entry name="hidden" value="4">
+        <description summary="the workspace is not visible">
+          The workspace is not visible in its workspace group, and clients
+          attempting to visualize the compositor workspace state should not
+          display such workspaces.
+        </description>
+      </entry>
+    </enum>
+
+    <event name="state">
+      <description summary="the state of the workspace changed">
+        This event is emitted immediately after the ext_workspace_handle_v1 is
+        created and each time the workspace state changes, either because of a
+        compositor action or because of a request in this protocol.
+
+        Missing states convey the opposite meaning, e.g. an unset active bit
+        means the workspace is currently inactive.
+      </description>
+      <arg name="state" type="uint" enum="state"/>
+    </event>
+
+    <enum name="workspace_capabilities" bitfield="true">
+      <entry name="activate" value="1" summary="activate request is available"/>
+      <entry name="deactivate" value="2" summary="deactivate request is available"/>
+      <entry name="remove" value="4" summary="remove request is available"/>
+      <entry name="assign" value="8" summary="assign request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for removing workspaces, a button
+        triggering the remove request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for remove will ignore
+        remove requests.
+
+        Compositors must send this event once after creation of an
+        ext_workspace_handle_v1 . When the capabilities change, compositors
+        must send this event again.
+      </description>
+      <arg name="capabilities" type="uint" summary="capabilities" enum="workspace_capabilities"/>
+    </event>
+
+    <event name="removed">
+      <description summary="this workspace has been removed">
+        This event is send when the workspace associated with the ext_workspace_handle_v1
+        has been removed. After sending this request, the compositor will immediately consider
+        the object inert. Any requests will be ignored except the destroy request.
+
+        It is guaranteed there won't be any more events referencing this
+        ext_workspace_handle_v1.
+
+        The compositor must only remove a workspaces not currently belonging to any
+        workspace_group.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_workspace_handle_v1 object">
+        Destroys the ext_workspace_handle_v1 object.
+
+        This request should be made either when the client does not want to
+        use the workspace object any more or after the remove event to finalize
+        the destruction of the object.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the workspace">
+        Request that this workspace be activated.
+
+        There is no guarantee the workspace will be actually activated, and
+        behaviour may be compositor-dependent. For example, activating a
+        workspace may or may not deactivate all other workspaces in the same
+        group.
+      </description>
+    </request>
+
+    <request name="deactivate">
+      <description summary="deactivate the workspace">
+        Request that this workspace be deactivated.
+
+        There is no guarantee the workspace will be actually deactivated.
+      </description>
+    </request>
+
+    <request name="assign">
+      <description summary="assign workspace to group">
+        Requests that this workspace is assigned to the given workspace group.
+
+        There is no guarantee the workspace will be assigned.
+      </description>
+      <arg name="workspace_group" type="object" interface="ext_workspace_group_handle_v1"/>
+    </request>
+
+    <request name="remove">
+      <description summary="remove the workspace">
+        Request that this workspace be removed.
+
+        There is no guarantee the workspace will be actually removed.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -35,8 +35,10 @@ LXQtTaskbarWlrootsBackend::LXQtTaskbarWlrootsBackend(QObject *parent) :
     connect(m_wsmgr.get(), &LXQt::Taskbar::WorkspaceManagerV1::workspaceAdded, this,
         &LXQtTaskbarWlrootsBackend::workspacesCountChanged);
 
-    connect(m_wsmgr.get(), &LXQt::Taskbar::WorkspaceManagerV1::currentWorkspaceChanged, this, [this] () {
-
+    connect(m_wsmgr.get(), &LXQt::Taskbar::WorkspaceManagerV1::currentWorkspaceChanged, this, [this] ()
+    {
+        qDebug() << "Current workspace changed" << m_wsmgr->currentWorkspaceIndex();
+        emit currentWorkspaceChanged(m_wsmgr->currentWorkspaceIndex(), QString());
     });
 }
 
@@ -299,7 +301,9 @@ int LXQtTaskbarWlrootsBackend::getCurrentWorkspace() const
 
 bool LXQtTaskbarWlrootsBackend::setCurrentWorkspace(int idx)
 {
+    qDebug() << "Setting current workspace" << idx;
     m_wsmgr->setCurrentWorkspaceIndex(idx);
+    m_wsmgr->commit();
 
     /** Currently we always assume that this is true */
     return true;

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -1,5 +1,6 @@
 #include "lxqttaskbarwlrwm.h"
 #include "lxqtwmbackend_wlr.h"
+#include "workspace.hpp"
 
 #include <QIcon>
 #include <QDateTime>
@@ -9,12 +10,14 @@
 #include <private/qwaylandscreen_p.h>
 
 // Function to erase a window from the vector
-void eraseWindow(std::vector<WId>& windows, WId tgt) {
+void eraseWindow(std::vector<WId>& windows, WId tgt)
+{
     // Use std::vector::iterator to find the window
     auto it = std::find(windows.begin(), windows.end(), tgt);
 
     // Check if the window was found
-    if (it != windows.end()) {
+    if (it != windows.end())
+    {
         // If found, erase the element pointed to by the iterator
         windows.erase(it);
     }
@@ -25,23 +28,24 @@ LXQtTaskbarWlrootsBackend::LXQtTaskbarWlrootsBackend(QObject *parent) :
 {
     m_managment.reset(new LXQtTaskbarWlrootsWindowManagment);
 
-    connect(m_managment.get(), &LXQtTaskbarWlrootsWindowManagment::windowCreated, this, &LXQtTaskbarWlrootsBackend::addWindow);
+    connect(m_managment.get(), &LXQtTaskbarWlrootsWindowManagment::windowCreated, this,
+        &LXQtTaskbarWlrootsBackend::addWindow);
 }
 
 bool LXQtTaskbarWlrootsBackend::supportsAction(WId, LXQtTaskBarBackendAction action) const
 {
     switch (action)
     {
-    case LXQtTaskBarBackendAction::Maximize:
+      case LXQtTaskBarBackendAction::Maximize:
         return true;
 
-    case LXQtTaskBarBackendAction::Minimize:
+      case LXQtTaskBarBackendAction::Minimize:
         return true;
 
-    case LXQtTaskBarBackendAction::FullScreen:
+      case LXQtTaskBarBackendAction::FullScreen:
         return true;
 
-    default:
+      default:
         return false;
     }
 
@@ -53,11 +57,12 @@ bool LXQtTaskbarWlrootsBackend::reloadWindows()
     const QVector<WId> wids = getCurrentWindows();
 
     // Force removal and re-adding
-    for(WId windowId : wids)
+    for (WId windowId : wids)
     {
         emit windowRemoved(windowId);
     }
-    for(WId windowId : wids)
+
+    for (WId windowId : wids)
     {
         emit windowAdded(windowId);
     }
@@ -69,7 +74,8 @@ QVector<WId> LXQtTaskbarWlrootsBackend::getCurrentWindows() const
 {
     QVector<WId> wids;
 
-    for( WId wid: windows ){
+    for ( WId wid : windows )
+    {
         wids << wid;
     }
 
@@ -79,8 +85,10 @@ QVector<WId> LXQtTaskbarWlrootsBackend::getCurrentWindows() const
 QString LXQtTaskbarWlrootsBackend::getWindowTitle(WId windowId) const
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return QString();
+    }
 
     return window->windowState.title;
 }
@@ -95,8 +103,10 @@ QIcon LXQtTaskbarWlrootsBackend::getApplicationIcon(WId windowId, int devicePixe
     Q_UNUSED(devicePixels)
 
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return QIcon();
+    }
 
     return window->icon;
 }
@@ -104,8 +114,11 @@ QIcon LXQtTaskbarWlrootsBackend::getApplicationIcon(WId windowId, int devicePixe
 QString LXQtTaskbarWlrootsBackend::getWindowClass(WId windowId) const
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return QString();
+    }
+
     return window->windowState.appId;
 }
 
@@ -122,17 +135,25 @@ bool LXQtTaskbarWlrootsBackend::setWindowLayer(WId, LXQtTaskBarWindowLayer)
 LXQtTaskBarWindowState LXQtTaskbarWlrootsBackend::getWindowState(WId windowId) const
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return LXQtTaskBarWindowState::Normal;
+    }
 
-    if(window->windowState.minimized)
+    if (window->windowState.minimized)
+    {
         return LXQtTaskBarWindowState::Minimized;
+    }
 
-    if(window->windowState.maximized)
+    if (window->windowState.maximized)
+    {
         return LXQtTaskBarWindowState::Maximized;
+    }
 
-    if(window->windowState.fullscreen)
+    if (window->windowState.fullscreen)
+    {
         return LXQtTaskBarWindowState::FullScreen;
+    }
 
     return LXQtTaskBarWindowState::Normal;
 }
@@ -140,42 +161,47 @@ LXQtTaskBarWindowState LXQtTaskbarWlrootsBackend::getWindowState(WId windowId) c
 bool LXQtTaskbarWlrootsBackend::setWindowState(WId windowId, LXQtTaskBarWindowState state, bool set)
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return false;
+    }
 
     switch (state)
     {
-    case LXQtTaskBarWindowState::Minimized:
+      case LXQtTaskBarWindowState::Minimized:
     {
-        if ( set ) {
+        if (set)
+        {
             window->set_minimized();
-        }
-
-        else {
+        } else
+        {
             window->unset_minimized();
         }
 
         break;
     }
-    case LXQtTaskBarWindowState::Maximized:
-    case LXQtTaskBarWindowState::MaximizedVertically:
-    case LXQtTaskBarWindowState::MaximizedHorizontally:
-    {
-        if ( set ) {
-            window->set_maximized();
-        }
 
-        else {
+      case LXQtTaskBarWindowState::Maximized:
+      case LXQtTaskBarWindowState::MaximizedVertically:
+      case LXQtTaskBarWindowState::MaximizedHorizontally:
+    {
+        if (set)
+        {
+            window->set_maximized();
+        } else
+        {
             window->unset_maximized();
         }
 
         break;
     }
-    case LXQtTaskBarWindowState::Normal:
+
+      case LXQtTaskBarWindowState::Normal:
     {
         if (set)
         {
-            if ( window->windowState.maximized) {
+            if (window->windowState.maximized)
+            {
                 window->unset_maximized();
             }
         }
@@ -183,19 +209,20 @@ bool LXQtTaskbarWlrootsBackend::setWindowState(WId windowId, LXQtTaskBarWindowSt
         break;
     }
 
-    case LXQtTaskBarWindowState::FullScreen:
+      case LXQtTaskBarWindowState::FullScreen:
     {
-        if ( set ) {
+        if (set)
+        {
             window->set_fullscreen(nullptr);
-        }
-
-        else {
+        } else
+        {
             window->unset_fullscreen();
         }
+
         break;
     }
 
-    default:
+      default:
         return false;
     }
 
@@ -205,8 +232,10 @@ bool LXQtTaskbarWlrootsBackend::setWindowState(WId windowId, LXQtTaskBarWindowSt
 bool LXQtTaskbarWlrootsBackend::isWindowActive(WId windowId) const
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return false;
+    }
 
     return activeWindow == windowId || window->windowState.activated;
 }
@@ -216,8 +245,10 @@ bool LXQtTaskbarWlrootsBackend::raiseWindow(WId windowId, bool onCurrentWorkSpac
     Q_UNUSED(onCurrentWorkSpace) // Cannot be done on a generic wlroots-based compositor!
 
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return false;
+    }
 
     window->activate();
     return true;
@@ -226,8 +257,10 @@ bool LXQtTaskbarWlrootsBackend::raiseWindow(WId windowId, bool onCurrentWorkSpac
 bool LXQtTaskbarWlrootsBackend::closeWindow(WId windowId)
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(!window)
+    if (!window)
+    {
         return false;
+    }
 
     window->close();
     return true;
@@ -240,7 +273,7 @@ WId LXQtTaskbarWlrootsBackend::getActiveWindow() const
 
 int LXQtTaskbarWlrootsBackend::getWorkspacesCount() const
 {
-    return 1;
+    return m_wsmgr->workspaceCount();
 }
 
 QString LXQtTaskbarWlrootsBackend::getWorkspaceName(int, QString) const
@@ -250,12 +283,15 @@ QString LXQtTaskbarWlrootsBackend::getWorkspaceName(int, QString) const
 
 int LXQtTaskbarWlrootsBackend::getCurrentWorkspace() const
 {
-    return 1;
+    return m_wsmgr->currentWorkspaceIndex();
 }
 
-bool LXQtTaskbarWlrootsBackend::setCurrentWorkspace(int)
+bool LXQtTaskbarWlrootsBackend::setCurrentWorkspace(int idx)
 {
-    return false;
+    m_wsmgr->setCurrentWorkspaceIndex(idx);
+
+    /** Currently we always assume that this is true */
+    return true;
 }
 
 int LXQtTaskbarWlrootsBackend::getWindowWorkspace(WId) const
@@ -275,19 +311,22 @@ void LXQtTaskbarWlrootsBackend::moveApplicationToPrevNextMonitor(WId, bool, bool
 bool LXQtTaskbarWlrootsBackend::isWindowOnScreen(QScreen *screen, WId windowId) const
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(windowId);
-    if(window)
+    if (window)
     {
-        QtWaylandClient::QWaylandScreen *waylandScreen = dynamic_cast<QtWaylandClient::QWaylandScreen*>(screen->handle());
+        QtWaylandClient::QWaylandScreen *waylandScreen =
+            dynamic_cast<QtWaylandClient::QWaylandScreen*>(screen->handle());
         if (waylandScreen)
         {
             wl_output *output = waylandScreen->output();
             return window->windowState.outputs.contains(output);
         }
     }
+
     return false;
 }
 
-bool LXQtTaskbarWlrootsBackend::setDesktopLayout(Qt::Orientation, int, int, bool) {
+bool LXQtTaskbarWlrootsBackend::setDesktopLayout(Qt::Orientation, int, int, bool)
+{
     // Wlroots has no support for workspace as of 2024-August-20
     return false;
 }
@@ -302,7 +341,6 @@ void LXQtTaskbarWlrootsBackend::resizeApplication(WId)
 
 void LXQtTaskbarWlrootsBackend::refreshIconGeometry(WId, const QRect &)
 {
-
 }
 
 bool LXQtTaskbarWlrootsBackend::isAreaOverlapped(const QRect &) const
@@ -318,7 +356,9 @@ bool LXQtTaskbarWlrootsBackend::isShowingDesktop() const
 bool LXQtTaskbarWlrootsBackend::showDesktop(bool value)
 {
     if (isShowingDesktop() == value)
+    {
         return false;
+    }
 
     // If the windows are going to be restored but all of them are already restored,
     // removed or closed (e.g., by the user), show the desktop instead.
@@ -327,52 +367,64 @@ bool LXQtTaskbarWlrootsBackend::showDesktop(bool value)
         bool hasMinimized = false;
         for (auto windowId : std::as_const(showDesktopWins))
         {
-            if (getWindowState(windowId) == LXQtTaskBarWindowState::Minimized
-                && std::find(windows.begin(), windows.end(), windowId) != windows.end())
+            if ((getWindowState(windowId) == LXQtTaskBarWindowState::Minimized) &&
+                (std::find(windows.begin(), windows.end(), windowId) != windows.end()))
             {
                 hasMinimized = true;
                 break;
             }
         }
+
         if (!hasMinimized)
+        {
             value = true;
+        }
     }
 
     if (value)
     {
         showDesktopWins.clear();
         QVector<WId> wids = getCurrentWindows();
-        std::sort(wids.begin(), wids.end(), [this](WId id1, WId id2) {
+        std::sort(wids.begin(), wids.end(), [this] (WId id1, WId id2)
+        {
             // sort the list by activation time to keep the z-order on restoring
             return (lastActivated.value(id1) < lastActivated.value(id2));
         });
         for (auto windowId : std::as_const(wids))
         {
             if (getWindowState(windowId) == LXQtTaskBarWindowState::Minimized)
-            { // was minimized before showing the desktop and so, should not be restored later
+            {
+                // was minimized before showing the desktop and so, should not be restored later
                 continue;
             }
+
             setWindowState(windowId, LXQtTaskBarWindowState::Minimized, true);
             showDesktopWins.push_back(windowId);
         }
-    }
-    else
+    } else
     {
         for (auto windowId : std::as_const(showDesktopWins))
+        {
             setWindowState(windowId, LXQtTaskBarWindowState::Minimized, false);
+        }
+
         showDesktopWins.clear();
     }
+
     m_managment->setShowingDesktop(!showDesktopWins.empty());
     return true;
 }
 
 WId LXQtTaskbarWlrootsBackend::findWindow(WId tgt) const
 {
-    for (auto id : std::as_const(windows)) {
-        if (equalIds(id, tgt)) {
+    for (auto id : std::as_const(windows))
+    {
+        if (equalIds(id, tgt))
+        {
             return id;
         }
     }
+
     return 0;
 }
 
@@ -391,15 +443,20 @@ WId LXQtTaskbarWlrootsBackend::findTopParent(WId winId) const
                 break;
             }
         }
+
         if (window)
+        {
             winId = window;
-        else
+        } else
         {
             window = findWindow(winId);
             if (window)
+            {
                 winId = window;
+            }
         }
     }
+
     return winId;
 }
 
@@ -419,27 +476,30 @@ void LXQtTaskbarWlrootsBackend::addWindow(WId winId)
     }
 
     LXQtTaskbarWlrootsWindow *window = getWindow(winId);
-    if (window == nullptr) {
+    if (window == nullptr)
+    {
         return;
     }
 
-    if (window->windowState.activated) {
+    if (window->windowState.activated)
+    {
         WId pId = findTopParent(winId);
         setLastActivated(pId);
         activeWindow = pId;
         emit activeWindowChanged(activeWindow);
     }
 
-    connect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this, &LXQtTaskbarWlrootsBackend::onActivatedChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this, &LXQtTaskbarWlrootsBackend::onParentChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this,
+        &LXQtTaskbarWlrootsBackend::onActivatedChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this,
+        &LXQtTaskbarWlrootsBackend::onParentChanged);
 
     // add it either to transients or windows
     if (WId leader = window->parentWindow)
     {
         transients.insert(winId, leader);
         connect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeTransient);
-    }
-    else
+    } else
     {
         addToWindows(winId);
     }
@@ -448,21 +508,28 @@ void LXQtTaskbarWlrootsBackend::addWindow(WId winId)
 void LXQtTaskbarWlrootsBackend::addToWindows(WId winId)
 {
     LXQtTaskbarWlrootsWindow *window = getWindow(winId);
-    if (window == nullptr) {
+    if (window == nullptr)
+    {
         return;
     }
 
     windows.push_back(winId);
 
     connect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeWindow);
-    connect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this, &LXQtTaskbarWlrootsBackend::onTitleChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this, &LXQtTaskbarWlrootsBackend::onAppIdChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-    connect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this, &LXQtTaskbarWlrootsBackend::onOutputsChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this,
+        &LXQtTaskbarWlrootsBackend::onTitleChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this,
+        &LXQtTaskbarWlrootsBackend::onAppIdChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this,
+        &LXQtTaskbarWlrootsBackend::onStateChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this,
+        &LXQtTaskbarWlrootsBackend::onStateChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this,
+        &LXQtTaskbarWlrootsBackend::onStateChanged);
+    connect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this,
+        &LXQtTaskbarWlrootsBackend::onOutputsChanged);
 
-    emit windowAdded( winId );
+    emit windowAdded(winId);
     emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::WindowClass));
     emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::Title));
     emit windowPropertyChanged(winId, int(LXQtTaskBarWindowProperty::Icon));
@@ -471,17 +538,25 @@ void LXQtTaskbarWlrootsBackend::addToWindows(WId winId)
 
 void LXQtTaskbarWlrootsBackend::removeWindow()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
     {
         disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeWindow);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this, &LXQtTaskbarWlrootsBackend::onParentChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this, &LXQtTaskbarWlrootsBackend::onActivatedChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this, &LXQtTaskbarWlrootsBackend::onTitleChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this, &LXQtTaskbarWlrootsBackend::onAppIdChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this, &LXQtTaskbarWlrootsBackend::onOutputsChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this,
+            &LXQtTaskbarWlrootsBackend::onParentChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this,
+            &LXQtTaskbarWlrootsBackend::onActivatedChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this,
+            &LXQtTaskbarWlrootsBackend::onTitleChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this,
+            &LXQtTaskbarWlrootsBackend::onAppIdChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this,
+            &LXQtTaskbarWlrootsBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this,
+            &LXQtTaskbarWlrootsBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this,
+            &LXQtTaskbarWlrootsBackend::onStateChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this,
+            &LXQtTaskbarWlrootsBackend::onOutputsChanged);
 
         WId winId = window->getWindowId();
         eraseWindow(windows, winId);
@@ -499,18 +574,21 @@ void LXQtTaskbarWlrootsBackend::removeWindow()
 
 void LXQtTaskbarWlrootsBackend::removeTransient()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
     {
-        disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeTransient);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this, &LXQtTaskbarWlrootsBackend::onParentChanged);
-        disconnect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this, &LXQtTaskbarWlrootsBackend::onActivatedChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this,
+            &LXQtTaskbarWlrootsBackend::removeTransient);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::parentChanged, this,
+            &LXQtTaskbarWlrootsBackend::onParentChanged);
+        disconnect(window, &LXQtTaskbarWlrootsWindow::activatedChanged, this,
+            &LXQtTaskbarWlrootsBackend::onActivatedChanged);
         transients.remove(window->getWindowId());
     }
 }
 
 void LXQtTaskbarWlrootsBackend::onActivatedChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
     {
         WId effectiveWindow = findTopParent(window->getWindowId());
 
@@ -523,18 +601,19 @@ void LXQtTaskbarWlrootsBackend::onActivatedChanged()
                 activeWindow = effectiveWindow;
                 emit activeWindowChanged(activeWindow);
             }
-        }
-        else
+        } else
         {
             // First check if it has an active child (transient) window.
             for (auto i = transients.cbegin(), end = transients.cend(); i != end; ++i)
             {
-                if (window->getWindowId() != i.key() && equalIds(findTopParent(i.key()), effectiveWindow))
+                if ((window->getWindowId() != i.key()) && equalIds(findTopParent(i.key()), effectiveWindow))
                 {
                     if (auto win = getWindow(i.key()))
                     {
                         if (win->windowState.activated)
+                        {
                             return;
+                        }
                     }
                 }
             }
@@ -550,9 +629,9 @@ void LXQtTaskbarWlrootsBackend::onActivatedChanged()
 
 void LXQtTaskbarWlrootsBackend::onParentChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
     {
-       WId leader = window->parentWindow;
+        WId leader = window->parentWindow;
 
         /** Basically, check if this window is a transient */
         if (transients.remove(window->getWindowId()))
@@ -561,16 +640,17 @@ void LXQtTaskbarWlrootsBackend::onParentChanged()
             {
                 // leader change.
                 transients.insert(window->getWindowId(), leader);
-            }
-            else
+            } else
             {
                 // lost a leader, add to regular windows list.
                 Q_ASSERT(findWindow(leader) == 0);
 
-                disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeTransient);
+                disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this,
+                    &LXQtTaskbarWlrootsBackend::removeTransient);
                 addToWindows(window->getWindowId());
 
-                // Correct the activation state if an active window that has lost its leader was active before,
+                // Correct the activation state if an active window that has lost its leader was active
+                // before,
                 // because "LXQtTaskbarWlrootsWindow::activatedChanged" might not be emitted for it.
                 if (window->windowState.activated)
                 {
@@ -579,17 +659,23 @@ void LXQtTaskbarWlrootsBackend::onParentChanged()
                     emit activeWindowChanged(activeWindow);
                 }
             }
-        }
-        else if (leader)
+        } else if (leader)
         {
             // remove it from regular windows list
-            disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeWindow);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this, &LXQtTaskbarWlrootsBackend::onTitleChanged);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this, &LXQtTaskbarWlrootsBackend::onAppIdChanged);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this, &LXQtTaskbarWlrootsBackend::onStateChanged);
-            disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this, &LXQtTaskbarWlrootsBackend::onOutputsChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::closed, this,
+                &LXQtTaskbarWlrootsBackend::removeWindow);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::titleChanged, this,
+                &LXQtTaskbarWlrootsBackend::onTitleChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::appIdChanged, this,
+                &LXQtTaskbarWlrootsBackend::onAppIdChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::fullscreenChanged, this,
+                &LXQtTaskbarWlrootsBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::maximizedChanged, this,
+                &LXQtTaskbarWlrootsBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::minimizedChanged, this,
+                &LXQtTaskbarWlrootsBackend::onStateChanged);
+            disconnect(window, &LXQtTaskbarWlrootsWindow::outputsChanged, this,
+                &LXQtTaskbarWlrootsBackend::onOutputsChanged);
             eraseWindow(windows, window->getWindowId());
             lastActivated.remove(window->getWindowId());
             // announce that it's removed
@@ -597,7 +683,8 @@ void LXQtTaskbarWlrootsBackend::onParentChanged()
 
             // add it to transients
             transients.insert(window->getWindowId(), leader);
-            connect(window, &LXQtTaskbarWlrootsWindow::closed, this, &LXQtTaskbarWlrootsBackend::removeTransient);
+            connect(window, &LXQtTaskbarWlrootsWindow::closed, this,
+                &LXQtTaskbarWlrootsBackend::removeTransient);
 
             // Correct the activation state if a window that has got a leader was active before.
             if (activeWindow == window->getWindowId())
@@ -613,41 +700,52 @@ void LXQtTaskbarWlrootsBackend::onParentChanged()
 
 void LXQtTaskbarWlrootsBackend::onTitleChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
+    {
         emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::Title));
+    }
 }
 
 void LXQtTaskbarWlrootsBackend::onAppIdChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
+    {
         emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::WindowClass));
+    }
 }
 
 void LXQtTaskbarWlrootsBackend::onStateChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
+    {
         emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::State));
+    }
 }
 
 void LXQtTaskbarWlrootsBackend::onOutputsChanged()
 {
-    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow *>(QObject::sender()))
+    if (auto window = qobject_cast<LXQtTaskbarWlrootsWindow*>(QObject::sender()))
+    {
         emit windowPropertyChanged(window->getWindowId(), int(LXQtTaskBarWindowProperty::Geometry));
+    }
 }
 
 bool LXQtTaskbarWlrootsBackend::acceptWindow(WId window) const
 {
-    if(transients.contains(window))
+    if (transients.contains(window))
+    {
         return false;
+    }
 
     return true;
 }
 
-LXQtTaskbarWlrootsWindow *LXQtTaskbarWlrootsBackend::getWindow(WId windowId) const
+LXQtTaskbarWlrootsWindow*LXQtTaskbarWlrootsBackend::getWindow(WId windowId) const
 {
     /** Easiest way is to convert the quintptr to the actual pointer */
-    LXQtTaskbarWlrootsWindow *win = reinterpret_cast<LXQtTaskbarWlrootsWindow *>( windowId );
-    if ( win ) {
+    LXQtTaskbarWlrootsWindow *win = reinterpret_cast<LXQtTaskbarWlrootsWindow*>(windowId);
+    if (win)
+    {
         return win;
     }
 
@@ -656,17 +754,23 @@ LXQtTaskbarWlrootsWindow *LXQtTaskbarWlrootsBackend::getWindow(WId windowId) con
 
 bool LXQtTaskbarWlrootsBackend::equalIds(WId windowId1, WId windowId2) const
 {
-    if (windowId1 == windowId2) {
+    if (windowId1 == windowId2)
+    {
         return true;
     }
-    LXQtTaskbarWlrootsWindow *win1 = reinterpret_cast<LXQtTaskbarWlrootsWindow *>( windowId1 );
-    LXQtTaskbarWlrootsWindow *win2 = reinterpret_cast<LXQtTaskbarWlrootsWindow *>( windowId2 );
-    if (win1 == nullptr && win2 == nullptr) {
+
+    LXQtTaskbarWlrootsWindow *win1 = reinterpret_cast<LXQtTaskbarWlrootsWindow*>(windowId1);
+    LXQtTaskbarWlrootsWindow *win2 = reinterpret_cast<LXQtTaskbarWlrootsWindow*>(windowId2);
+    if ((win1 == nullptr) && (win2 == nullptr))
+    {
         return true;
     }
-    if (win1 != nullptr && win2 != nullptr) {
+
+    if ((win1 != nullptr) && (win2 != nullptr))
+    {
         return win1->ID == win2->ID;
     }
+
     return false;
 }
 
@@ -674,10 +778,12 @@ void LXQtTaskbarWlrootsBackend::setLastActivated(WId id)
 {
     auto t = QDateTime::currentMSecsSinceEpoch();
     while (lastActivated.key(t) != 0)
+    {
         ++t; // make sure the times are not equal
+    }
+
     lastActivated[id] = t;
 }
-
 
 int LXQtWMBackendWlrootsLibrary::getBackendScore(const QString& key) const
 {
@@ -687,13 +793,13 @@ int LXQtWMBackendWlrootsLibrary::getBackendScore(const QString& key) const
     }
 
     static const QStringList supportedList = {QStringLiteral("labwc"),
-                                              QStringLiteral("sway"),
-                                              QStringLiteral("wayfire"),
-                                              // The following compositors are also supported,
-                                              // although they are not based on wlroots.
-                                              QStringLiteral("hyprland"),
-                                              QStringLiteral("river"),
-                                              QStringLiteral("niri")};
+        QStringLiteral("sway"),
+        QStringLiteral("wayfire"),
+        // The following compositors are also supported,
+        // although they are not based on wlroots.
+        QStringLiteral("hyprland"),
+        QStringLiteral("river"),
+        QStringLiteral("niri")};
     if (supportedList.contains(key, Qt::CaseInsensitive))
     {
         return 30;
@@ -703,8 +809,7 @@ int LXQtWMBackendWlrootsLibrary::getBackendScore(const QString& key) const
     return 0;
 }
 
-
-ILXQtAbstractWMInterface *LXQtWMBackendWlrootsLibrary::instance() const
+ILXQtAbstractWMInterface*LXQtWMBackendWlrootsLibrary::instance() const
 {
     return new LXQtTaskbarWlrootsBackend(nullptr);
 }

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.cpp
@@ -27,9 +27,17 @@ LXQtTaskbarWlrootsBackend::LXQtTaskbarWlrootsBackend(QObject *parent) :
     ILXQtAbstractWMInterface(parent)
 {
     m_managment.reset(new LXQtTaskbarWlrootsWindowManagment);
+    m_wsmgr.reset(new LXQt::Taskbar::WorkspaceManagerV1);
 
     connect(m_managment.get(), &LXQtTaskbarWlrootsWindowManagment::windowCreated, this,
         &LXQtTaskbarWlrootsBackend::addWindow);
+
+    connect(m_wsmgr.get(), &LXQt::Taskbar::WorkspaceManagerV1::workspaceAdded, this,
+        &LXQtTaskbarWlrootsBackend::workspacesCountChanged);
+
+    connect(m_wsmgr.get(), &LXQt::Taskbar::WorkspaceManagerV1::currentWorkspaceChanged, this, [this] () {
+
+    });
 }
 
 bool LXQtTaskbarWlrootsBackend::supportsAction(WId, LXQtTaskBarBackendAction action) const
@@ -43,6 +51,9 @@ bool LXQtTaskbarWlrootsBackend::supportsAction(WId, LXQtTaskBarBackendAction act
         return true;
 
       case LXQtTaskBarBackendAction::FullScreen:
+        return true;
+
+      case LXQtTaskBarBackendAction::DesktopSwitch:
         return true;
 
       default:

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -10,12 +10,21 @@ class LXQtTaskbarWlrootsWindow;
 class LXQtTaskbarWlrootsWindowManagment;
 class LXQtWlrootsWaylandWorkspaceInfo;
 
+namespace LXQt
+{
+namespace Taskbar
+{
+class WorkspaceManagerV1;
+class WorkspaceGroupHandleV1;
+class WorkspaceHandleV1;
+}
+}
 
 class LXQtTaskbarWlrootsBackend : public ILXQtAbstractWMInterface
 {
     Q_OBJECT
 
-public:
+  public:
     explicit LXQtTaskbarWlrootsBackend(QObject *parent = nullptr);
 
     // Backend
@@ -53,7 +62,8 @@ public:
     virtual int getWindowWorkspace(WId windowId) const override;
     virtual bool setWindowOnWorkspace(WId windowId, int idx) override;
 
-    virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next, bool raiseOnCurrentDesktop) override;
+    virtual void moveApplicationToPrevNextMonitor(WId windowId, bool next,
+        bool raiseOnCurrentDesktop) override;
 
     virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
 
@@ -63,7 +73,7 @@ public:
     virtual void moveApplication(WId windowId) override;
     virtual void resizeApplication(WId windowId) override;
 
-    virtual void refreshIconGeometry(WId windowId, const QRect &geom) override;
+    virtual void refreshIconGeometry(WId windowId, const QRect & geom) override;
 
     // Panel internal
     virtual bool isAreaOverlapped(const QRect& area) const override;
@@ -72,7 +82,7 @@ public:
     virtual bool isShowingDesktop() const override;
     virtual bool showDesktop(bool value) override;
 
-private slots:
+  private slots:
     void addWindow(WId wid);
     void removeWindow();
     void removeTransient();
@@ -83,7 +93,7 @@ private slots:
     void onStateChanged();
     void onOutputsChanged();
 
-private:
+  private:
     void addToWindows(WId winId);
     bool acceptWindow(WId wid) const;
     WId findWindow(WId tgt) const;
@@ -95,6 +105,7 @@ private:
     LXQtTaskbarWlrootsWindow *getWindow(WId windowId) const;
 
     std::unique_ptr<LXQtTaskbarWlrootsWindowManagment> m_managment;
+    std::unique_ptr<LXQt::Taskbar::WorkspaceManagerV1> m_wsmgr;
 
     QHash<WId, qint64> lastActivated;
     WId activeWindow = 0;
@@ -108,13 +119,14 @@ private:
 };
 
 
-class LXQtWMBackendWlrootsLibrary: public QObject, public ILXQtWMBackendLibrary
+class LXQtWMBackendWlrootsLibrary : public QObject, public ILXQtWMBackendLibrary
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "lxqt.org/Panel/WMInterface/1.0")
     Q_INTERFACES(ILXQtWMBackendLibrary)
-public:
+
+  public:
     int getBackendScore(const QString& key) const override;
 
-    ILXQtAbstractWMInterface* instance() const override;
+    ILXQtAbstractWMInterface * instance() const override;
 };

--- a/panel/backends/wayland/wlroots/workspace.cpp
+++ b/panel/backends/wayland/wlroots/workspace.cpp
@@ -1,0 +1,204 @@
+#include "workspace.hpp"
+
+#include <QMap>
+
+/** ext_workspace_handle_v1 <-> WorkspaceHandleV1 map */
+QMap<struct ::ext_workspace_handle_v1 *, LXQt::Taskbar::WorkspaceHandleV1 *> workspaceMap;
+
+/**
+ * Implementation of the LXQt::TaskBar::WorkspaceManagerV1 class
+ */
+
+LXQt::Taskbar::WorkspaceManagerV1::WorkspaceManagerV1() : QWaylandClientExtensionTemplate(
+        version ) {
+    /** Automatically destroy thie object */
+    connect(
+        this, &QWaylandClientExtension::activeChanged, this, [ this ]{
+            if ( !isActive() ) {
+                ext_workspace_manager_v1_destroy( object() );
+            }
+        } );
+}
+
+
+LXQt::Taskbar::WorkspaceManagerV1::~WorkspaceManagerV1() {
+    if ( !isActive() ) {
+        ext_workspace_manager_v1_destroy( object() );
+    }
+}
+
+
+int LXQt::Taskbar::WorkspaceManagerV1::workspaceCount( QScreen * ) {
+    return workspaceMap.count();
+}
+
+
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace_group( struct ::ext_workspace_group_handle_v1 *workspace_group ) {
+    emit workspaceGroup( new WorkspaceGroupHandleV1( workspace_group ) );
+}
+
+
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace( struct ::ext_workspace_handle_v1 *workspace_ ) {
+    workspaceMap[ workspace_ ] = new WorkspaceHandleV1( workspace_ );
+    emit workspace( workspaceMap[ workspace_ ] );
+}
+
+
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_done() {
+    emit done();
+}
+
+
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_finished() {
+    emit finished();
+}
+
+
+/**
+ * Implementation of the LXQt::TaskBar::WorkspaceGroupHandleV1 class
+ */
+
+LXQt::Taskbar::WorkspaceGroupHandleV1::WorkspaceGroupHandleV1( struct ::ext_workspace_group_handle_v1 *object ): QObject(), QtWayland::ext_workspace_group_handle_v1( object ) {
+}
+
+
+LXQt::Taskbar::WorkspaceGroupHandleV1::~WorkspaceGroupHandleV1() {
+    destroy();
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_capabilities( uint32_t caps ) {
+    m_supported_capabilities = caps;
+    emit capabilities( caps );
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_enter( struct ::wl_output *output ) {
+    if ( !outputs.contains( output ) ) {
+        outputs << output;
+
+        emit outputEnter( output );
+    }
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_leave( struct ::wl_output *output ) {
+    if ( outputs.contains( output ) ) {
+        outputs.removeAll( output );
+
+        emit outputLeave( output );
+    }
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_enter( struct ::ext_workspace_handle_v1 *workspace ) {
+    if ( !workspaces.contains( workspaceMap[ workspace ] ) ) {
+        workspaces << workspaceMap[ workspace ];
+
+        emit workspaceAdded( workspaceMap[ workspace ] );
+    }
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_leave( struct ::ext_workspace_handle_v1 *workspace ) {
+    if ( workspaces.contains( workspaceMap[ workspace ] ) ) {
+        workspaces.removeAll( workspaceMap[ workspace ] );
+
+        emit workspaceRemoved( workspaceMap[ workspace ] );
+    }
+}
+
+
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_removed() {
+    emit removed();
+}
+
+
+/**
+ * Implementation of the LXQt::TaskBar::WorkspaceHandleV1 class
+ */
+
+
+LXQt::Taskbar::WorkspaceHandleV1::WorkspaceHandleV1( struct ::ext_workspace_handle_v1 *object ): QObject(), QtWayland::ext_workspace_handle_v1( object ) {
+}
+
+
+LXQt::Taskbar::WorkspaceHandleV1::~WorkspaceHandleV1() {
+    destroy();
+}
+
+
+QString LXQt::Taskbar::WorkspaceHandleV1::getId() const {
+    return m_id;
+}
+
+
+QString LXQt::Taskbar::WorkspaceHandleV1::getName() const {
+    return m_name;
+}
+
+
+QList<int> LXQt::Taskbar::WorkspaceHandleV1::getCoordinates() const {
+    return m_coordinates;
+}
+
+
+uint32_t LXQt::Taskbar::WorkspaceHandleV1::getState() const {
+    return m_state;
+}
+
+
+uint32_t LXQt::Taskbar::WorkspaceHandleV1::getCapabilities() const {
+    return m_capabilities;
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_id( const QString& id_ ) {
+    m_id = id_;
+
+    emit id( m_id );
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_name( const QString& name_ ) {
+    m_name = name_;
+
+    emit name( m_name );
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_coordinates( wl_array *coordinates_ ) {
+    m_coordinates.clear();
+
+    int32_t *data = static_cast<int32_t *>( coordinates_->data );
+    size_t  count = coordinates_->size / sizeof( int32_t );
+
+    for (size_t i = 0; i < count; ++i) {
+        m_coordinates.append( data[ i ] );
+    }
+
+    emit coordinates( m_coordinates );
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_state( uint32_t state_ ) {
+    m_state = state_;
+
+    emit state( m_state );
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_capabilities( uint32_t capabilities_ ) {
+    m_capabilities = capabilities_;
+
+    emit capabilities( m_capabilities );
+}
+
+
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_removed() {
+    if ( workspaceMap.contains( object() ) ) {
+        workspaceMap.remove( object() );
+    }
+
+    emit removed();
+}

--- a/panel/backends/wayland/wlroots/workspace.cpp
+++ b/panel/backends/wayland/wlroots/workspace.cpp
@@ -3,201 +3,270 @@
 #include <QMap>
 
 /** ext_workspace_handle_v1 <-> WorkspaceHandleV1 map */
-QMap<struct ::ext_workspace_handle_v1 *, LXQt::Taskbar::WorkspaceHandleV1 *> workspaceMap;
+QMap<struct ::ext_workspace_handle_v1*, LXQt::Taskbar::WorkspaceHandleV1*> workspaceMap;
 
 /**
  * Implementation of the LXQt::TaskBar::WorkspaceManagerV1 class
  */
 
 LXQt::Taskbar::WorkspaceManagerV1::WorkspaceManagerV1() : QWaylandClientExtensionTemplate(
-        version ) {
+        version)
+{
     /** Automatically destroy thie object */
     connect(
-        this, &QWaylandClientExtension::activeChanged, this, [ this ]{
-            if ( !isActive() ) {
-                ext_workspace_manager_v1_destroy( object() );
-            }
-        } );
+        this, &QWaylandClientExtension::activeChanged, this, [this]
+    {
+        if (!isActive())
+        {
+            ext_workspace_manager_v1_destroy(object());
+        }
+    });
 }
 
-
-LXQt::Taskbar::WorkspaceManagerV1::~WorkspaceManagerV1() {
-    if ( !isActive() ) {
-        ext_workspace_manager_v1_destroy( object() );
+LXQt::Taskbar::WorkspaceManagerV1::~WorkspaceManagerV1()
+{
+    if (!isActive())
+    {
+        ext_workspace_manager_v1_destroy(object());
     }
 }
 
-
-int LXQt::Taskbar::WorkspaceManagerV1::workspaceCount( QScreen * ) {
+int LXQt::Taskbar::WorkspaceManagerV1::workspaceCount(QScreen*)
+{
     return workspaceMap.count();
 }
 
+int LXQt::Taskbar::WorkspaceManagerV1::currentWorkspaceIndex(QScreen*)
+{
+    for ( WorkspaceHandleV1 *ws : workspaceMap.values())
+    {
+        if (ws->getState() && WorkspaceHandleV1::state_active)
+        {
+            return ws->getIndex();
+        }
+    }
 
-void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace_group( struct ::ext_workspace_group_handle_v1 *workspace_group ) {
-    emit workspaceGroup( new WorkspaceGroupHandleV1( workspace_group ) );
+    return -1;
 }
 
-
-void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace( struct ::ext_workspace_handle_v1 *workspace_ ) {
-    workspaceMap[ workspace_ ] = new WorkspaceHandleV1( workspace_ );
-    emit workspace( workspaceMap[ workspace_ ] );
+void LXQt::Taskbar::WorkspaceManagerV1::setCurrentWorkspaceIndex(int idx)
+{
+    for ( WorkspaceHandleV1 *ws : workspaceMap.values())
+    {
+        if (ws->getIndex() == idx)
+        {
+            ws->activate();
+        }
+    }
 }
 
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace_group(
+    struct ::ext_workspace_group_handle_v1 *workspace_group)
+{
+    emit workspaceGroupAdded(new WorkspaceGroupHandleV1(workspace_group));
+}
 
-void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_done() {
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_workspace(
+    struct ::ext_workspace_handle_v1 *workspace_)
+{
+    workspaceMap[workspace_] = new WorkspaceHandleV1(workspace_);
+    emit workspaceAdded(workspaceMap[workspace_]);
+
+    /** Automatically destroy thie object */
+    connect(workspaceMap[workspace_], &WorkspaceHandleV1::activated, this,
+        &WorkspaceManagerV1::currentWorkspaceChanged);
+    connect(workspaceMap[workspace_], &WorkspaceHandleV1::deactivated, this,
+        &WorkspaceManagerV1::currentWorkspaceChanged);
+}
+
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_done()
+{
     emit done();
 }
 
-
-void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_finished() {
+void LXQt::Taskbar::WorkspaceManagerV1::ext_workspace_manager_v1_finished()
+{
     emit finished();
 }
-
 
 /**
  * Implementation of the LXQt::TaskBar::WorkspaceGroupHandleV1 class
  */
 
-LXQt::Taskbar::WorkspaceGroupHandleV1::WorkspaceGroupHandleV1( struct ::ext_workspace_group_handle_v1 *object ): QObject(), QtWayland::ext_workspace_group_handle_v1( object ) {
-}
+LXQt::Taskbar::WorkspaceGroupHandleV1::WorkspaceGroupHandleV1(
+    struct ::ext_workspace_group_handle_v1 *object) : QObject(),
+    QtWayland::ext_workspace_group_handle_v1(object)
+{}
 
-
-LXQt::Taskbar::WorkspaceGroupHandleV1::~WorkspaceGroupHandleV1() {
+LXQt::Taskbar::WorkspaceGroupHandleV1::~WorkspaceGroupHandleV1()
+{
     destroy();
 }
 
-
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_capabilities( uint32_t caps ) {
-    m_supported_capabilities = caps;
-    emit capabilities( caps );
+bool LXQt::Taskbar::WorkspaceGroupHandleV1::canCreateWorkspace() const
+{
+    return (m_supported_capabilities & group_capabilities_create_workspace);
 }
 
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_capabilities(uint32_t caps)
+{
+    m_supported_capabilities = caps;
+    emit capabilities(caps);
+}
 
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_enter( struct ::wl_output *output ) {
-    if ( !outputs.contains( output ) ) {
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_enter(
+    struct ::wl_output *output)
+{
+    if (!outputs.contains(output))
+    {
         outputs << output;
 
-        emit outputEnter( output );
+        emit outputEnter(output);
     }
 }
 
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_leave(
+    struct ::wl_output *output)
+{
+    if (outputs.contains(output))
+    {
+        outputs.removeAll(output);
 
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_output_leave( struct ::wl_output *output ) {
-    if ( outputs.contains( output ) ) {
-        outputs.removeAll( output );
-
-        emit outputLeave( output );
+        emit outputLeave(output);
     }
 }
 
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_enter(
+    struct ::ext_workspace_handle_v1 *workspace)
+{
+    if (!workspaces.contains(workspaceMap[workspace]))
+    {
+        workspaces << workspaceMap[workspace];
 
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_enter( struct ::ext_workspace_handle_v1 *workspace ) {
-    if ( !workspaces.contains( workspaceMap[ workspace ] ) ) {
-        workspaces << workspaceMap[ workspace ];
-
-        emit workspaceAdded( workspaceMap[ workspace ] );
+        emit workspaceAdded(workspaceMap[workspace]);
     }
 }
 
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_leave(
+    struct ::ext_workspace_handle_v1 *workspace)
+{
+    if (workspaces.contains(workspaceMap[workspace]))
+    {
+        workspaces.removeAll(workspaceMap[workspace]);
 
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_workspace_leave( struct ::ext_workspace_handle_v1 *workspace ) {
-    if ( workspaces.contains( workspaceMap[ workspace ] ) ) {
-        workspaces.removeAll( workspaceMap[ workspace ] );
-
-        emit workspaceRemoved( workspaceMap[ workspace ] );
+        emit workspaceRemoved(workspaceMap[workspace]);
     }
 }
 
-
-void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_removed() {
+void LXQt::Taskbar::WorkspaceGroupHandleV1::ext_workspace_group_handle_v1_removed()
+{
     emit removed();
 }
-
 
 /**
  * Implementation of the LXQt::TaskBar::WorkspaceHandleV1 class
  */
 
 
-LXQt::Taskbar::WorkspaceHandleV1::WorkspaceHandleV1( struct ::ext_workspace_handle_v1 *object ): QObject(), QtWayland::ext_workspace_handle_v1( object ) {
-}
+LXQt::Taskbar::WorkspaceHandleV1::WorkspaceHandleV1(struct ::ext_workspace_handle_v1 *object) : QObject(),
+    QtWayland::ext_workspace_handle_v1(object)
+{}
 
-
-LXQt::Taskbar::WorkspaceHandleV1::~WorkspaceHandleV1() {
+LXQt::Taskbar::WorkspaceHandleV1::~WorkspaceHandleV1()
+{
     destroy();
 }
 
-
-QString LXQt::Taskbar::WorkspaceHandleV1::getId() const {
+QString LXQt::Taskbar::WorkspaceHandleV1::getId() const
+{
     return m_id;
 }
 
-
-QString LXQt::Taskbar::WorkspaceHandleV1::getName() const {
+QString LXQt::Taskbar::WorkspaceHandleV1::getName() const
+{
     return m_name;
 }
 
-
-QList<int> LXQt::Taskbar::WorkspaceHandleV1::getCoordinates() const {
+QList<int> LXQt::Taskbar::WorkspaceHandleV1::getCoordinates() const
+{
     return m_coordinates;
 }
 
-
-uint32_t LXQt::Taskbar::WorkspaceHandleV1::getState() const {
+uint32_t LXQt::Taskbar::WorkspaceHandleV1::getState() const
+{
     return m_state;
 }
 
-
-uint32_t LXQt::Taskbar::WorkspaceHandleV1::getCapabilities() const {
+uint32_t LXQt::Taskbar::WorkspaceHandleV1::getCapabilities() const
+{
     return m_capabilities;
 }
 
+int LXQt::Taskbar::WorkspaceHandleV1::getIndex() const
+{
+    return 0;
+}
 
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_id( const QString& id_ ) {
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_id(const QString& id_)
+{
     m_id = id_;
 
-    emit id( m_id );
+    emit idChanged(m_id);
 }
 
-
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_name( const QString& name_ ) {
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_name(const QString& name_)
+{
     m_name = name_;
 
-    emit name( m_name );
+    emit nameChanged(m_name);
 }
 
-
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_coordinates( wl_array *coordinates_ ) {
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_coordinates(wl_array *coordinates_)
+{
     m_coordinates.clear();
 
-    int32_t *data = static_cast<int32_t *>( coordinates_->data );
-    size_t  count = coordinates_->size / sizeof( int32_t );
+    int32_t *data = static_cast<int32_t*>(coordinates_->data);
+    size_t count  = coordinates_->size / sizeof(int32_t);
 
-    for (size_t i = 0; i < count; ++i) {
-        m_coordinates.append( data[ i ] );
+    for (size_t i = 0; i < count; ++i)
+    {
+        m_coordinates.append(data[i]);
     }
 
-    emit coordinates( m_coordinates );
+    emit coordinatesChanged(m_coordinates);
 }
 
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_state(uint32_t state_)
+{
+    /** Check if this workspace was activated */
+    if (!(m_state & state_active) && (state_ & state_active))
+    {
+        emit activated();
+    }
 
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_state( uint32_t state_ ) {
+    /** Check if this workspace was deactivated */
+    if ((m_state & state_active) && !(state_ & state_active))
+    {
+        emit deactivated();
+    }
+
     m_state = state_;
 
-    emit state( m_state );
+    emit stateChanged(m_state);
 }
 
-
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_capabilities( uint32_t capabilities_ ) {
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_capabilities(uint32_t capabilities_)
+{
     m_capabilities = capabilities_;
 
-    emit capabilities( m_capabilities );
+    emit capabilitiesChanged(m_capabilities);
 }
 
-
-void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_removed() {
-    if ( workspaceMap.contains( object() ) ) {
-        workspaceMap.remove( object() );
+void LXQt::Taskbar::WorkspaceHandleV1::ext_workspace_handle_v1_removed()
+{
+    if (workspaceMap.contains(object()))
+    {
+        workspaceMap.remove(object());
     }
 
     emit removed();

--- a/panel/backends/wayland/wlroots/workspace.hpp
+++ b/panel/backends/wayland/wlroots/workspace.hpp
@@ -111,7 +111,7 @@ class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_w
     Q_OBJECT;
 
   public:
-    WorkspaceHandleV1(struct ::ext_workspace_handle_v1 *object);
+    WorkspaceHandleV1(struct ::ext_workspace_handle_v1 *object, int index);
     virtual ~WorkspaceHandleV1();
 
     /**
@@ -125,13 +125,13 @@ class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_w
      * These functions are complete, and we do not have to re-implement them here.
      */
 
-    QString getId() const;
-    QString getName() const;
-    QList<int> getCoordinates() const;
-    uint32_t getState() const;
-    uint32_t getCapabilities() const;
+    QString id() const;
+    QString name() const;
+    QList<int> coordinates() const;
+    uint32_t state() const;
+    uint32_t capabilities() const;
 
-    int getIndex() const;
+    int index() const;
 
     Q_SIGNAL void idChanged(const QString& id);
     Q_SIGNAL void nameChanged(const QString& name);

--- a/panel/backends/wayland/wlroots/workspace.hpp
+++ b/panel/backends/wayland/wlroots/workspace.hpp
@@ -13,123 +13,151 @@
 
 struct wl_registry;
 
-namespace LXQt {
-    namespace Taskbar {
-        class WorkspaceManagerV1;
-        class WorkspaceGroupHandleV1;
-        class WorkspaceHandleV1;
-    }
+namespace LXQt
+{
+namespace Taskbar
+{
+class WorkspaceManagerV1;
+class WorkspaceGroupHandleV1;
+class WorkspaceHandleV1;
+}
 }
 
 class LXQt::Taskbar::WorkspaceManagerV1 : public QWaylandClientExtensionTemplate<LXQt::Taskbar::WorkspaceManagerV1>,
-                                          public QtWayland::ext_workspace_manager_v1 {
+    public QtWayland::ext_workspace_manager_v1
+{
     Q_OBJECT
 
-    public:
-        static constexpr int version = 16;
+  public:
+    static constexpr int version = 16;
 
-        WorkspaceManagerV1();
-        virtual ~WorkspaceManagerV1();
+    WorkspaceManagerV1();
+    virtual ~WorkspaceManagerV1();
 
-        /**
-         * TODO: We have to eventually implement this.
-         */
-        int workspaceCount( QScreen *screen = nullptr );
+    /**
+     * TODO: We have to eventually implement @screen.
+     */
+    int workspaceCount(QScreen *screen = nullptr);
 
-        Q_SIGNAL void workspaceGroup( WorkspaceGroupHandleV1 *workspace_group );
-        Q_SIGNAL void workspace( WorkspaceHandleV1 *workspace );
-        Q_SIGNAL void done();
-        Q_SIGNAL void finished();
+    /**
+     * TODO: We have to eventually implement @screen.
+     */
+    int currentWorkspaceIndex(QScreen *screen = nullptr);
+    void setCurrentWorkspaceIndex(int idx     = 0);
 
-    protected:
-        virtual void ext_workspace_manager_v1_workspace_group( struct ::ext_workspace_group_handle_v1 *workspace_group );
-        virtual void ext_workspace_manager_v1_workspace( struct ::ext_workspace_handle_v1 *workspace );
-        virtual void ext_workspace_manager_v1_done();
-        virtual void ext_workspace_manager_v1_finished();
+    Q_SIGNAL void workspaceGroupAdded(WorkspaceGroupHandleV1 *workspace_group);
+    Q_SIGNAL void workspaceAdded(WorkspaceHandleV1 *workspace);
+
+    /** A workspace became active or inactive. */
+    Q_SIGNAL void currentWorkspaceChanged();
+
+    Q_SIGNAL void done();
+    Q_SIGNAL void finished();
+
+  protected:
+    virtual void ext_workspace_manager_v1_workspace_group(
+        struct ::ext_workspace_group_handle_v1 *workspace_group);
+    virtual void ext_workspace_manager_v1_workspace(struct ::ext_workspace_handle_v1 *workspace);
+    virtual void ext_workspace_manager_v1_done();
+    virtual void ext_workspace_manager_v1_finished();
 };
 
-class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::ext_workspace_group_handle_v1 {
+class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::ext_workspace_group_handle_v1
+{
     Q_OBJECT;
-    public:
-        WorkspaceGroupHandleV1( struct ::ext_workspace_group_handle_v1 *object );
-        virtual ~WorkspaceGroupHandleV1();
 
-        /**
-         * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
-         *  - create_workspace( QString )
-         *  - destroy()
-         *  - object() -> struct ::ext_workspace_group_handle_v1 *
-         * These functions are complete, and we do not have to re-implement them here.
-         */
+  public:
+    WorkspaceGroupHandleV1(struct ::ext_workspace_group_handle_v1 *object);
+    virtual ~WorkspaceGroupHandleV1();
 
-        Q_SIGNAL void capabilities( uint32_t capabilities );
-        Q_SIGNAL void outputEnter( struct ::wl_output *output );
-        Q_SIGNAL void outputLeave( struct ::wl_output *output );
-        Q_SIGNAL void workspaceAdded( WorkspaceHandleV1 *workspace );
-        Q_SIGNAL void workspaceRemoved( WorkspaceHandleV1 *workspace );
-        Q_SIGNAL void removed();
+    bool canCreateWorkspace() const;
 
-    protected:
-        virtual void ext_workspace_group_handle_v1_capabilities( uint32_t capabilities );
-        virtual void ext_workspace_group_handle_v1_output_enter( struct ::wl_output *output );
-        virtual void ext_workspace_group_handle_v1_output_leave( struct ::wl_output *output );
-        virtual void ext_workspace_group_handle_v1_workspace_enter( struct ::ext_workspace_handle_v1 *workspace );
-        virtual void ext_workspace_group_handle_v1_workspace_leave( struct ::ext_workspace_handle_v1 *workspace );
-        virtual void ext_workspace_group_handle_v1_removed();
+    /**
+     * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
+     *  - create_workspace( QString )
+     *  - destroy()
+     *  - object() -> struct ::ext_workspace_group_handle_v1 *
+     * These functions are complete, and we do not have to re-implement them here.
+     */
 
-    private:
-        /** Track on which outputs this workspace group is visible */
-        QList<struct ::wl_output *> outputs;
+    Q_SIGNAL void capabilities(uint32_t capabilities);
+    Q_SIGNAL void outputEnter(struct ::wl_output *output);
+    Q_SIGNAL void outputLeave(struct ::wl_output *output);
+    Q_SIGNAL void workspaceAdded(WorkspaceHandleV1 *workspace);
+    Q_SIGNAL void workspaceRemoved(WorkspaceHandleV1 *workspace);
+    Q_SIGNAL void removed();
 
-        /** Store the capabilities */
-        uint32_t m_supported_capabilities;
+  protected:
+    virtual void ext_workspace_group_handle_v1_capabilities(uint32_t capabilities);
+    virtual void ext_workspace_group_handle_v1_output_enter(struct ::wl_output *output);
+    virtual void ext_workspace_group_handle_v1_output_leave(struct ::wl_output *output);
+    virtual void ext_workspace_group_handle_v1_workspace_enter(struct ::ext_workspace_handle_v1 *workspace);
+    virtual void ext_workspace_group_handle_v1_workspace_leave(struct ::ext_workspace_handle_v1 *workspace);
+    virtual void ext_workspace_group_handle_v1_removed();
 
-        /** Track on which workspaces are a part of this workspace group */
-        QList<WorkspaceHandleV1 *> workspaces;
+  private:
+    /** Track on which outputs this workspace group is visible */
+    QList<struct ::wl_output*> outputs;
+
+    /** Store the capabilities */
+    uint32_t m_supported_capabilities;
+
+    /** Track on which workspaces are a part of this workspace group */
+    QList<WorkspaceHandleV1*> workspaces;
 };
 
-class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_workspace_handle_v1 {
+class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_workspace_handle_v1
+{
     Q_OBJECT;
-    public:
-        WorkspaceHandleV1( struct ::ext_workspace_handle_v1 *object );
-        virtual ~WorkspaceHandleV1();
 
-        /**
-         * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
-         *  - object() -> struct ::ext_workspace_group_handle_v1 *
-         *  - destroy();
-         *  - activate();
-         *  - deactivate();
-         *  - assign(struct ::ext_workspace_group_handle_v1 *workspace_group);
-         *  - remove();
-         * These functions are complete, and we do not have to re-implement them here.
-         */
+  public:
+    WorkspaceHandleV1(struct ::ext_workspace_handle_v1 *object);
+    virtual ~WorkspaceHandleV1();
 
-        QString getId() const;
-        QString getName() const;
-        QList<int> getCoordinates() const;
-        uint32_t getState() const;
-        uint32_t getCapabilities() const;
+    /**
+     * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
+     *  - object() -> struct ::ext_workspace_group_handle_v1 *
+     *  - destroy();
+     *  - activate();
+     *  - deactivate();
+     *  - assign(struct ::ext_workspace_group_handle_v1 *workspace_group);
+     *  - remove();
+     * These functions are complete, and we do not have to re-implement them here.
+     */
 
-        Q_SIGNAL void id( const QString& id );
-        Q_SIGNAL void name( const QString& name );
-        Q_SIGNAL void coordinates( QList<int> coordinates );
-        Q_SIGNAL void state( uint32_t state );
-        Q_SIGNAL void capabilities( uint32_t capabilities );
-        Q_SIGNAL void removed();
+    QString getId() const;
+    QString getName() const;
+    QList<int> getCoordinates() const;
+    uint32_t getState() const;
+    uint32_t getCapabilities() const;
 
-    protected:
-        virtual void ext_workspace_handle_v1_id( const QString& id );
-        virtual void ext_workspace_handle_v1_name( const QString& name );
-        virtual void ext_workspace_handle_v1_coordinates( wl_array *coordinates );
-        virtual void ext_workspace_handle_v1_state( uint32_t state );
-        virtual void ext_workspace_handle_v1_capabilities( uint32_t capabilities );
-        virtual void ext_workspace_handle_v1_removed();
+    int getIndex() const;
 
-    private:
-        QString m_id;
-        QString m_name;
-        QList<int> m_coordinates;
-        uint32_t m_state;
-        uint32_t m_capabilities;
+    Q_SIGNAL void idChanged(const QString& id);
+    Q_SIGNAL void nameChanged(const QString& name);
+    Q_SIGNAL void coordinatesChanged(QList<int> coordinates);
+    Q_SIGNAL void stateChanged(uint32_t state);
+    Q_SIGNAL void capabilitiesChanged(uint32_t capabilities);
+    Q_SIGNAL void removed();
+
+    /** This workspace just became active */
+    Q_SIGNAL void activated();
+
+    /** This workspace was just deactived */
+    Q_SIGNAL void deactivated();
+
+  protected:
+    virtual void ext_workspace_handle_v1_id(const QString& id);
+    virtual void ext_workspace_handle_v1_name(const QString& name);
+    virtual void ext_workspace_handle_v1_coordinates(wl_array *coordinates);
+    virtual void ext_workspace_handle_v1_state(uint32_t state);
+    virtual void ext_workspace_handle_v1_capabilities(uint32_t capabilities);
+    virtual void ext_workspace_handle_v1_removed();
+
+  private:
+    QString m_id;
+    QString m_name;
+    QList<int> m_coordinates;
+    uint32_t m_state;
+    uint32_t m_capabilities;
 };

--- a/panel/backends/wayland/wlroots/workspace.hpp
+++ b/panel/backends/wayland/wlroots/workspace.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#include <QScreen>
+
+#include <string>
+#include "wayland-ext-workspace-v1-client-protocol.h"
+#include "qwayland-ext-workspace-v1.h"
+
+#include <QWaylandClientExtension>
+
+struct wl_registry;
+
+namespace LXQt {
+    namespace Taskbar {
+        class WorkspaceManagerV1;
+        class WorkspaceGroupHandleV1;
+        class WorkspaceHandleV1;
+    }
+}
+
+class LXQt::Taskbar::WorkspaceManagerV1 : public QWaylandClientExtensionTemplate<LXQt::Taskbar::WorkspaceManagerV1>,
+                                          public QtWayland::ext_workspace_manager_v1 {
+    Q_OBJECT
+
+    public:
+        static constexpr int version = 16;
+
+        WorkspaceManagerV1();
+        virtual ~WorkspaceManagerV1();
+
+        /**
+         * TODO: We have to eventually implement this.
+         */
+        int workspaceCount( QScreen *screen = nullptr );
+
+        Q_SIGNAL void workspaceGroup( WorkspaceGroupHandleV1 *workspace_group );
+        Q_SIGNAL void workspace( WorkspaceHandleV1 *workspace );
+        Q_SIGNAL void done();
+        Q_SIGNAL void finished();
+
+    protected:
+        virtual void ext_workspace_manager_v1_workspace_group( struct ::ext_workspace_group_handle_v1 *workspace_group );
+        virtual void ext_workspace_manager_v1_workspace( struct ::ext_workspace_handle_v1 *workspace );
+        virtual void ext_workspace_manager_v1_done();
+        virtual void ext_workspace_manager_v1_finished();
+};
+
+class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::ext_workspace_group_handle_v1 {
+    Q_OBJECT;
+    public:
+        WorkspaceGroupHandleV1( struct ::ext_workspace_group_handle_v1 *object );
+        virtual ~WorkspaceGroupHandleV1();
+
+        /**
+         * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
+         *  - create_workspace( QString )
+         *  - destroy()
+         *  - object() -> struct ::ext_workspace_group_handle_v1 *
+         * These functions are complete, and we do not have to re-implement them here.
+         */
+
+        Q_SIGNAL void capabilities( uint32_t capabilities );
+        Q_SIGNAL void outputEnter( struct ::wl_output *output );
+        Q_SIGNAL void outputLeave( struct ::wl_output *output );
+        Q_SIGNAL void workspaceAdded( WorkspaceHandleV1 *workspace );
+        Q_SIGNAL void workspaceRemoved( WorkspaceHandleV1 *workspace );
+        Q_SIGNAL void removed();
+
+    protected:
+        virtual void ext_workspace_group_handle_v1_capabilities( uint32_t capabilities );
+        virtual void ext_workspace_group_handle_v1_output_enter( struct ::wl_output *output );
+        virtual void ext_workspace_group_handle_v1_output_leave( struct ::wl_output *output );
+        virtual void ext_workspace_group_handle_v1_workspace_enter( struct ::ext_workspace_handle_v1 *workspace );
+        virtual void ext_workspace_group_handle_v1_workspace_leave( struct ::ext_workspace_handle_v1 *workspace );
+        virtual void ext_workspace_group_handle_v1_removed();
+
+    private:
+        /** Track on which outputs this workspace group is visible */
+        QList<struct ::wl_output *> outputs;
+
+        /** Store the capabilities */
+        uint32_t m_supported_capabilities;
+
+        /** Track on which workspaces are a part of this workspace group */
+        QList<WorkspaceHandleV1 *> workspaces;
+};
+
+class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_workspace_handle_v1 {
+    Q_OBJECT;
+    public:
+        WorkspaceHandleV1( struct ::ext_workspace_handle_v1 *object );
+        virtual ~WorkspaceHandleV1();
+
+        /**
+         * Note: QtWayland::ext_workspace_group_handle_v1 has following member functions:
+         *  - object() -> struct ::ext_workspace_group_handle_v1 *
+         *  - destroy();
+         *  - activate();
+         *  - deactivate();
+         *  - assign(struct ::ext_workspace_group_handle_v1 *workspace_group);
+         *  - remove();
+         * These functions are complete, and we do not have to re-implement them here.
+         */
+
+        QString getId() const;
+        QString getName() const;
+        QList<int> getCoordinates() const;
+        uint32_t getState() const;
+        uint32_t getCapabilities() const;
+
+        Q_SIGNAL void id( const QString& id );
+        Q_SIGNAL void name( const QString& name );
+        Q_SIGNAL void coordinates( QList<int> coordinates );
+        Q_SIGNAL void state( uint32_t state );
+        Q_SIGNAL void capabilities( uint32_t capabilities );
+        Q_SIGNAL void removed();
+
+    protected:
+        virtual void ext_workspace_handle_v1_id( const QString& id );
+        virtual void ext_workspace_handle_v1_name( const QString& name );
+        virtual void ext_workspace_handle_v1_coordinates( wl_array *coordinates );
+        virtual void ext_workspace_handle_v1_state( uint32_t state );
+        virtual void ext_workspace_handle_v1_capabilities( uint32_t capabilities );
+        virtual void ext_workspace_handle_v1_removed();
+
+    private:
+        QString m_id;
+        QString m_name;
+        QList<int> m_coordinates;
+        uint32_t m_state;
+        uint32_t m_capabilities;
+};


### PR DESCRIPTION
Initial draft of the ext-workspaces-v1 protocol implementation.
- [x] Classes that implement the protocol (`WorkspaceManagerV1`, `WorkspaceGroupHandleV1`, `WorkspaceHandleV1`).
- [ ] Extensions to the classes to actually make them useful. For example, `workspaceCount( QScreen * ) function is needed in `WorkspaceManagerV1` class to get the number of workspaces on a visible on a given screen.
- [ ] Testing if this works (detects the number of workspace groups, workspaces etc), potential flaws etc..
- [ ] Integrating it with the rest of the panel. This is our toughest challenge. We can bind multiple outputs to a single workspace group, or one output can be mapped to a single workspace group. We need to make provisions for such behaviour in other parts of the panel.

