### PR TITLE
mainmenu: fix position (not submenus) in wayland

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -176,7 +176,8 @@ void LXQtMainMenu::showMenu()
     willShowWindow(mMenu);
     // Just using Qt`s activateWindow() won't work on some WMs like Kwin.
     // Solution is to execute menu 1ms later using timer
-    mMenu->popup(calculatePopupWindowPos(mMenu->sizeHint()).topLeft());
+    mMenu->setGeometry(calculatePopupWindowPos(mMenu->sizeHint()));
+    mMenu->show();
     if (mFilterMenu || mFilterShow)
     {
         //Note: part of the workadound for https://bugreports.qt.io/browse/QTBUG-52021


### PR DESCRIPTION
related #2171
with this PR the main `QMenu` doesn't show on top of the panel anymore, submenus are still broken.

for some reason `QMenu::exec` and `QMenu::popup` are broken, but not `QMenu::setGeometry + QMenu::show`

edit: tested in labwc

<img width="389" height="579" alt="mainmenu" src="https://github.com/user-attachments/assets/b7b41f08-d753-4956-93a1-e38a5039e9bf" />
