### PR TITLE
customcommand: Update button every time it receives output.

### DIFF
--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -206,7 +206,6 @@ void LXQtCustomCommand::handleOutput()
         if (mOutput.endsWith(QStringLiteral("\n")))
             mOutput.chop(1);
     }
-    qDebug() << "mOutput" << mOutput;
     updateButton();
 }
 

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -219,11 +219,15 @@ void LXQtCustomCommand::handleOutput()
 void LXQtCustomCommand::updateButton() {
 
     if (mOutputImage) {
-        QPixmap pixmap;
-        pixmap.loadFromData(mOutputByteArray);
-        if (pixmap.isNull())
-            pixmap.loadFromData(QByteArray::fromBase64(mOutputByteArray));
-        QIcon icon(pixmap);
+        QString iconString = QString::fromUtf8(mOutputByteArray.trimmed());
+        QIcon icon = XdgIcon::fromTheme(iconString, QIcon(iconString));
+        if (icon.isNull()) {
+            QPixmap pixmap;
+            pixmap.loadFromData(mOutputByteArray);
+            if (pixmap.isNull())
+                pixmap.loadFromData(QByteArray::fromBase64(mOutputByteArray));
+            icon = QIcon(pixmap);
+        }
         mButton->setIcon(icon);
         mButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
     } else {

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -188,8 +188,10 @@ void LXQtCustomCommand::handleClick()
 
 void LXQtCustomCommand::handleFinished(int exitCode, QProcess::ExitStatus /*exitStatus*/)
 {
-    if (exitCode != 0) 
+    if (exitCode != 0) {
         mOutput = tr("Error");
+        updateButton();
+    }
     
     if (mRepeat)
         mTimer->start();

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -156,7 +156,7 @@ void LXQtCustomCommand::settingsChanged()
     if (mFirstRun || oldRepeatTimer != mRepeatTimer)
         mTimer->setInterval(mRepeatTimer * 1000);
 
-    if (oldIcon != mIcon) {
+    if (oldIcon != mIcon || (oldOutputImage && !mOutputImage)) {
         mButton->setIcon(XdgIcon::fromTheme(mIcon, QIcon(mIcon)));
         updateButton();
     }
@@ -218,9 +218,11 @@ void LXQtCustomCommand::handleOutput()
 
 void LXQtCustomCommand::updateButton() {
 
-    if(mOutputImage) {
+    if (mOutputImage) {
         QPixmap pixmap;
         pixmap.loadFromData(mOutputByteArray);
+        if (pixmap.isNull())
+            pixmap.loadFromData(QByteArray::fromBase64(mOutputByteArray));
         QIcon icon(pixmap);
         mButton->setIcon(icon);
         mButton->setToolButtonStyle(Qt::ToolButtonIconOnly);

--- a/plugin-customcommand/lxqtcustomcommand.h
+++ b/plugin-customcommand/lxqtcustomcommand.h
@@ -56,6 +56,7 @@ protected slots:
 private slots:
     void handleClick();
     void handleFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void handleOutput();
     void handleWheelScrolled(int delta);
     void updateButton();
     void runCommand();


### PR DESCRIPTION
related to #2304
Changed the handling to update every time it receives output, i don't think it needs an option to use this or the previous behavior, my commands are working the same, and to test this change:
``` bash
while true; do
    date +"%H:%M:%S"
    sleep 1
done
```
with "bash -c"
repeat doesn't matter since the command won't exit

@stefonarch  can you test with images as well? i don't use any here.