### PR TITLE
mainmenu: Accept .menu basename

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -209,6 +209,8 @@ void LXQtMainMenu::settingsChanged()
     QString menu_file = settings()->value(QStringLiteral("menu_file"), QString()).toString();
     if (menu_file.isEmpty())
         menu_file = XdgMenu::getMenuFileName();
+    else if (!menu_file.contains(QLatin1String("/")))
+        menu_file = XdgMenu::getMenuFileName(menu_file);
 
     if (mMenuFile != menu_file)
     {

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -124,10 +124,11 @@ void LXQtMainMenuConfiguration::loadSettings()
 
     QString menuFile = settings().value(QStringLiteral("menu_file"), QString()).toString();
     if (menuFile.isEmpty())
-    {
         menuFile = XdgMenu::getMenuFileName();
-    }
+    else if (!menuFile.contains(QLatin1String("/")))
+        menuFile = XdgMenu::getMenuFileName(menuFile);
     ui->menuFilePathLE->setText(menuFile);
+
     ui->shortcutEd->setText(nullptr != mShortcut ? mShortcut->shortcut() : mDefaultShortcut);
 
     ui->customFontCB->setChecked(settings().value(QStringLiteral("customFont"), false).toBool());


### PR DESCRIPTION
Unless I'm imagining things, sometimes under certain environments mainmenu and fancymenu start with no menu because there is no default set. This allows for setting a system default in the same vein as https://github.com/lxqt/lxqt-panel/pull/2325 .

Otherwise, it's harmless and makes things ~orthogonal~ in sync between mainmenu and fancymenu.