### PR TITLE
Use `QPointer` to store `WorkspaceHandleV1`

### DIFF
--- a/panel/backends/wayland/wlroots/workspace.cpp
+++ b/panel/backends/wayland/wlroots/workspace.cpp
@@ -6,7 +6,7 @@
 #include <private/qwaylandscreen_p.h>
 
 /** ext_workspace_handle_v1 <-> WorkspaceHandleV1 map */
-QMap<struct ::ext_workspace_handle_v1*, LXQt::Taskbar::WorkspaceHandleV1*> workspaceMap;
+QMap<struct ::ext_workspace_handle_v1*, QPointer<LXQt::Taskbar::WorkspaceHandleV1>> workspaceMap;
 QList<LXQt::Taskbar::WorkspaceGroupHandleV1*> workspaceGroups;
 
 /**
@@ -66,9 +66,10 @@ int LXQt::Taskbar::WorkspaceManagerV1::currentWorkspaceIndex(QScreen *screen)
                 if (wg->outputs().contains(output))
                 {
                     const auto workspaces = wg->workspaces();
-                    for (WorkspaceHandleV1 *ws : workspaces)
+                    for (const auto& ws : workspaces)
                     {
-                        map[ws->coordinates()] = ws;
+                        if (ws)
+                            map[ws->coordinates()] = ws;
                     }
                     break;
                 }
@@ -107,9 +108,10 @@ QString LXQt::Taskbar::WorkspaceManagerV1::workspaceName(int idx, const QString 
                     if (wg->outputs().contains(output))
                     {
                         const auto workspaces = wg->workspaces();
-                        for (WorkspaceHandleV1 *ws : workspaces)
+                        for (const auto& ws : workspaces)
                         {
-                            map[ws->coordinates()] = ws;
+                            if (ws)
+                                map[ws->coordinates()] = ws;
                         }
                         break;
                     }
@@ -148,9 +150,10 @@ void LXQt::Taskbar::WorkspaceManagerV1::setCurrentWorkspaceIndex(int idx, QScree
                 if (wg->outputs().contains(output))
                 {
                     const auto workspaces = wg->workspaces();
-                    for (WorkspaceHandleV1 *ws : workspaces)
+                    for (const auto& ws : workspaces)
                     {
-                        map[ws->coordinates()] = ws;
+                        if (ws)
+                            map[ws->coordinates()] = ws;
                     }
                     break;
                 }

--- a/panel/backends/wayland/wlroots/workspace.hpp
+++ b/panel/backends/wayland/wlroots/workspace.hpp
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QList>
 #include <QScreen>
+#include <QPointer>
 
 #include <string>
 #include "wayland-ext-workspace-v1-client-protocol.h"
@@ -73,7 +74,7 @@ class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::
         return m_outputs;
     }
 
-    QList<WorkspaceHandleV1*> workspaces() const {
+    QList<QPointer<WorkspaceHandleV1>> workspaces() const {
         return m_workspaces;
     }
 
@@ -108,7 +109,7 @@ class LXQt::Taskbar::WorkspaceGroupHandleV1 : public QObject, public QtWayland::
     uint32_t m_supported_capabilities;
 
     /** Track workspaces that are a part of this workspace group */
-    QList<WorkspaceHandleV1*> m_workspaces;
+    QList<QPointer<WorkspaceHandleV1>> m_workspaces;
 };
 
 class LXQt::Taskbar::WorkspaceHandleV1 : public QObject, public QtWayland::ext_workspace_handle_v1


### PR DESCRIPTION
Because otherwise it may become a dangling pointer, especially with bad compositor codes.

Closes https://github.com/lxqt/lxqt-panel/issues/2376