### PR TITLE
plugin-cpuload: Remove groupbox properties and AlignVCenter

### DIFF
--- a/plugin-cpuload/lxqtcpuloadconfiguration.ui
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.ui
@@ -19,15 +19,6 @@
      <property name="title">
       <string>General</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="showTextCB">


### PR DESCRIPTION
Remove AlignVCenter (looks odd) and redundant properties.

See also https://github.com/lxqt/lxqt-panel/pull/2249