### PR TITLE
add drag-drop and double click to widget config dialog

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -579,6 +579,7 @@ void LXQtPanel::loadPlugins()
     //reemit signals
     connect(mPlugins.get(), &PanelPluginsModel::pluginAdded, this, &LXQtPanel::pluginAdded);
     connect(mPlugins.get(), &PanelPluginsModel::pluginRemoved, this, &LXQtPanel::pluginRemoved);
+    connect(mPlugins.get(), &PanelPluginsModel::itemMoved, mLayout, &LXQtPanelLayout::moveItem);
 
     const auto plugins = mPlugins->plugins();
     for (auto const & plugin : plugins)
@@ -1072,15 +1073,6 @@ bool LXQtPanel::canPlacedOn(int screenNum, LXQtPanel::Position position)
     }
 
     return false;
-}
-
-
-/************************************************
-
- ************************************************/
-void LXQtPanel::moveItem(int from, int to, bool withAnimation)
-{
-    mLayout->moveItem(from, to, withAnimation);
 }
 
 

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -484,8 +484,6 @@ private:
      * (for preventing hide)
      */
     std::unique_ptr<WindowNotifier> mStandaloneWindows;
-    
-    void moveItem(int from, int to, bool withAnimation=false);
 
     /**
      * @brief Returns the screen index of a screen on which this panel could

--- a/panel/panelpluginsmodel.cpp
+++ b/panel/panelpluginsmodel.cpp
@@ -231,7 +231,7 @@ bool PanelPluginsModel::moveRows(const QModelIndex &sourceParent, int sourceRow,
         if (auto plugin = pluginByName(sourceName)) {
             movePlugin(plugin, destName);
             int destRow = destinationChild > sourceRow ? destinationChild -1 : destinationChild;
-            mPanel->moveItem(sourceRow, destRow, true);
+            emit itemMoved(sourceRow, destRow, true);
             return true;
         }
     }

--- a/panel/panelpluginsmodel.h
+++ b/panel/panelpluginsmodel.h
@@ -154,6 +154,7 @@ public:
     bool moveRows(const QModelIndex &sourceParent, int sourceRow, int count, const QModelIndex &destinationParent, int destinationChild) override;
 
 signals:
+    void itemMoved(int from, int to, bool withAnimation);
     /*!
      * \brief pluginAdded gets emitted whenever a new Plugin is added
      * to the panel.


### PR DESCRIPTION
closes #2297 

https://github.com/user-attachments/assets/3351d283-b44d-413a-8a5a-56268a33f41a

also added double click to open the plugin's config dialog