### PR TITLE
Use begin/end filter

### DIFF
--- a/plugin-mainmenu/actionview.cpp
+++ b/plugin-mainmenu/actionview.cpp
@@ -210,7 +210,7 @@ void ActionView::fillActions(QMenu * menu)
 
 void ActionView::setFilter(QString const & filter)
 {
-    mProxy->setfilerString(filter);
+    mProxy->setFilterString(filter);
     const int count = mProxy->rowCount();
     if (0 < count)
     {

--- a/plugin-mainmenu/actionview.h
+++ b/plugin-mainmenu/actionview.h
@@ -42,9 +42,14 @@ public:
     explicit FilterProxyModel(QObject* parent = nullptr);
     virtual ~FilterProxyModel();
 
-    void setfilerString(const QString &str) {
+    void setFilterString(const QString& str)
+    {
+        if (filterStr_ == str)
+            return;
+
+        beginFilterChange();
         filterStr_ = str;
-        invalidateFilter();
+        endFilterChange();
     }
 
 protected:


### PR DESCRIPTION
Warning:
```
warning: ‘void QSortFilterProxyModel::invalidateFilter()’ is deprecated: Use begin/endFilterChange() instead [-Wdeprecated-declarations]
   47 |         invalidateFilter();

```
Also fixed a typo I guess.

There is another warning left which is above my skills:

```
 warning: ignoring return value of ‘virtual bool QFile::open(QIODeviceBase::OpenMode)’, declared with attribute ‘nodiscard’ [-Wunused-result]
   73 |     file.open(QIODevice::ReadOnly);
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```