### PR TITLE
Remove unneeded QOverloads for connect() (Qt5 → Qt6)

### DIFF
--- a/panel/config/configplacement.cpp
+++ b/panel/config/configplacement.cpp
@@ -90,22 +90,22 @@ ConfigPlacement::ConfigPlacement(LXQtPanel *panel, QWidget *parent) :
     // reset configurations from file
     reset();
 
-    connect(ui->spinBox_panelSize,          QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
-    connect(ui->spinBox_iconSize,           QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
-    connect(ui->spinBox_lineCount,          QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
+    connect(ui->spinBox_panelSize,      &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
+    connect(ui->spinBox_iconSize,       &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
+    connect(ui->spinBox_lineCount,      &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
 
-    connect(ui->spinBox_length,             QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
-    connect(ui->comboBox_lengthType,        QOverload<int>::of(&QComboBox::activated),        this, &ConfigPlacement::widthTypeChanged);
+    connect(ui->spinBox_length,         &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
+    connect(ui->comboBox_lengthType,    &QComboBox::activated,     this, &ConfigPlacement::widthTypeChanged);
 
-    connect(ui->comboBox_alignment,         QOverload<int>::of(&QComboBox::activated),        this, &ConfigPlacement::editChanged);
-    connect(ui->comboBox_position,          QOverload<int>::of(&QComboBox::activated),        this, &ConfigPlacement::positionChanged);
-    connect(ui->groupBox_hidable,           &QGroupBox::toggled,                              this, &ConfigPlacement::editChanged);
-    connect(ui->checkBox_visibleMargin,     &QCheckBox::toggled,                              this, &ConfigPlacement::editChanged);
-    connect(ui->checkBox_overlap,           &QAbstractButton::toggled,                        this, &ConfigPlacement::editChanged);
-    connect(ui->spinBox_animation,          QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
-    connect(ui->spinBox_delay,              QOverload<int>::of(&QSpinBox::valueChanged),      this, &ConfigPlacement::editChanged);
+    connect(ui->comboBox_alignment,     &QComboBox::activated,     this, &ConfigPlacement::editChanged);
+    connect(ui->comboBox_position,      &QComboBox::activated,     this, &ConfigPlacement::positionChanged);
+    connect(ui->groupBox_hidable,       &QGroupBox::toggled,       this, &ConfigPlacement::editChanged);
+    connect(ui->checkBox_visibleMargin, &QCheckBox::toggled,       this, &ConfigPlacement::editChanged);
+    connect(ui->checkBox_overlap,       &QAbstractButton::toggled, this, &ConfigPlacement::editChanged);
+    connect(ui->spinBox_animation,      &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
+    connect(ui->spinBox_delay,          &QSpinBox::valueChanged,   this, &ConfigPlacement::editChanged);
 
-    connect(ui->checkBox_reserveSpace,      &QAbstractButton::toggled, this, [this](bool checked) { mPanel->setReserveSpace(checked, true); });
+    connect(ui->checkBox_reserveSpace,  &QAbstractButton::toggled, this, [this](bool checked) { mPanel->setReserveSpace(checked, true); });
 
 }
 

--- a/panel/config/configstyling.cpp
+++ b/panel/config/configstyling.cpp
@@ -59,16 +59,16 @@ ConfigStyling::ConfigStyling(LXQtPanel *panel, QWidget *parent) :
     // reset configurations from file
     reset();
 
-    connect(ui->checkBox_customFontColor,   &QCheckBox::toggled,       this, &ConfigStyling::editChanged);
-    connect(ui->pushButton_customFontColor, &QPushButton::clicked,     this, &ConfigStyling::pickFontColor);
-    connect(ui->checkBox_customBgColor,     &QCheckBox::toggled,       this, &ConfigStyling::editChanged);
-    connect(ui->pushButton_customBgColor,   &QPushButton::clicked,     this, &ConfigStyling::pickBackgroundColor);
-    connect(ui->checkBox_customBgImage,     &QCheckBox::toggled,       this, &ConfigStyling::editChanged);
-    connect(ui->lineEdit_customBgImage,     &QLineEdit::textChanged,   this, &ConfigStyling::editChanged);
-    connect(ui->pushButton_customBgImage,   &QPushButton::clicked,     this, &ConfigStyling::pickBackgroundImage);
-    connect(ui->slider_opacity,             &QSlider::valueChanged,    this, &ConfigStyling::editChanged);
-    connect(ui->groupBox_icon,              &QGroupBox::clicked,                       this, &ConfigStyling::editChanged);
-    connect(ui->comboBox_icon,              QOverload<int>::of(&QComboBox::activated), this, &ConfigStyling::editChanged);
+    connect(ui->checkBox_customFontColor,   &QCheckBox::toggled,     this, &ConfigStyling::editChanged);
+    connect(ui->pushButton_customFontColor, &QPushButton::clicked,   this, &ConfigStyling::pickFontColor);
+    connect(ui->checkBox_customBgColor,     &QCheckBox::toggled,     this, &ConfigStyling::editChanged);
+    connect(ui->pushButton_customBgColor,   &QPushButton::clicked,   this, &ConfigStyling::pickBackgroundColor);
+    connect(ui->checkBox_customBgImage,     &QCheckBox::toggled,     this, &ConfigStyling::editChanged);
+    connect(ui->lineEdit_customBgImage,     &QLineEdit::textChanged, this, &ConfigStyling::editChanged);
+    connect(ui->pushButton_customBgImage,   &QPushButton::clicked,   this, &ConfigStyling::pickBackgroundImage);
+    connect(ui->slider_opacity,             &QSlider::valueChanged,  this, &ConfigStyling::editChanged);
+    connect(ui->groupBox_icon,              &QGroupBox::clicked,     this, &ConfigStyling::editChanged);
+    connect(ui->comboBox_icon,              &QComboBox::activated,   this, &ConfigStyling::editChanged);
 }
 
 

--- a/plugin-cpuload/lxqtcpuloadconfiguration.cpp
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.cpp
@@ -48,10 +48,10 @@ LXQtCpuLoadConfiguration::LXQtCpuLoadConfiguration(PluginSettings *settings, QWi
 
     loadSettings();
 
-    connect(ui->showTextCB,            &QCheckBox::toggled,                                  this, &LXQtCpuLoadConfiguration::showTextChanged);
-    connect(ui->barWidthSB,            QOverload<int>::of(&QSpinBox::valueChanged),          this, &LXQtCpuLoadConfiguration::barWidthChanged);
-    connect(ui->updateIntervalSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &LXQtCpuLoadConfiguration::updateIntervalChanged);
-    connect(ui->barOrientationCOB,     QOverload<int>::of(&QComboBox::currentIndexChanged),  this, &LXQtCpuLoadConfiguration::barOrientationChanged);
+    connect(ui->showTextCB,            &QCheckBox::toggled,             this, &LXQtCpuLoadConfiguration::showTextChanged);
+    connect(ui->barWidthSB,            &QSpinBox::valueChanged,         this, &LXQtCpuLoadConfiguration::barWidthChanged);
+    connect(ui->updateIntervalSpinBox, &QDoubleSpinBox::valueChanged,   this, &LXQtCpuLoadConfiguration::updateIntervalChanged);
+    connect(ui->barOrientationCOB,     &QComboBox::currentIndexChanged, this, &LXQtCpuLoadConfiguration::barOrientationChanged);
 }
 
 LXQtCpuLoadConfiguration::~LXQtCpuLoadConfiguration()

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -64,7 +64,7 @@ LXQtCustomCommand::LXQtCustomCommand(const ILXQtPanelPluginStartupInfo &startupI
     connect(mButton, &CustomButton::wheelScrolled, this, &LXQtCustomCommand::handleWheelScrolled);
     connect(mTimer, &QTimer::timeout, this, &LXQtCustomCommand::runCommand);
     connect(mDelayedRunTimer, &QTimer::timeout, this, &LXQtCustomCommand::runCommand);
-    connect(mProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &LXQtCustomCommand::handleFinished);
+    connect(mProcess, &QProcess::finished, this, &LXQtCustomCommand::handleFinished);
 
     settingsChanged();
 }

--- a/plugin-desktopswitch/desktopswitchconfiguration.cpp
+++ b/plugin-desktopswitch/desktopswitchconfiguration.cpp
@@ -45,9 +45,9 @@ DesktopSwitchConfiguration::DesktopSwitchConfiguration(PluginSettings *settings,
 
     loadSettings();
 
-    connect(ui->rowsSB,           QOverload<int>::of(&QSpinBox::valueChanged),         this, &DesktopSwitchConfiguration::rowsChanged);
-    connect(ui->labelTypeCB,      QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DesktopSwitchConfiguration::labelTypeChanged);
-    connect(ui->showOnlyActiveCB, &QAbstractButton::toggled,                           this, [this] (bool checked) {
+    connect(ui->rowsSB,           &QSpinBox::valueChanged,         this, &DesktopSwitchConfiguration::rowsChanged);
+    connect(ui->labelTypeCB,      &QComboBox::currentIndexChanged, this, &DesktopSwitchConfiguration::labelTypeChanged);
+    connect(ui->showOnlyActiveCB, &QAbstractButton::toggled,       this, [this] (bool checked) {
         this->settings().setValue(QStringLiteral("showOnlyActive"), checked);
     });
 

--- a/plugin-directorymenu/directorymenuconfiguration.cpp
+++ b/plugin-directorymenu/directorymenuconfiguration.cpp
@@ -54,7 +54,7 @@ DirectoryMenuConfiguration::DirectoryMenuConfiguration(PluginSettings *settings,
     ui->buttonStyleCB->addItem(tr("Only icon"), QLatin1String("Icon"));
     ui->buttonStyleCB->addItem(tr("Only text"), QLatin1String("Text"));
     ui->buttonStyleCB->addItem(tr("Icon and text"), QLatin1String("IconText"));
-    connect(ui->buttonStyleCB, QOverload<int>::of(&QComboBox::activated), this, &DirectoryMenuConfiguration::saveSettings);
+    connect(ui->buttonStyleCB, &QComboBox::activated, this, &DirectoryMenuConfiguration::saveSettings);
 
     loadSettings();
     ui->baseDirectoryB->setIcon(mDefaultIcon);

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -81,12 +81,12 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
     connect(ui->shortcutEd->addMenuAction(tr("Reset")), &QAction::triggered, this, &LXQtFancyMenuConfiguration::shortcutReset);
 
     connect(ui->customFontCB, &QAbstractButton::toggled, this, &LXQtFancyMenuConfiguration::customFontChanged);
-    connect(ui->customFontSizeSB, QOverload<int>::of(&QSpinBox::valueChanged), this, &LXQtFancyMenuConfiguration::customFontSizeChanged);
+    connect(ui->customFontSizeSB, &QSpinBox::valueChanged, this, &LXQtFancyMenuConfiguration::customFontSizeChanged);
 
     connect(ui->autoSelCB, &QAbstractButton::toggled, this, [this] (bool checked) {
         this->settings().setValue(QStringLiteral("autoSel"), checked);
     });
-    connect(ui->autoSelSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+    connect(ui->autoSelSB, &QSpinBox::valueChanged, this, [this] (int value) {
         this->settings().setValue(QStringLiteral("autoSelDelay"), value);
     });
 
@@ -97,8 +97,8 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
             this->settings().setValue(QStringLiteral("filterClear"), value);
     });
 
-    connect(ui->buttRowPosCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtFancyMenuConfiguration::buttonRowPositionChanged);
-    connect(ui->categoryViewPosCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtFancyMenuConfiguration::categoryPositionChanged);
+    connect(ui->buttRowPosCB, &QComboBox::activated, this, &LXQtFancyMenuConfiguration::buttonRowPositionChanged);
+    connect(ui->categoryViewPosCB, &QComboBox::activated, this, &LXQtFancyMenuConfiguration::categoryPositionChanged);
 }
 
 LXQtFancyMenuConfiguration::~LXQtFancyMenuConfiguration()

--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -46,7 +46,7 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
     connect(m_ui->showLayout, &QGroupBox::clicked, this, &KbdStateConfig::save);
     connect(m_ui->layoutFlagPattern, &QLineEdit::textEdited, this, &KbdStateConfig::save);
 
-    connect(m_ui->modes, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked), this, [this] {
+    connect(m_ui->modes, &QButtonGroup::buttonClicked, this, [this] {
         KbdStateConfig::save();
     });
 

--- a/plugin-mainmenu/actionview.cpp
+++ b/plugin-mainmenu/actionview.cpp
@@ -118,7 +118,7 @@ namespace
             return s;
         }
     private:
-        int mMaxItemWidth{300};
+        int mMaxItemWidth = 300;
     };
 
 }

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -90,11 +90,11 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShow"), value);
     });
-    connect(ui->filterShowMaxItemsSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+    connect(ui->filterShowMaxItemsSB, &QSpinBox::valueChanged, this, [this] (int value) {
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShowMaxItems"), value);
     });
-    connect(ui->filterShowMaxWidthSB, QOverload<int>::of(&QSpinBox::valueChanged), this, [this] (int value) {
+    connect(ui->filterShowMaxWidthSB, &QSpinBox::valueChanged, this, [this] (int value) {
         if (!mLockSettingChanges)
             this->settings().setValue(QStringLiteral("filterShowMaxWidth"), value);
     });

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
@@ -49,9 +49,9 @@ LXQtNetworkMonitorConfiguration::LXQtNetworkMonitorConfiguration(PluginSettings 
     setObjectName(QStringLiteral("NetworkMonitorConfigurationWindow"));
     ui->setupUi(this);
 
-    connect(ui->buttons,     &QDialogButtonBox::clicked,                          this, &LXQtNetworkMonitorConfiguration::dialogButtonsAction);
-    connect(ui->iconCB,      QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtNetworkMonitorConfiguration::saveSettings);
-    connect(ui->interfaceCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtNetworkMonitorConfiguration::saveSettings);
+    connect(ui->buttons,     &QDialogButtonBox::clicked,      this, &LXQtNetworkMonitorConfiguration::dialogButtonsAction);
+    connect(ui->iconCB,      &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);
+    connect(ui->interfaceCB, &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);
 
     loadSettings();
 }

--- a/plugin-sensors/lxqtsensorsconfiguration.cpp
+++ b/plugin-sensors/lxqtsensorsconfiguration.cpp
@@ -46,14 +46,14 @@ LXQtSensorsConfiguration::LXQtSensorsConfiguration(PluginSettings *settings, QWi
     // We load settings here cause we have to set up dynamic widgets
     loadSettings();
 
-    connect(ui->buttons,                        &QDialogButtonBox::clicked,                  this, &LXQtSensorsConfiguration::dialogButtonsAction);
-    connect(ui->updateIntervalSB,               QOverload<int>::of(&QSpinBox::valueChanged), this, &LXQtSensorsConfiguration::saveSettings);
-    connect(ui->tempBarWidthSB,                 QOverload<int>::of(&QSpinBox::valueChanged), this, &LXQtSensorsConfiguration::saveSettings);
-    connect(ui->detectedChipsCB,                QOverload<int>::of(&QComboBox::activated),   this, &LXQtSensorsConfiguration::detectedChipSelected);
-    connect(ui->celsiusTempScaleRB,             &QRadioButton::toggled,                      this, &LXQtSensorsConfiguration::saveSettings);
+    connect(ui->buttons,                        &QDialogButtonBox::clicked, this, &LXQtSensorsConfiguration::dialogButtonsAction);
+    connect(ui->updateIntervalSB,               &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);
+    connect(ui->tempBarWidthSB,                 &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);
+    connect(ui->detectedChipsCB,                &QComboBox::activated,      this, &LXQtSensorsConfiguration::detectedChipSelected);
+    connect(ui->celsiusTempScaleRB,             &QRadioButton::toggled,     this, &LXQtSensorsConfiguration::saveSettings);
     // We don't need signal from the other radio box as celsiusTempScaleRB will send one
     //connect(ui->fahrenheitTempScaleRB, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
-    connect(ui->warningAboutHighTemperatureChB, &QCheckBox::toggled,                         this, &LXQtSensorsConfiguration::saveSettings);
+    connect(ui->warningAboutHighTemperatureChB, &QCheckBox::toggled,        this, &LXQtSensorsConfiguration::saveSettings);
 
     /**
      * Signals for enable/disable and bar color change are set in the loadSettings method because

--- a/plugin-statusnotifier/statusnotifierconfiguration.cpp
+++ b/plugin-statusnotifier/statusnotifierconfiguration.cpp
@@ -89,7 +89,7 @@ void StatusNotifierConfiguration::addItems(const QStringList &items)
             cb->setCurrentIndex(1);
         else if (mHideList.contains(item))
             cb->setCurrentIndex(2);
-        connect(cb, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, item] (int indx) {
+        connect(cb, &QComboBox::currentIndexChanged, this, [this, item] (int indx) {
             if (indx == 0)
             {
                 mAutoHideList.removeAll(item);

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -78,11 +78,11 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
 #else
     connect(ui->limitByDesktopCB, &QCheckBox::stateChanged, ui->showDesktopNumCB, &QWidget::setEnabled);
 #endif
-    connect(ui->showDesktopNumCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->showDesktopNumCB, &QComboBox::activated, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->limitByScreenCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->limitByMinimizedCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->raiseOnCurrentDesktopCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
-    connect(ui->buttonStyleCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->buttonStyleCB, &QComboBox::activated, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->buttonWidthSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->buttonHeightSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->autoRotateCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
@@ -94,7 +94,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     connect(ui->showGroupOnHoverCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->ungroupedNextToExistingCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->iconByClassCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
-    connect(ui->wheelEventsActionCB, QOverload<int>::of(&QComboBox::activated), this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->wheelEventsActionCB, &QComboBox::activated, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->wheelDeltaThresholdSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->excludeLE, &QLineEdit::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
 }

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -41,14 +41,14 @@ LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool 
     ui->setupUi(this);
 
     loadSettings();
-    connect(ui->devAddedCombo,                     QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtVolumeConfiguration::sinkSelectionChanged);
-    connect(ui->buttons,                           &QDialogButtonBox::clicked,                          this, &LXQtVolumeConfiguration::dialogButtonsAction);
-    connect(ui->muteOnMiddleClickCheckBox,         &QCheckBox::toggled,                                 this, &LXQtVolumeConfiguration::muteOnMiddleClickChanged);
-    connect(ui->mixerLineEdit,                     &QLineEdit::textChanged,                             this, &LXQtVolumeConfiguration::mixerLineEditChanged);
-    connect(ui->stepSpinBox,                       QOverload<int>::of(&QSpinBox::valueChanged),         this, &LXQtVolumeConfiguration::stepSpinBoxChanged);
-    connect(ui->ignoreMaxVolumeCheckBox,           &QCheckBox::toggled,                                 this, &LXQtVolumeConfiguration::ignoreMaxVolumeCheckBoxChanged);
-    connect(ui->alwaysShowNotificationsCheckBox,  &QAbstractButton::toggled,                           this, &LXQtVolumeConfiguration::alwaysShowNotificationsCheckBoxChanged);
-    connect(ui->showKeyboardNotificationsCheckBox, &QAbstractButton::toggled,                           this, &LXQtVolumeConfiguration::showKeyboardNotificationsCheckBoxChanged);
+    connect(ui->devAddedCombo,                     &QComboBox::currentIndexChanged, this, &LXQtVolumeConfiguration::sinkSelectionChanged);
+    connect(ui->buttons,                           &QDialogButtonBox::clicked,      this, &LXQtVolumeConfiguration::dialogButtonsAction);
+    connect(ui->muteOnMiddleClickCheckBox,         &QCheckBox::toggled,             this, &LXQtVolumeConfiguration::muteOnMiddleClickChanged);
+    connect(ui->mixerLineEdit,                     &QLineEdit::textChanged,         this, &LXQtVolumeConfiguration::mixerLineEditChanged);
+    connect(ui->stepSpinBox,                       &QSpinBox::valueChanged,         this, &LXQtVolumeConfiguration::stepSpinBoxChanged);
+    connect(ui->ignoreMaxVolumeCheckBox,           &QCheckBox::toggled,             this, &LXQtVolumeConfiguration::ignoreMaxVolumeCheckBoxChanged);
+    connect(ui->alwaysShowNotificationsCheckBox,   &QAbstractButton::toggled,       this, &LXQtVolumeConfiguration::alwaysShowNotificationsCheckBoxChanged);
+    connect(ui->showKeyboardNotificationsCheckBox, &QAbstractButton::toggled,       this, &LXQtVolumeConfiguration::showKeyboardNotificationsCheckBoxChanged);
 
     if (ossAvailable)
         connect(ui->ossRadioButton, &QRadioButton::toggled, this, &LXQtVolumeConfiguration::audioEngineChanged);

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -52,16 +52,16 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtWorldClockConfiguration::dialogButtonsAction);
 
-    connect(ui->timeFormatCB,         QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::saveSettings);
+    connect(ui->timeFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timeShowSecondsCB,    &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timePadHourCB,        &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timeAMPMCB,           &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timezoneGB,           &QGroupBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
-    connect(ui->timezonePositionCB,   QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::saveSettings);
-    connect(ui->timezoneFormatCB,     QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::saveSettings);
+    connect(ui->timezonePositionCB,   &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
+    connect(ui->timezoneFormatCB,     &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->dateGB,               &QGroupBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
-    connect(ui->datePositionCB,       QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::saveSettings);
-    connect(ui->dateFormatCB,         QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::saveSettings);
+    connect(ui->datePositionCB,       &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
+    connect(ui->dateFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->dateShowYearCB,       &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->dateShowDoWCB,        &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->datePadDayCB,         &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
@@ -69,9 +69,9 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
     connect(ui->advancedManualGB,     &QGroupBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->customisePB,          &QPushButton::clicked,           this, &LXQtWorldClockConfiguration::customiseManualFormatClicked);
 
-    connect(ui->timeFormatCB,         QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::timeFormatChanged);
+    connect(ui->timeFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::timeFormatChanged);
     connect(ui->dateGB,               &QGroupBox::toggled,             this, &LXQtWorldClockConfiguration::dateGroupToggled);
-    connect(ui->dateFormatCB,         QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LXQtWorldClockConfiguration::dateFormatChanged);
+    connect(ui->dateFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::dateFormatChanged);
     connect(ui->advancedManualGB,     &QGroupBox::toggled,             this, &LXQtWorldClockConfiguration::advancedFormatToggled);
 
     connect(ui->timeZonesTW,          &QTableWidget::itemSelectionChanged, this, &LXQtWorldClockConfiguration::updateTimeZoneButtons);


### PR DESCRIPTION
With Qt6, signals/slots are normally no longer overloaded. Therefore no disambiguation is needed.

In a couple of places `QOverload<>::of(` was still needed.