### PR TITLE
Silenced several clang warnings

### DIFF
--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.cpp
@@ -216,7 +216,7 @@ LXQtTaskbarWayfireBackend::LXQtTaskbarWayfireBackend(QObject *parent) :
 {
     mWayfire.reset(new LXQt::Panel::Wayfire);
 
-    connect(mWayfire.get(), &LXQt::Panel::Wayfire::workspaceSetChanged, [this] ( QJsonDocument )
+    connect(mWayfire.get(), &LXQt::Panel::Wayfire::workspaceSetChanged, [] ( QJsonDocument )
     {
         // no-op
     });

--- a/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
+++ b/panel/backends/wayland/wayfire/lxqtwmbackend_wf.h
@@ -80,7 +80,7 @@ class LXQtTaskbarWayfireBackend : public ILXQtAbstractWMInterface
     virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
 
     // Not supported on wayfire at the moment
-    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft);
+    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft) override;
 
     // X11 Specific
     virtual void moveApplication(WId windowId) override;

--- a/panel/backends/wayland/wayfire/wayfire-common.h
+++ b/panel/backends/wayland/wayfire/wayfire-common.h
@@ -52,7 +52,7 @@ struct WaylandId
 
 class LXQt::Panel::WayfireImpl : public QThread
 {
-    Q_OBJECT;
+    Q_OBJECT
 
   public:
     WayfireImpl(QObject *parent = nullptr);

--- a/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
+++ b/panel/backends/wayland/wlroots/lxqtwmbackend_wlr.h
@@ -66,7 +66,7 @@ public:
 
     virtual bool isWindowOnScreen(QScreen *screen, WId windowId) const override;
 
-    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft);
+    virtual bool setDesktopLayout(Qt::Orientation orientation, int rows, int columns, bool rightToLeft) override;
 
     // X11 Specific
     virtual void moveApplication(WId windowId) override;

--- a/panel/backends/wayland/wlroots/workspace.hpp
+++ b/panel/backends/wayland/wlroots/workspace.hpp
@@ -65,7 +65,7 @@ class LXQt::Taskbar::WorkspaceManagerV1 : public QWaylandClientExtensionTemplate
 
 class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::ext_workspace_group_handle_v1
 {
-    Q_OBJECT;
+    Q_OBJECT
 
   public:
     WorkspaceGroupHandleV1(struct ::ext_workspace_group_handle_v1 *object);
@@ -109,7 +109,7 @@ class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::
 
 class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_workspace_handle_v1
 {
-    Q_OBJECT;
+    Q_OBJECT
 
   public:
     WorkspaceHandleV1(struct ::ext_workspace_handle_v1 *object, int index);

--- a/plugin-fancymenu/lxqtfancymenuappmodel.h
+++ b/plugin-fancymenu/lxqtfancymenuappmodel.h
@@ -51,11 +51,11 @@ public:
     // Drag support
     Qt::ItemFlags flags(const QModelIndex &idx) const override;
 
-    virtual QStringList mimeTypes() const;
-    virtual QMimeData *mimeData(const QModelIndexList &indexes) const;
+    virtual QStringList mimeTypes() const override;
+    virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
     virtual bool dropMimeData(const QMimeData *data_, Qt::DropAction action,
-                              int row, int column, const QModelIndex &p);
-    virtual Qt::DropActions supportedDragActions() const;
+                              int row, int column, const QModelIndex &p) override;
+    virtual Qt::DropActions supportedDragActions() const override;
 
     void reloadAppMap(bool end);
     void setCurrentCategory(int category);

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -98,10 +98,10 @@ public slots:
     void setSearchQuery(const QString& text);
 
 protected:
-    void hideEvent(QHideEvent *e);
-    void showEvent(QShowEvent *e);
-    void keyPressEvent(QKeyEvent *e);
-    void paintEvent(QPaintEvent *e);
+    void hideEvent(QHideEvent *e) override;
+    void showEvent(QShowEvent *e) override;
+    void keyPressEvent(QKeyEvent *e) override;
+    void paintEvent(QPaintEvent *e) override;
 
 private slots:
     void activateCategory(const QModelIndex& idx);


### PR DESCRIPTION
It doesn't silence the following (and perhaps some other) warnings:

```
…/plugin-kbindicator/src/x11/kbdlayout.cpp:41:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]
   41 | #define explicit _explicit
```