### PR TITLE
Set fallback icon for Favorites

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuappmap.cpp
+++ b/plugin-fancymenu/lxqtfancymenuappmap.cpp
@@ -48,7 +48,8 @@ LXQtFancyMenuAppMap::LXQtFancyMenuAppMap()
     //Add Favorites category
     Category favorites;
     favorites.menuTitle = LXQtFancyMenuAppMapStrings::tr("Favorites");
-    favorites.icon = XdgIcon::fromTheme(QLatin1String("bookmarks"));
+    QStringList favoritesIcons = { QLatin1String("bookmarks"), QLatin1String("emblem-favorite") };
+    favorites.icon = XdgIcon::fromTheme(favoritesIcons);
     favorites.type = LXQtFancyMenuItemType::CategoryItem;
     mCategories.append(favorites);
 

--- a/plugin-fancymenu/lxqtfancymenuappmap.cpp
+++ b/plugin-fancymenu/lxqtfancymenuappmap.cpp
@@ -48,8 +48,7 @@ LXQtFancyMenuAppMap::LXQtFancyMenuAppMap()
     //Add Favorites category
     Category favorites;
     favorites.menuTitle = LXQtFancyMenuAppMapStrings::tr("Favorites");
-    QStringList favoritesIcons = { QLatin1String("bookmarks"), QLatin1String("emblem-favorite") };
-    favorites.icon = XdgIcon::fromTheme(favoritesIcons);
+    favorites.icon = XdgIcon::fromTheme(QStringLiteral("bookmarks"), QStringLiteral("user-bookmarks"));
     favorites.type = LXQtFancyMenuItemType::CategoryItem;
     mCategories.append(favorites);
 


### PR DESCRIPTION
To facilitate Qt and GTK icon name schemes.

~KDE icon sets have `bookmarks`; GTK has no `places/` equivalent but instead `emblem-favorite`. For "gnome" and "mate" it is supported up to 48x48. The main concern is that it is an _emblem_ icon.~