### PR TITLE
Change tooltip in Status Notifier if an app sets title instead of tooltip

### DIFF
--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -69,6 +69,7 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     connect(interface, &SniAsync::NewOverlayIcon, this, &StatusNotifierButton::newOverlayIcon);
     connect(interface, &SniAsync::NewAttentionIcon, this, &StatusNotifierButton::newAttentionIcon);
     connect(interface, &SniAsync::NewToolTip, this, &StatusNotifierButton::newToolTip);
+    connect(interface, &SniAsync::NewTitle, this, &StatusNotifierButton::newToolTip);
     connect(interface, &SniAsync::NewStatus, this, &StatusNotifierButton::newStatus);
 
     // get the title only at the start because that title is used


### PR DESCRIPTION
Some GTK apps can't set the tooltip but may change the title.

Closes https://github.com/lxqt/lxqt-panel/issues/2372