### PR TITLE
Accept menu file base-name in Fancy Menu

### DIFF
--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -178,6 +178,8 @@ void LXQtFancyMenu::settingsChanged()
     QString menu_file = settings()->value(QStringLiteral("menu_file"), QString()).toString();
     if (menu_file.isEmpty())
         menu_file = XdgMenu::getMenuFileName();
+    else if (!menu_file.contains(QLatin1String("/")))
+        menu_file = XdgMenu::getMenuFileName(menu_file);
 
     if (mMenuFile != menu_file)
     {

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -129,9 +129,9 @@ void LXQtFancyMenuConfiguration::loadSettings()
 
     QString menuFile = settings().value(QStringLiteral("menu_file"), QString()).toString();
     if (menuFile.isEmpty())
-    {
         menuFile = XdgMenu::getMenuFileName();
-    }
+    else if (!menuFile.contains(QLatin1String("/")))
+        menuFile = XdgMenu::getMenuFileName(menuFile);
     ui->menuFilePathLE->setText(menuFile);
     ui->shortcutEd->setText(nullptr != mShortcut ? mShortcut->shortcut() : mDefaultShortcut);
 


### PR DESCRIPTION
The base name is the name minus the prefix (`lxqt-` for LXQt), which is added by `libqtxdg` depending on `XDG_MENU_PREFIX`.