### PR TITLE
draw plugin move indicators with QProxyStyle+QMargins instead of stylesheet

### DIFF
--- a/panel/pluginmoveprocessor.h
+++ b/panel/pluginmoveprocessor.h
@@ -64,7 +64,7 @@ private slots:
     void doStart();
     void doFinish(bool cancel);
 
-private:
+public:
     enum MarkType
     {
         TopMark,
@@ -73,6 +73,7 @@ private:
         RightMark
     };
 
+private:
     struct MousePosInfo
     {
         int index;


### PR DESCRIPTION
closes #2338 

before:

https://github.com/user-attachments/assets/ebafd674-68ed-414d-b099-34d492a302ed

after:

https://github.com/user-attachments/assets/377f00f3-57f4-42c3-8724-927fce4071e4