### PR TITLE
Implement multi sink volume plugin

### DIFF
--- a/plugin-volume/audioengine.cpp
+++ b/plugin-volume/audioengine.cpp
@@ -53,6 +53,11 @@ int AudioEngine::volumeBounded(int volume, AudioDevice* device) const
     return std::round((bounded / maximum) * 100);
 }
 
+bool AudioEngine::setDefaultSink(AudioDevice */*device*/)
+{
+    return false;
+}
+
 
 void AudioEngine::mute(AudioDevice *device)
 {

--- a/plugin-volume/audioengine.h
+++ b/plugin-volume/audioengine.h
@@ -47,6 +47,8 @@ public:
     virtual int volumeBounded(int volume, AudioDevice *device) const;
     virtual const QString backendName() const = 0;
 
+    virtual bool setDefaultSink(AudioDevice *device);
+
 public slots:
     virtual void commitDeviceVolume(AudioDevice *device) = 0;
     virtual void setMute(AudioDevice *device, bool state) = 0;

--- a/plugin-volume/lxqtvolume.h
+++ b/plugin-volume/lxqtvolume.h
@@ -66,8 +66,10 @@ protected slots:
     void handleShortcutVolumeUp();
     void handleShortcutVolumeDown();
     void handleShortcutVolumeMute();
+    void handleDefaultSinkRequested(AudioDevice *device);
     void shortcutRegistered();
     void showNotification(bool forceShow) const;
+    void updateTrayIconFromDefaultSink();
 
 private:
     AudioEngine *m_engine;

--- a/plugin-volume/pulseaudioengine.h
+++ b/plugin-volume/pulseaudioengine.h
@@ -52,9 +52,11 @@ public:
     PulseAudioEngine(QObject *parent = nullptr);
     ~PulseAudioEngine();
 
-    virtual const QString backendName() const { return QLatin1String("PulseAudio"); }
+    const QString backendName() const override { return QLatin1String("PulseAudio"); }
 
-    int volumeMax(AudioDevice */*device*/) const { return m_maximumVolume; }
+    int volumeMax(AudioDevice */*device*/) const override { return m_maximumVolume; }
+
+    bool setDefaultSink(AudioDevice *device) override;
 
     void requestSinkInfoUpdate(uint32_t idx);
     void removeSink(uint32_t idx);
@@ -65,11 +67,11 @@ public:
     pa_threaded_mainloop *mainloop() const { return m_mainLoop; }
 
 public slots:
-    void commitDeviceVolume(AudioDevice *device);
+    void commitDeviceVolume(AudioDevice *device) override;
     void retrieveSinkInfo(uint32_t idx);
-    void setMute(AudioDevice *device, bool state);
+    void setMute(AudioDevice *device, bool state) override;
     void setContextState(pa_context_state_t state);
-    void setIgnoreMaxVolume(bool ignore);
+    void setIgnoreMaxVolume(bool ignore) override;
 
 signals:
     void sinkInfoChanged(uint32_t idx);

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -127,9 +127,18 @@ void VolumeButton::showVolumeSlider()
     m_volumePopup->updateGeometry();
     m_volumePopup->adjustSize();
     QRect pos = mPlugin->calculatePopupWindowPos(m_volumePopup->size());
-    // Center the popup horizontally on the volume button
     const QPoint buttonCenter = mapToGlobal(rect().center());
-    pos.moveLeft(buttonCenter.x() - pos.width() / 2);
+    const auto panelPosition = mPlugin->panel()->position();
+    if (panelPosition == ILXQtPanel::PositionLeft || panelPosition == ILXQtPanel::PositionRight)
+    {
+        // Vertical panel: popup is already beside the panel; center it vertically with the volume icon.
+        pos.moveTop(buttonCenter.y() - pos.height() / 2);
+    }
+    else
+    {
+        // Horizontal panel (top/bottom): center the popup horizontally on the volume button.
+        pos.moveLeft(buttonCenter.x() - pos.width() / 2);
+    }
     mPlugin->willShowWindow(m_volumePopup);
     m_volumePopup->openAt(pos.topLeft(), Qt::TopLeftCorner);
     m_volumePopup->activateWindow();

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -127,6 +127,9 @@ void VolumeButton::showVolumeSlider()
     m_volumePopup->updateGeometry();
     m_volumePopup->adjustSize();
     QRect pos = mPlugin->calculatePopupWindowPos(m_volumePopup->size());
+    // Center the popup horizontally on the volume button
+    const QPoint buttonCenter = mapToGlobal(rect().center());
+    pos.moveLeft(buttonCenter.x() - pos.width() / 2);
     mPlugin->willShowWindow(m_volumePopup);
     m_volumePopup->openAt(pos.topLeft(), Qt::TopLeftCorner);
     m_volumePopup->activateWindow();

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -111,6 +111,7 @@ void VolumeButton::wheelEvent(QWheelEvent *event)
 {
     m_volumePopup->handleWheelEvent(event);
     QToolTip::showText(event->globalPosition().toPoint(), toolTip(), this);
+    event->accept();
 }
 
 void VolumeButton::mouseReleaseEvent(QMouseEvent *event)

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -110,6 +110,7 @@ void VolumeButton::mouseMoveEvent(QMouseEvent *event)
 void VolumeButton::wheelEvent(QWheelEvent *event)
 {
     m_volumePopup->handleWheelEvent(event);
+    QToolTip::showText(event->globalPosition().toPoint(), toolTip(), this);
 }
 
 void VolumeButton::mouseReleaseEvent(QMouseEvent *event)

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -143,19 +143,14 @@ void VolumeButton::showVolumeSlider()
     m_popupHideTimer.stop();
     m_volumePopup->updateGeometry();
     m_volumePopup->adjustSize();
-    QRect pos = mPlugin->calculatePopupWindowPos(m_volumePopup->size());
+
     const QPoint buttonCenter = mapToGlobal(rect().center());
+    QRect pos = mPlugin->panel()->calculatePopupWindowPos(buttonCenter, m_volumePopup->size());
     const auto panelPosition = mPlugin->panel()->position();
     if (panelPosition == ILXQtPanel::PositionLeft || panelPosition == ILXQtPanel::PositionRight)
-    {
-        // Vertical panel: popup is already beside the panel; center it vertically with the volume icon.
         pos.moveTop(buttonCenter.y() - pos.height() / 2);
-    }
     else
-    {
-        // Horizontal panel (top/bottom): center the popup horizontally on the volume button.
         pos.moveLeft(buttonCenter.x() - pos.width() / 2);
-    }
 
     // Clamp to available screen geometry so the popup is never cut off (e.g. icon at panel edge).
     QScreen *screen = QGuiApplication::screenAt(buttonCenter);

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -30,6 +30,7 @@
 #include "volumepopup.h"
 #include "audiodevice.h"
 
+#include <QGuiApplication>
 #include <QSlider>
 #include <QMouseEvent>
 #include <QProcess>
@@ -139,6 +140,19 @@ void VolumeButton::showVolumeSlider()
         // Horizontal panel (top/bottom): center the popup horizontally on the volume button.
         pos.moveLeft(buttonCenter.x() - pos.width() / 2);
     }
+
+    // Clamp to available screen geometry so the popup is never cut off (e.g. icon at panel edge).
+    QScreen *screen = QGuiApplication::screenAt(buttonCenter);
+    const QRect geom = screen ? screen->availableGeometry() : QGuiApplication::primaryScreen()->availableGeometry();
+    if (pos.left() < geom.left())
+        pos.moveLeft(geom.left());
+    if (pos.right() > geom.right())
+        pos.moveRight(geom.right());
+    if (pos.top() < geom.top())
+        pos.moveTop(geom.top());
+    if (pos.bottom() > geom.bottom())
+        pos.moveBottom(geom.bottom());
+
     mPlugin->willShowWindow(m_volumePopup);
     m_volumePopup->openAt(pos.topLeft(), Qt::TopLeftCorner);
     m_volumePopup->activateWindow();

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -63,9 +63,20 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
 
     connect(m_volumePopup, &VolumePopup::launchMixer,      this, &VolumeButton::handleMixerLaunch);
     connect(m_volumePopup, &VolumePopup::stockIconChanged, this, &VolumeButton::handleStockIconChanged);
+    connect(m_volumePopup, &VolumePopup::popupHidden,      this, [this]() {
+        setDown(false);
+        suppressTooltipTemporarily();
+    });
 }
 
 VolumeButton::~VolumeButton() = default;
+
+void VolumeButton::suppressTooltipTemporarily()
+{
+    QToolTip::hideText();
+    m_suppressTooltip = true;
+    QTimer::singleShot(500, this, [this]() { m_suppressTooltip = false; });
+}
 
 void VolumeButton::setMuteOnMiddleClick(bool state)
 {
@@ -80,6 +91,8 @@ void VolumeButton::setMixerCommand(const QString &command)
 
 void VolumeButton::enterEvent(QEnterEvent *event)
 {
+    if (m_volumePopup->isVisible() || m_suppressTooltip)
+        return;
     // show tooltip immediately on entering widget
     QToolTip::showText(event->globalPosition().toPoint(), toolTip(), this);
 }
@@ -87,6 +100,8 @@ void VolumeButton::enterEvent(QEnterEvent *event)
 void VolumeButton::mouseMoveEvent(QMouseEvent *event)
 {
     QToolButton::mouseMoveEvent(event);
+    if (m_volumePopup->isVisible() || m_suppressTooltip)
+        return;
     // show tooltip immediately on moving the mouse
     if (!QToolTip::isVisible()) // prevent sliding of tooltip
         QToolTip::showText(event->globalPosition().toPoint(), toolTip(), this);
@@ -124,6 +139,7 @@ void VolumeButton::showVolumeSlider()
     if (m_volumePopup->isVisible())
         return;
 
+    QToolTip::hideText();
     m_popupHideTimer.stop();
     m_volumePopup->updateGeometry();
     m_volumePopup->adjustSize();
@@ -156,6 +172,7 @@ void VolumeButton::showVolumeSlider()
     mPlugin->willShowWindow(m_volumePopup);
     m_volumePopup->openAt(pos.topLeft(), Qt::TopLeftCorner);
     m_volumePopup->activateWindow();
+    setDown(true);
 }
 
 void VolumeButton::hideVolumeSlider()
@@ -163,6 +180,8 @@ void VolumeButton::hideVolumeSlider()
     // qDebug() << "hideVolumeSlider";
     m_popupHideTimer.stop();
     m_volumePopup->hide();
+    setDown(false);
+    suppressTooltipTemporarily();
 }
 
 void VolumeButton::handleMixerLaunch()

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -62,10 +62,13 @@ private slots:
     void handleStockIconChanged(const QString &iconName);
 
 private:
+    void suppressTooltipTemporarily();
+
     VolumePopup *m_volumePopup;
     ILXQtPanelPlugin *mPlugin;
     QTimer m_popupHideTimer;
     bool m_muteOnMiddleClick;
+    bool m_suppressTooltip = false;
     QString m_mixerCommand;
     QStringList m_mixerParams;
 };

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -408,14 +408,12 @@ SinkRow VolumePopup::makeSinkRow(AudioDevice *device)
     row.muteButton->setChecked(device->mute());
     row.muteButton->setIcon(QIcon::fromTheme(QLatin1String("audio-volume-muted-panel")));
     row.muteButton->setToolTip(tr("Mute"));
-    row.muteButton->setFixedSize(28, 28);
     row.muteButton->setAutoDefault(false);
     rowLayout->addWidget(row.muteButton);
 
     row.defaultButton = new QPushButton(row.rowWidget);
     row.defaultButton->setCheckable(true);
     row.defaultButton->setToolTip(tr("Set as default output"));
-    row.defaultButton->setFixedSize(28, 28);
     row.defaultButton->setAutoDefault(false);
     rowLayout->addWidget(row.defaultButton);
 

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -401,6 +401,8 @@ SinkRow VolumePopup::makeSinkRow(AudioDevice *device)
     row.slider->setSingleStep(m_sliderStep);
     row.slider->setPageStep(m_sliderStep * 10);
     row.slider->setMinimumWidth(120);
+    row.slider->setTickPosition(QSlider::TicksBelow);
+    row.slider->setTickInterval(10);
     rowLayout->addWidget(row.slider, 1);
 
     row.muteButton = new QPushButton(row.rowWidget);

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -44,6 +44,36 @@
 #include <QWheelEvent>
 #include <QScreen>
 
+#include <cmath>
+
+namespace {
+
+// Touchpads often use pixelDelta() and/or small angle steps; angleDelta()/120 truncates to 0.
+int volumeScrollStep(const QWheelEvent *event, int singleStep)
+{
+    if (singleStep <= 0)
+        singleStep = 3;
+
+    const QPoint pixel = event->pixelDelta();
+    if (!pixel.isNull() && pixel.y() != 0)
+    {
+        const int py = pixel.y();
+        int step = (py * singleStep) / 32;
+        if (step == 0 && qAbs(py) >= 3)
+            step = (py > 0) ? 1 : -1;
+        return step;
+    }
+
+    const int angleY = event->angleDelta().y();
+    if (angleY == 0)
+        return 0;
+
+    return static_cast<int>(std::lround(static_cast<double>(angleY) * static_cast<double>(singleStep)
+                                        / static_cast<double>(QWheelEvent::DefaultDeltasPerStep)));
+}
+
+} // namespace
+
 VolumePopup::VolumePopup(QWidget* parent):
     QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::Popup | Qt::X11BypassWindowManagerHint),
     m_pos(0, 0),
@@ -260,23 +290,26 @@ void VolumePopup::handleWheelEvent(QWheelEvent *event, QSlider *sliderFromWheel)
         {
             if (row.slider == sliderFromWheel && row.device)
             {
-                const int step = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * sliderFromWheel->singleStep();
-                row.device->setVolume(row.device->volume() + step);
+                const int step = volumeScrollStep(event, sliderFromWheel->singleStep());
+                if (step != 0)
+                    row.device->setVolume(row.device->volume() + step);
                 return;
             }
         }
     }
     if (m_defaultSink)
     {
-        const int step = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * m_sliderStep;
-        m_defaultSink->setVolume(m_defaultSink->volume() + step);
+        const int step = volumeScrollStep(event, m_sliderStep);
+        if (step != 0)
+            m_defaultSink->setVolume(m_defaultSink->volume() + step);
         return;
     }
     if (m_sinkRows.size() == 1 && m_sinkRows.at(0).slider && m_sinkRows.at(0).device)
     {
         QSlider *slider = m_sinkRows.at(0).slider;
-        const int step = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * slider->singleStep();
-        m_sinkRows.at(0).device->setVolume(slider->sliderPosition() + step);
+        const int step = volumeScrollStep(event, slider->singleStep());
+        if (step != 0)
+            m_sinkRows.at(0).device->setVolume(slider->sliderPosition() + step);
     }
 }
 

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -114,7 +114,7 @@ bool VolumePopup::eventFilter(QObject * watched, QEvent * event)
             {
                 if (row.slider && watched == row.slider)
                 {
-                    handleWheelEvent(wheelEvent);
+                    handleWheelEvent(wheelEvent, row.slider);
                     return true;
                 }
             }
@@ -252,8 +252,20 @@ void VolumePopup::openAt(QPoint pos, Qt::Corner anchor)
     show();
 }
 
-void VolumePopup::handleWheelEvent(QWheelEvent *event)
+void VolumePopup::handleWheelEvent(QWheelEvent *event, QSlider *sliderFromWheel)
 {
+    if (sliderFromWheel)
+    {
+        for (const SinkRow &row : std::as_const(m_sinkRows))
+        {
+            if (row.slider == sliderFromWheel && row.device)
+            {
+                const int step = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * sliderFromWheel->singleStep();
+                row.device->setVolume(row.device->volume() + step);
+                return;
+            }
+        }
+    }
     if (m_defaultSink)
     {
         const int step = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * m_sliderStep;

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -87,6 +87,12 @@ VolumePopup::VolumePopup(QWidget* parent):
     connect(m_mixerButton, &QPushButton::released, this, &VolumePopup::launchMixer);
 }
 
+void VolumePopup::hideEvent(QHideEvent *event)
+{
+    QDialog::hideEvent(event);
+    emit popupHidden();
+}
+
 bool VolumePopup::event(QEvent *event)
 {
     if(event->type() == QEvent::WindowDeactivate)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -443,9 +443,13 @@ SinkRow VolumePopup::makeSinkRow(AudioDevice *device)
 
 void VolumePopup::updateDefaultButtons()
 {
+    const bool showDefaultButton = m_sinkRows.count() > 1;
     for (SinkRow &row : m_sinkRows)
     {
         if (!row.defaultButton || !row.device)
+            continue;
+        row.defaultButton->setVisible(showDefaultButton);
+        if (!showDefaultButton)
             continue;
         const bool isDefault = (row.device == m_defaultSink);
         row.defaultButton->setChecked(isDefault);

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -30,6 +30,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QPointer>
 
 class QSlider;
 class QPushButton;
@@ -98,7 +99,7 @@ private:
     Qt::Corner m_anchor;
     QList<SinkRow> m_sinkRows;
     QList<AudioDevice*> m_sinks;
-    AudioDevice *m_defaultSink;
+    QPointer<AudioDevice> m_defaultSink;
     int m_sliderStep;
 };
 

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -29,10 +29,21 @@
 #define VOLUMEPOPUP_H
 
 #include <QDialog>
+#include <QList>
 
 class QSlider;
 class QPushButton;
+class QScrollArea;
+class QWheelEvent;
 class AudioDevice;
+
+struct SinkRow {
+    AudioDevice *device = nullptr;
+    QWidget *rowWidget = nullptr;
+    QSlider *slider = nullptr;
+    QPushButton *muteButton = nullptr;
+    QPushButton *defaultButton = nullptr;
+};
 
 class VolumePopup : public QDialog
 {
@@ -43,20 +54,20 @@ public:
     void openAt(QPoint pos, Qt::Corner anchor);
     void handleWheelEvent(QWheelEvent *event);
 
-    QSlider *volumeSlider() const { return m_volumeSlider; }
-
-    AudioDevice *device() const { return m_device; }
+    AudioDevice *device() const { return m_defaultSink; }
     void setDevice(AudioDevice *device);
+    void setSinks(const QList<AudioDevice*> &sinks, AudioDevice *defaultSink);
+    void setDefaultSink(AudioDevice *defaultSink);
     void setSliderStep(int step);
 
 signals:
     void mouseEntered();
     void mouseLeft();
 
-    // void volumeChanged(int value);
     void deviceChanged();
     void launchMixer();
     void stockIconChanged(const QString &iconName);
+    void defaultSinkRequested(AudioDevice *device);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -68,19 +79,27 @@ protected:
 private slots:
     void handleSliderValueChanged(int value);
     void handleMuteToggleClicked();
-    void handleDeviceVolumeChanged(int volume);
-    void handleDeviceMuteChanged(bool mute);
+    void handleSetDefaultClicked();
+    void handleDeviceVolumeChanged(AudioDevice *device, int volume);
+    void handleDeviceMuteChanged(AudioDevice *device, bool mute);
+    void onDefaultSinkVolumeOrMuteChanged();
 
 private:
     void realign();
     void updateStockIcon();
+    void rebuildSinkRows();
+    SinkRow makeSinkRow(AudioDevice *device);
+    void updateDefaultButtons();
 
-    QSlider *m_volumeSlider;
+    QScrollArea *m_sinkScrollArea;
+    QWidget *m_sinksContainer;
     QPushButton *m_mixerButton;
-    QPushButton *m_muteToggleButton;
     QPoint m_pos;
     Qt::Corner m_anchor;
-    AudioDevice *m_device;
+    QList<SinkRow> m_sinkRows;
+    QList<AudioDevice*> m_sinks;
+    AudioDevice *m_defaultSink;
+    int m_sliderStep;
 };
 
 #endif // VOLUMEPOPUP_H

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -39,7 +39,7 @@ class QWheelEvent;
 class AudioDevice;
 
 struct SinkRow {
-    AudioDevice *device = nullptr;
+    QPointer<AudioDevice> device;
     QWidget *rowWidget = nullptr;
     QSlider *slider = nullptr;
     QPushButton *muteButton = nullptr;

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -53,7 +53,7 @@ public:
     VolumePopup(QWidget* parent = nullptr);
 
     void openAt(QPoint pos, Qt::Corner anchor);
-    void handleWheelEvent(QWheelEvent *event);
+    void handleWheelEvent(QWheelEvent *event, QSlider *slider = nullptr);
 
     AudioDevice *device() const { return m_defaultSink; }
     void setDevice(AudioDevice *device);

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -69,8 +69,10 @@ signals:
     void launchMixer();
     void stockIconChanged(const QString &iconName);
     void defaultSinkRequested(AudioDevice *device);
+    void popupHidden();
 
 protected:
+    void hideEvent(QHideEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void enterEvent(QEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-panel/issues/2402. Basically implements the ability to click on the volume plugin and get all the available sinks so it's easy to choose which one is the default one and control the volume of each sink individually.