### PR TITLE
update fsf address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/panel/ilxqtpanel.h
+++ b/panel/ilxqtpanel.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/panel/ilxqtpanelplugin.h
+++ b/panel/ilxqtpanelplugin.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/panel/lxqtpanelglobals.h
+++ b/panel/lxqtpanelglobals.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/panel/pluginsettings.h
+++ b/panel/pluginsettings.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.