### PR TITLE
mainmenu: Use locale-aware sorting for action view

### DIFF
--- a/plugin-mainmenu/actionview.cpp
+++ b/plugin-mainmenu/actionview.cpp
@@ -45,7 +45,10 @@
 
 //==============================
 FilterProxyModel::FilterProxyModel(QObject* parent) :
-    QSortFilterProxyModel(parent) {
+    QSortFilterProxyModel(parent)
+{
+    setSortCaseSensitivity(Qt::CaseInsensitive);
+    setSortLocaleAware(true);
 }
 
 FilterProxyModel::~FilterProxyModel() = default;


### PR DESCRIPTION
This fixes the problem that entries starting with non-English characters were placed at the end of the list during search.