### PR TITLE
mainmenu: use `lxqt-applications.menu` by default

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -208,7 +208,7 @@ void LXQtMainMenu::settingsChanged()
 
     QString menu_file = settings()->value(QStringLiteral("menu_file"), QString()).toString();
     if (menu_file.isEmpty())
-        menu_file = XdgMenu::getMenuFileName();
+        menu_file = XdgMenu::getMenuFileName(QLatin1String("applications.menu"));
     else if (!menu_file.contains(QLatin1String("/")))
         menu_file = XdgMenu::getMenuFileName(menu_file);
 

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -124,7 +124,7 @@ void LXQtMainMenuConfiguration::loadSettings()
 
     QString menuFile = settings().value(QStringLiteral("menu_file"), QString()).toString();
     if (menuFile.isEmpty())
-        menuFile = XdgMenu::getMenuFileName();
+        menuFile = XdgMenu::getMenuFileName(QLatin1String("applications.menu"));
     else if (!menuFile.contains(QLatin1String("/")))
         menuFile = XdgMenu::getMenuFileName(menuFile);
     ui->menuFilePathLE->setText(menuFile);


### PR DESCRIPTION
Exactly the same as https://github.com/lxqt/lxqt-panel/pull/2330 but for plugin-mainmenu.

Not sure if there is an effective change. Prior the menu had opened with no entries under unusual environments (may be unrelated.)