### PR TITLE
Removed GUI for desktop names

### DIFF
--- a/plugin-desktopswitch/desktopswitchconfiguration.cpp
+++ b/plugin-desktopswitch/desktopswitchconfiguration.cpp
@@ -51,8 +51,6 @@ DesktopSwitchConfiguration::DesktopSwitchConfiguration(PluginSettings *settings,
     connect(ui->showOnlyActiveCB, &QAbstractButton::toggled,       this, [this] (bool checked) {
         this->settings().setValue(QStringLiteral("showOnlyActive"), checked);
     });
-
-    loadDesktopsNames();
 }
 
 DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
@@ -65,38 +63,6 @@ void DesktopSwitchConfiguration::loadSettings()
     ui->rowsSB->setValue(settings().value(QStringLiteral("rows"), 1).toInt());
     ui->labelTypeCB->setCurrentIndex(settings().value(QStringLiteral("labelType"), 0).toInt());
     ui->showOnlyActiveCB->setChecked(settings().value(QStringLiteral("showOnlyActive"), false).toBool());
-}
-
-void DesktopSwitchConfiguration::loadDesktopsNames()
-{
-    LXQtPanelApplication *a = reinterpret_cast<LXQtPanelApplication*>(qApp);
-    auto wmBackend = a->getWMBackend();
-
-    int n = wmBackend->getWorkspacesCount(screen());
-    for (int i = 1; i <= n; i++)
-    {
-        auto deskName = wmBackend->getWorkspaceName(i, screen() ? screen()->name() : QString());
-        if (deskName.isEmpty())
-            deskName = tr("Desktop %1").arg(i);
-        QLineEdit *edit = new QLineEdit(deskName, this);
-        ((QFormLayout *) ui->namesGroupBox->layout())->addRow(tr("Desktop %1:").arg(i), edit);
-
-        //TODO: on Wayland we cannot set desktop names in a standart way
-        // On KWin we could use DBus org.kde.KWin as done by kcm_kwin_virtualdesktops
-        if(qGuiApp->nativeInterface<QNativeInterface::QX11Application>())
-        {
-            // C++11 rocks!
-            QTimer *timer = new QTimer(this);
-            timer->setInterval(400);
-            timer->setSingleShot(true);
-            connect(timer, &QTimer::timeout,       this, [=] { KX11Extras::setDesktopName(i, edit->text()); });
-            connect(edit,  &QLineEdit::textEdited, this, [=] { timer->start(); });
-        }
-        else
-        {
-            edit->setReadOnly(true);
-        }
-    }
 }
 
 void DesktopSwitchConfiguration::rowsChanged(int value)

--- a/plugin-desktopswitch/desktopswitchconfiguration.h
+++ b/plugin-desktopswitch/desktopswitchconfiguration.h
@@ -56,7 +56,6 @@ private slots:
        Saves settings in conf file.
     */
     void loadSettings();
-    void loadDesktopsNames();
     void rowsChanged(int value);
     void labelTypeChanged(int type);
 };

--- a/plugin-desktopswitch/desktopswitchconfiguration.ui
+++ b/plugin-desktopswitch/desktopswitchconfiguration.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>253</width>
+    <width>287</width>
     <height>235</height>
    </rect>
   </property>
@@ -80,20 +80,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="namesGroupBox">
-     <property name="title">
-      <string>Desktop names</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout"/>
-    </widget>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-panel/issues/2271

I tested again under openbox, the names set here are used only during the session (also when reloading the panel). I don't think we could and should make that work with the most commons WMs or Compositors.