### PR TITLE
Delete widget (non- top-level) geometry tags

### DIFF
--- a/plugin-dom/treewindow.ui
+++ b/plugin-dom/treewindow.ui
@@ -116,14 +116,6 @@
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>601</width>
-     <height>21</height>
-    </rect>
-   </property>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
  </widget>

--- a/plugin-worldclock/lxqtworldclockconfigurationmanualformat.ui
+++ b/plugin-worldclock/lxqtworldclockconfigurationmanualformat.ui
@@ -56,14 +56,6 @@
        <bool>true</bool>
       </property>
       <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>766</width>
-         <height>1050</height>
-        </rect>
-       </property>
        <layout class="QVBoxLayout" name="verticalLayout">
         <property name="leftMargin">
          <number>0</number>


### PR DESCRIPTION
- `<property name="geometry">` tags deleted for non- top-level widgets (Qt Designer remnants.)
- Geometry tag W x H rounded for top-level (windows) to the nearest `20` (they often were odd numbers, e.g. `139`.)