### PR TITLE
Improve fancy menu search results

### DIFF
--- a/plugin-fancymenu/lxqtfancymenuappmap.cpp
+++ b/plugin-fancymenu/lxqtfancymenuappmap.cpp
@@ -248,11 +248,11 @@ QList<const LXQtFancyMenuAppMap::AppItem *> LXQtFancyMenuAppMap::getMatchingApps
 
     for(const AppItem *app : std::as_const(mAppSortedByName))
     {
-        // Check name first
+        // Check name
         if (app->title.startsWith(query, Qt::CaseInsensitive))
         {
             startsWithTitle.append(app);
-            continue; // Skip other checks
+            continue;
         }
 
         bool found = false;


### PR DESCRIPTION
Shows matches by first characters on top now and stops searching comments, ~keywords~ and exec when there is a match in name.
Fixes https://github.com/lxqt/lxqt/issues/2811

