### PR TITLE
Fix crashes when PulseAudio sink information changes

### DIFF
--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -33,6 +33,7 @@
 #include <QMetaType>
 #include <QtDebug>
 
+#include <cmath>
 #include <algorithm>
 
 //#define PULSEAUDIO_ENGINE_DEBUG

--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -33,35 +33,42 @@
 #include <QMetaType>
 #include <QtDebug>
 
-#include <cmath>
 #include <algorithm>
 
 //#define PULSEAUDIO_ENGINE_DEBUG
 
-static void sinkInfoCallback(pa_context *context, const pa_sink_info *info, int isLast, void *userdata)
+// PA_VOLUME_UI_MAX is only supported since pulseaudio 0.9.23
+#ifndef PA_VOLUME_UI_MAX
+#define PA_VOLUME_UI_MAX (pa_sw_volume_from_dB(+11.0))
+#endif
+
+PulseAudioEngine::PulseAudioDevice::PulseAudioDevice(const pa_sink_info &pa_info)
+    : name{QString::fromUtf8(pa_info.name)}
+    , description{QString::fromUtf8(pa_info.description)}
+    , index{pa_info.index}
+    , mute{pa_info.mute}
+    , volume{pa_info.volume}
+{}
+
+void PulseAudioEngine::sinkInfoCallback(pa_context *context, const pa_sink_info *info, int isLast, void *userdata)
 {
     PulseAudioEngine *pulseEngine = static_cast<PulseAudioEngine*>(userdata);
-    QMap<pa_sink_state, QString> stateMap;
-    stateMap[PA_SINK_INVALID_STATE] = QLatin1String("n/a");
-    stateMap[PA_SINK_RUNNING] = QLatin1String("RUNNING");
-    stateMap[PA_SINK_IDLE] = QLatin1String("IDLE");
-    stateMap[PA_SINK_SUSPENDED] = QLatin1String("SUSPENDED");
 
     if (isLast < 0) {
-        pa_threaded_mainloop_signal(pulseEngine->mainloop(), 0);
+        pa_threaded_mainloop_signal(pulseEngine->m_mainLoop, 0);
         qWarning() << QStringLiteral("Failed to get sink information: %1").arg(QString::fromUtf8(pa_strerror(pa_context_errno(context))));
         return;
     }
 
     if (isLast) {
-        pa_threaded_mainloop_signal(pulseEngine->mainloop(), 0);
+        pa_threaded_mainloop_signal(pulseEngine->m_mainLoop, 0);
         return;
     }
 
-    pulseEngine->addOrUpdateSink(info);
+    emit pulseEngine->sinkInfoReceived(PulseAudioDevice{*info});
 }
 
-static void contextEventCallback(pa_context * /*context*/, const char *
+void PulseAudioEngine::contextEventCallback(pa_context * /*context*/, const char *
 #ifdef PULSEAUDIO_ENGINE_DEBUG
         name
 #endif
@@ -72,9 +79,9 @@ static void contextEventCallback(pa_context * /*context*/, const char *
 #endif
 }
 
-static void contextStateCallback(pa_context *context, void *userdata)
+void PulseAudioEngine::contextStateCallback(pa_context *context, void *userdata)
 {
-    PulseAudioEngine *pulseEngine = reinterpret_cast<PulseAudioEngine*>(userdata);
+    PulseAudioEngine *pulseEngine = static_cast<PulseAudioEngine*>(userdata);
 
     // update internal state
     pa_context_state_t state = pa_context_get_state(context);
@@ -108,24 +115,19 @@ static void contextStateCallback(pa_context *context, void *userdata)
     }
 #endif
 
-    pa_threaded_mainloop_signal(pulseEngine->mainloop(), 0);
+    pa_threaded_mainloop_signal(pulseEngine->m_mainLoop, 0);
 }
 
-static void contextSuccessCallback(pa_context *context, int success, void *userdata)
+void PulseAudioEngine::contextSuccessCallback(pa_context *, int , void *userdata)
 {
-    Q_UNUSED(context);
-    Q_UNUSED(success);
-    Q_UNUSED(userdata);
-
-    PulseAudioEngine *pulseEngine = reinterpret_cast<PulseAudioEngine*>(userdata);
-    pa_threaded_mainloop_signal(pulseEngine->mainloop(), 0);
+    pa_threaded_mainloop_signal(static_cast<PulseAudioEngine*>(userdata)->m_mainLoop, 0);
 }
 
-static void contextSubscriptionCallback(pa_context * /*context*/, pa_subscription_event_type_t t, uint32_t idx, void *userdata)
+void PulseAudioEngine::contextSubscriptionCallback(pa_context * /*context*/, pa_subscription_event_type_t t, uint32_t idx, void *userdata)
 {
-    PulseAudioEngine *pulseEngine = reinterpret_cast<PulseAudioEngine*>(userdata);
+    PulseAudioEngine *pulseEngine = static_cast<PulseAudioEngine*>(userdata);
     if (PA_SUBSCRIPTION_EVENT_REMOVE == t)
-        pulseEngine->removeSink(idx);
+        emit pulseEngine->sinkRemoved(idx);
     else
         pulseEngine->requestSinkInfoUpdate(idx);
 }
@@ -160,6 +162,8 @@ PulseAudioEngine::PulseAudioEngine(QObject *parent) :
     m_mainLoopApi = pa_threaded_mainloop_get_api(m_mainLoop);
 
     connect(this, &PulseAudioEngine::contextStateChanged, this, &PulseAudioEngine::handleContextStateChanged);
+    connect(this, &PulseAudioEngine::sinkRemoved, this, &PulseAudioEngine::removeSink, Qt::QueuedConnection);
+    connect(this, &PulseAudioEngine::sinkInfoReceived, this, &PulseAudioEngine::addOrUpdateSink, Qt::QueuedConnection);
 
     connectContext();
 }
@@ -189,33 +193,31 @@ void PulseAudioEngine::removeSink(uint32_t idx)
     emit sinkListChanged();
 }
 
-void PulseAudioEngine::addOrUpdateSink(const pa_sink_info *info)
+void PulseAudioEngine::addOrUpdateSink(const PulseAudioDevice &pulse_dev)
 {
-    AudioDevice *dev = nullptr;
+    auto const dev_it = std::find_if(m_sinks.constBegin(), m_sinks.constEnd(), [&](auto const dev) {
+        return dev->name() == pulse_dev.name;
+    });
+
+    AudioDevice* dev = nullptr;
     bool newSink = false;
-    QString name = QString::fromUtf8(info->name);
-
-    for (AudioDevice *device : std::as_const(m_sinks)) {
-        if (device->name() == name) {
-            dev = device;
-            break;
-        }
-    }
-
-    if (!dev) {
+    if (dev_it == m_sinks.constEnd()) {
         dev = new AudioDevice(Sink, this);
         newSink = true;
     }
+    else {
+        dev = *dev_it;
+    }
 
-    dev->setName(name);
-    dev->setIndex(info->index);
-    dev->setDescription(QString::fromUtf8(info->description));
-    dev->setMuteNoCommit(info->mute);
+    dev->setName(pulse_dev.name);
+    dev->setIndex(pulse_dev.index);
+    dev->setDescription(pulse_dev.description);
+    dev->setMuteNoCommit(pulse_dev.mute);
 
     // TODO: save separately? alsa does not have it
-    m_cVolumeMap.insert(dev, info->volume);
+    m_cVolumeMap.insert(dev, pulse_dev.volume);
 
-    pa_volume_t v = pa_cvolume_avg(&(info->volume));
+    pa_volume_t v = pa_cvolume_avg(&(pulse_dev.volume));
     // convert real volume to percentage
     dev->setVolumeNoCommit(std::round((static_cast<double>(v) * 100.0) / m_maximumVolume));
 
@@ -379,8 +381,7 @@ void PulseAudioEngine::retrieveSinkInfo(uint32_t idx)
 
     pa_threaded_mainloop_lock(m_mainLoop);
 
-    pa_operation *operation;
-    operation = pa_context_get_sink_info_by_index(m_context, idx, sinkInfoCallback, this);
+    pa_operation *const operation = pa_context_get_sink_info_by_index(m_context, idx, sinkInfoCallback, this);
     while (pa_operation_get_state(operation) == PA_OPERATION_RUNNING)
         pa_threaded_mainloop_wait(m_mainLoop);
     pa_operation_unref(operation);
@@ -395,8 +396,7 @@ void PulseAudioEngine::setMute(AudioDevice *device, bool state)
 
     pa_threaded_mainloop_lock(m_mainLoop);
 
-    pa_operation *operation;
-    operation = pa_context_set_sink_mute_by_index(m_context, device->index(), state, contextSuccessCallback, this);
+    pa_operation *const operation = pa_context_set_sink_mute_by_index(m_context, device->index(), state, contextSuccessCallback, this);
     while (pa_operation_get_state(operation) == PA_OPERATION_RUNNING)
         pa_threaded_mainloop_wait(m_mainLoop);
     pa_operation_unref(operation);
@@ -455,6 +455,3 @@ void PulseAudioEngine::setIgnoreMaxVolume(bool ignore)
     if (oldMax != m_maximumVolume)
         retrieveSinks();
 }
-
-
-

--- a/plugin-volume/pulseaudioengine.h
+++ b/plugin-volume/pulseaudioengine.h
@@ -37,11 +37,6 @@
 
 #include <pulse/pulseaudio.h>
 
-// PA_VOLUME_UI_MAX is only supported since pulseaudio 0.9.23
-#ifndef PA_VOLUME_UI_MAX
-#define PA_VOLUME_UI_MAX (pa_sw_volume_from_dB(+11.0))
-#endif
-
 class AudioDevice;
 
 class PulseAudioEngine : public AudioEngine
@@ -58,13 +53,16 @@ public:
 
     bool setDefaultSink(AudioDevice *device) override;
 
-    void requestSinkInfoUpdate(uint32_t idx);
-    void removeSink(uint32_t idx);
-    void addOrUpdateSink(const pa_sink_info *info);
+    struct PulseAudioDevice
+    {
+        PulseAudioDevice(const pa_sink_info&);
 
-    pa_context_state_t contextState() const { return m_contextState; }
-    bool ready() const { return m_ready; }
-    pa_threaded_mainloop *mainloop() const { return m_mainLoop; }
+        QString name;
+        QString description;
+        uint32_t index;
+        int mute;
+        pa_cvolume volume;
+    };
 
 public slots:
     void commitDeviceVolume(AudioDevice *device) override;
@@ -77,14 +75,28 @@ signals:
     void sinkInfoChanged(uint32_t idx);
     void contextStateChanged(pa_context_state_t state);
     void readyChanged(bool ready);
+    void sinkRemoved(uint32_t);
+    void sinkInfoReceived(const PulseAudioDevice&);
 
 private slots:
     void handleContextStateChanged();
     void connectContext();
+    void removeSink(uint32_t idx);
+    void addOrUpdateSink(const PulseAudioDevice&);
 
 private:
+    static void sinkInfoCallback(pa_context *, const pa_sink_info *, int, void *);
+    static void contextStateCallback(pa_context *, void *);
+    static void contextSuccessCallback(pa_context *, int, void *);
+    static void contextSubscriptionCallback(pa_context *,
+                                            pa_subscription_event_type_t,
+                                            uint32_t,
+                                            void *);
+    static void contextEventCallback(pa_context *, const char *, pa_proplist *, void *);
+
     void retrieveSinks();
     void setupSubscription();
+    void requestSinkInfoUpdate(uint32_t idx);
 
     pa_mainloop_api *m_mainLoopApi;
     pa_threaded_mainloop *m_mainLoop;


### PR DESCRIPTION
Fixes the crashes I've been experiencing by doing almost no actual work inside `sinkInfoCallback` and creating a temporary object that contains all the information that `addOrUpdateSink` needs, then raising a signal that's connected to `addOrUpdateSink` via a queued connection. Do the same for `contextSubscriptionCallback` and its call to `removeSink`.

This avoids modifying `m_sinks` and/or other `PulseAudioEngine` members from multiple threads as all operations take place from the Qt event loop thread.

Some small changes/improvements on top of that :
 * moving `PA_VOLUME_UI_MAX` to the cpp as it's not needed in the header,
 * removing the unused `stateMap` variable from `sinkInfoCallback`,
 * making the PulseAudio callback functions `static` members of the class which means that some getters aren't needed,
 * replacing `reinterpret_cast` with `static_cast` as we're not actually "reinterpreting" the contents - the object underneath the callbacks' `void*` is actually a `PulseAudioEngine`.