### PR TITLE
fancymenu: Use locale-aware sorting for app list

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuappmap.cpp
+++ b/plugin-fancymenu/lxqtfancymenuappmap.cpp
@@ -32,6 +32,7 @@
 #include <XdgIcon>
 
 #include <QCoreApplication>
+#include <QCollator>
 
 class LXQtFancyMenuAppMapStrings
 {
@@ -325,6 +326,17 @@ void LXQtFancyMenuAppMap::parseMenu(const QDomElement &menu, const QString& topL
 
         e = e.nextSiblingElement();
     }
+
+    // Build sorted list of all apps
+    mAppSortedByName = mAppSortedByDesktopFile.values();
+
+    QCollator collator;
+    collator.setCaseSensitivity(Qt::CaseInsensitive);
+
+    std::sort(mAppSortedByName.begin(), mAppSortedByName.end(),
+              [&](AppItem* a, AppItem* b) {
+                  return collator.compare(a->title, b->title) < 0;
+              });
 }
 
 void LXQtFancyMenuAppMap::parseAppLink(const QDomElement &app, const QString& topLevelCategory)
@@ -341,7 +353,6 @@ void LXQtFancyMenuAppMap::parseAppLink(const QDomElement &app, const QString& to
             return; // Invalid app
 
         mAppSortedByDesktopFile.insert(appItem->desktopFile, appItem);
-        mAppSortedByName.insert(appItem->title, appItem);
     }
 
     // Now add app to category

--- a/plugin-fancymenu/lxqtfancymenuappmap.h
+++ b/plugin-fancymenu/lxqtfancymenuappmap.h
@@ -119,13 +119,12 @@ private:
     AppItem *loadAppItem(const QString& desktopFile);
 
 private:
-    typedef QMap<QString, AppItem *> AppMap;
-    AppMap mAppSortedByDesktopFile;
-    AppMap mAppSortedByName;
+    QMap<QString, AppItem *> mAppSortedByDesktopFile;
+    QList<AppItem *> mAppSortedByName;
     QList<Category> mCategories;
 
     // Cache sort by name map access
-    AppMap::const_iterator mCachedIterator;
+    QList<AppItem *>::const_iterator mCachedIterator;
     int mCachedIndex;
 };
 


### PR DESCRIPTION
This fixes the problem that entries starting with non-English characters were placed at the end of the All Applications menu.

It also fixes the case when two apps had the same name and only one of them appeared in the list.

Note that there is another pull request to fix the sorting of the other categories: https://github.com/lxqt/libqtxdg/pull/317
This pull request is needed for the All Applications list.