### PR TITLE
Fix plugin numbering when adding plugins

### DIFF
--- a/panel/panelpluginsmodel.cpp
+++ b/panel/panelpluginsmodel.cpp
@@ -338,7 +338,8 @@ QPointer<Plugin> PanelPluginsModel::loadPlugin(LXQtPanel * panel, LXQt::PluginIn
 
 QString PanelPluginsModel::findNewPluginSettingsGroup(const QString &pluginType) const
 {
-    QStringList groups = mPanelSettings->childGroups();
+    QSettings userSettings(mPanelSettings->fileName(), QSettings::IniFormat);
+    QStringList groups = userSettings.childGroups();
     groups.sort();
 
     // Generate new section name


### PR DESCRIPTION
Like https://github.com/lxqt/lxqt-panel/pull/2201 but works on any config file.

`mPanelSettings->childGroups()` inherits from `/etc/xdg/lxqt/panel.conf` causing wrong numbering for some plugins. Re-initializing the `QSettings` from filename fixes that issue.