### PR TITLE
implement invert taskbar layout

### DIFF
--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -127,6 +127,8 @@ private:
 private:
     QMap<WId, LXQtTaskGroup*> mKnownWindows; //!< Ids of known windows (mapping to buttons/groups)
     LXQt::GridLayout *mLayout;
+    QWidget *mContentWidget; // container for mLayout so we can push it to the end
+    QBoxLayout *mOuterLayout;
     QList<GlobalKeyShortcut::Action*> mKeys;
     QSignalMapper *mSignalMapper;
 

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -97,6 +97,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     connect(ui->wheelEventsActionCB, &QComboBox::activated, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->wheelDeltaThresholdSB, &QAbstractSpinBox::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
     connect(ui->excludeLE, &QLineEdit::editingFinished, this, &LXQtTaskbarConfiguration::saveSettings);
+    connect(ui->alignToEndCB, &QAbstractButton::clicked, this, &LXQtTaskbarConfiguration::saveSettings);
 }
 
 LXQtTaskbarConfiguration::~LXQtTaskbarConfiguration()
@@ -107,6 +108,7 @@ LXQtTaskbarConfiguration::~LXQtTaskbarConfiguration()
 void LXQtTaskbarConfiguration::loadSettings()
 {
     const bool showOnlyOneDesktopTasks = settings().value(QStringLiteral("showOnlyOneDesktopTasks"), false).toBool();
+	const bool alignToEnd = settings().value(QStringLiteral("alignToEnd"), false).toBool();
     ui->limitByDesktopCB->setChecked(showOnlyOneDesktopTasks);
     ui->showDesktopNumCB->setCurrentIndex(ui->showDesktopNumCB->findData(settings().value(QStringLiteral("showDesktopNum"), 0).toInt()));
     ui->showDesktopNumCB->setEnabled(showOnlyOneDesktopTasks);
@@ -126,6 +128,7 @@ void LXQtTaskbarConfiguration::loadSettings()
     ui->wheelEventsActionCB->setCurrentIndex(ui->wheelEventsActionCB->findData(settings().value(QStringLiteral("wheelEventsAction"), 1).toInt()));
     ui->wheelDeltaThresholdSB->setValue(settings().value(QStringLiteral("wheelDeltaThreshold"), 300).toInt());
     ui->excludeLE->setText(settings().value(QStringLiteral("excludedList")).toString());
+    ui->alignToEndCB->setChecked(alignToEnd);
 }
 
 void LXQtTaskbarConfiguration::saveSettings()
@@ -147,4 +150,5 @@ void LXQtTaskbarConfiguration::saveSettings()
     settings().setValue(QStringLiteral("wheelEventsAction"), ui->wheelEventsActionCB->itemData(ui->wheelEventsActionCB->currentIndex()));
     settings().setValue(QStringLiteral("wheelDeltaThreshold"), ui->wheelDeltaThresholdSB->value());
     settings().setValue(QStringLiteral("excludedList"), ui->excludeLE->text());
+    settings().setValue(QStringLiteral("alignToEnd"), ui->alignToEndCB->isChecked());
 }

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>401</width>
-    <height>528</height>
+    <width>410</width>
+    <height>786</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -170,7 +170,7 @@
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
       </property>
       <item row="0" column="0">
        <widget class="QLabel" name="buttonStyleL">
@@ -241,14 +241,14 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="iconByClassCB">
         <property name="text">
          <string>Use icons by WindowClass, if available</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="excludeL">
         <property name="toolTip">
          <string>Comma separated list of window classes</string>
@@ -258,10 +258,20 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="7" column="1">
        <widget class="QLineEdit" name="excludeLE">
         <property name="toolTip">
          <string>Comma separated list of window classes</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="alignToEndCB">
+        <property name="toolTip">
+         <string>If enabled, the taskbar will align to the panel's end instead of its start</string>
+        </property>
+        <property name="text">
+         <string>Invert taskbar align</string>
         </property>
        </widget>
       </item>
@@ -271,7 +281,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -284,10 +294,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Reset</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
some user (specially for vertical taskbar) prefer taskbar align to be Right to left or Bottom to top, this PR tries to do that by adding a stretch at the start of the taskbar, so elements are pushed to the end.

Since i think there is not something like "LXQt::GridLayout::BottomToTop", this is the easiest approach