### PR TITLE
[volume] fix crash when device disconnects

### DIFF
--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -29,6 +29,7 @@
 #define VOLUMEPOPUP_H
 
 #include <QDialog>
+#include <QPointer>
 
 class QSlider;
 class QPushButton;
@@ -80,7 +81,7 @@ private:
     QPushButton *m_muteToggleButton;
     QPoint m_pos;
     Qt::Corner m_anchor;
-    AudioDevice *m_device;
+    QPointer<AudioDevice> m_device;
 };
 
 #endif // VOLUMEPOPUP_H


### PR DESCRIPTION
Recently my panel started crashing (and restarting) whenever i disconnected my bluetooth earphones, not sure what changed and when, but journalctl indicated the cause was the `disconnect` call [here](https://github.com/lxqt/lxqt-panel/blob/96971e51e45a8c1064f761d4828ee803e7402d46/plugin-volume/volumepopup.cpp#L210), changing `m_device` to a `QPointer` fixes it.