### PR TITLE
Use variadic QString::arg when possible

### DIFF
--- a/panel/backends/wayland/wayfire/wayfire-common.cpp
+++ b/panel/backends/wayland/wayfire/wayfire-common.cpp
@@ -375,7 +375,7 @@ QJsonArray LXQt::Panel::Wayfire::getWorkspaceSetsInfo() const
 
 QString LXQt::Panel::Wayfire::getWorkspaceName(int x, const QString &outputName) const
 {
-    QString targetKey = QString::fromUtf8("%1_workspace_%2").arg(outputName).arg(x);
+    QString targetKey = QString::fromUtf8("%1_workspace_%2").arg(outputName, x);
 
     QJsonObject request;
     request[QSL("method")] = QSL("wayfire/get-config-option");

--- a/panel/panelpluginsmodel.cpp
+++ b/panel/panelpluginsmodel.cpp
@@ -350,7 +350,7 @@ QString PanelPluginsModel::findNewPluginSettingsGroup(const QString &pluginType)
     {
         for (int i = 2; true; ++i)
         {
-            pluginName = QStringLiteral("%1%2").arg(pluginType).arg(i);
+            pluginName = QStringLiteral("%1%2").arg(pluginType, i);
             if (!groups.contains(pluginName))
                 return pluginName;
         }

--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -105,7 +105,7 @@ void DesktopSwitch::registerShortcuts()
     QString description;
     for (int i = 0; i < 12; ++i)
     {
-        path = QStringLiteral("/panel/%1/desktop_%2").arg(settings()->group()).arg(i + 1);
+        path = QStringLiteral("/panel/%1/desktop_%2").arg(settings()->group(), i + 1);
         description = tr("Switch to desktop %1").arg(i + 1);
 
         gshortcut = GlobalKeyShortcut::Client::instance()->addAction(QString(), path, description, this);

--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -101,7 +101,7 @@ void Content::layoutChanged(const QString & sym, const QString & name, const QSt
     QString txt = QStringLiteral("<html><table>\
     <tr><td>%1: </td><td>%3</td></tr>\
     <tr><td>%2: </td><td>%4</td></tr>\
-    </table></html>").arg(tr("Layout")).arg(tr("Variant")).arg(name).arg(variant);
+    </table></html>").arg(tr("Layout"), tr("Variant"), name, variant);
     m_layout->setToolTip(txt);
 }
 

--- a/plugin-statusnotifier/statusnotifierproxy.cpp
+++ b/plugin-statusnotifier/statusnotifierproxy.cpp
@@ -59,7 +59,7 @@ void StatusNotifierProxy::createWatcher()
 
     QFuture<StatusNotifierWatcher *> future = QtConcurrent::run([]
         {
-            QString dbusName = QStringLiteral("org.kde.StatusNotifierHost-%1-%2").arg(QApplication::applicationPid()).arg(1);
+            QString dbusName = QStringLiteral("org.kde.StatusNotifierHost-%1-%2").arg(QApplication::applicationPid(), 1);
             if (QDBusConnectionInterface::ServiceNotRegistered == QDBusConnection::sessionBus().interface()->registerService(dbusName, QDBusConnectionInterface::DontQueueService))
                 qDebug() << "unable to register service for " << dbusName;
 

--- a/plugin-sysstat/lxqtsysstat.cpp
+++ b/plugin-sysstat/lxqtsysstat.cpp
@@ -493,7 +493,7 @@ void LXQtSysStatContent::memoryUpdate(float apps, float buffers, float cached)
     int y_cached  = static_cast<int>(cached  * 100.0);
 
     toolTipInfo(tr("apps: %1%<br>buffers: %2%<br>cached: %3%", "Memory tooltip information")
-        .arg(y_apps).arg(y_buffers).arg(y_cached));
+        .arg(y_apps, y_buffers, y_cached));
 
     y_apps    = std::clamp(y_apps, 0, 99);
     y_buffers = std::clamp(y_buffers + y_apps, 0, 99);
@@ -558,7 +558,7 @@ void LXQtSysStatContent::networkUpdate(unsigned received, unsigned transmitted)
     int y_min_value = static_cast<int>(min_value * 100.0);
     int y_max_value = static_cast<int>(max_value * 100.0);
 
-    toolTipInfo(tr("min: %1%<br>max: %2%", "Network tooltip information").arg(y_min_value).arg(y_max_value));
+    toolTipInfo(tr("min: %1%<br>max: %2%", "Network tooltip information").arg(y_min_value, y_max_value));
 
     y_min_value = std::clamp(y_min_value, 0, 99);
     y_max_value = std::clamp(y_max_value + y_min_value, 0, 99);
@@ -630,7 +630,7 @@ void LXQtSysStatContent::paintEvent(QPaintEvent *event)
 void LXQtSysStatContent::toolTipInfo(QString const & tooltip)
 {
     setToolTip(QStringLiteral("<b>%1(%2)</b><br>%3")
-            .arg(QCoreApplication::translate("LXQtSysStatConfiguration", mDataType.toStdString().c_str()))
-            .arg(QCoreApplication::translate("LXQtSysStatConfiguration", mDataSource.toStdString().c_str()))
-            .arg(tooltip));
+            .arg(QCoreApplication::translate("LXQtSysStatConfiguration", mDataType.toStdString().c_str()),
+                 QCoreApplication::translate("LXQtSysStatConfiguration", mDataSource.toStdString().c_str()),
+                 tooltip));
 }

--- a/plugin-sysstat/lxqtsysstatcolours.cpp
+++ b/plugin-sysstat/lxqtsysstatcolours.cpp
@@ -94,7 +94,8 @@ void LXQtSysStatColours::selectColour(const QString &name)
     if (color.isValid())
     {
         mColours[name] = color;
-        mShowColourMap[name]->setStyleSheet(QStringLiteral("background-color: %1;\ncolor: %2;").arg(color.name()).arg((color.toHsl().lightnessF() > 0.5) ? QStringLiteral("black") : QStringLiteral("white")));
+        mShowColourMap[name]->setStyleSheet(QStringLiteral("background-color: %1;\ncolor: %2;")
+            .arg(color.name(), (color.toHsl().lightnessF() > 0.5) ? QStringLiteral("black") : QStringLiteral("white")));
 
         ui->buttons->button(QDialogButtonBox::Apply)->setEnabled(true);
     }
@@ -115,7 +116,8 @@ void LXQtSysStatColours::applyColoursToButtons()
     for (Colours::ConstIterator I = mColours.constBegin(); I != M; ++I)
     {
         const QColor &color = I.value();
-        mShowColourMap[I.key()]->setStyleSheet(QStringLiteral("background-color: %1;\ncolor: %2;").arg(color.name()).arg((color.toHsl().lightnessF() > 0.5) ? QStringLiteral("black") : QStringLiteral("white")));
+        mShowColourMap[I.key()]->setStyleSheet(QStringLiteral("background-color: %1;\ncolor: %2;")
+            .arg(color.name(), (color.toHsl().lightnessF() > 0.5) ? QStringLiteral("black") : QStringLiteral("white")));
     }
 }
 

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -645,7 +645,7 @@ void LXQtTaskBar::registerShortcuts()
     QString description;
     for (int i = 1; i <= 10; ++i)
     {
-        path = QStringLiteral("/panel/%1/task_%2").arg(mPlugin->settings()->group()).arg(i);
+        path = QStringLiteral("/panel/%1/task_%2").arg(mPlugin->settings()->group(), i);
         description = tr("Activate task %1").arg(i);
 
         gshortcut = GlobalKeyShortcut::Client::instance()->addAction(QLatin1String(""), path, description, this);

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -348,7 +348,7 @@ void LXQtTaskGroup::regroup()
     else
     {
         mSingleButton = false;
-        QString t = QString(QStringLiteral("%1 - %2 windows")).arg(mGroupName).arg(cont);
+        QString t = QString(QStringLiteral("%1 - %2 windows")).arg(mGroupName, cont);
         setTextExplicitly(t);
         setToolTip(parentTaskBar()->isShowGroupOnHover() ? QString() : t);
     }

--- a/plugin-volume/lxqtvolume.cpp
+++ b/plugin-volume/lxqtvolume.cpp
@@ -311,7 +311,7 @@ void LXQtVolume::updateTrayIconFromDefaultSink()
         iconName = QLatin1String("audio-volume-high");
     iconName.append(QLatin1String("-panel"));
     m_volumeButton->setIcon(XdgIcon::fromTheme(iconName));
-    m_volumeButton->setToolTip(tr("%1: %2%").arg(m_defaultSink->description()).arg(m_defaultSink->volume()));
+    m_volumeButton->setToolTip(tr("%1: %2%").arg(m_defaultSink->description(), m_defaultSink->volume()));
 }
 
 QWidget *LXQtVolume::widget()
@@ -346,7 +346,7 @@ void LXQtVolume::showNotification(bool forceShow) const
     {
         if (Q_LIKELY(m_defaultSink))
         {
-            m_notification->setSummary(tr("Volume: %1%%2").arg(QString::number(m_defaultSink->volume())).arg(m_defaultSink->mute() ? tr("(muted)") : QLatin1String("")));
+            m_notification->setSummary(tr("Volume: %1%%2").arg(QString::number(m_defaultSink->volume()), m_defaultSink->mute() ? tr("(muted)") : QLatin1String("")));
             m_notification->update();
         }
     }

--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -256,7 +256,10 @@ void LXQtWorldClock::settingsChanged()
         else if (formatType == QLatin1String("long-timeonly"))
             mFormat = QLocale{}.timeFormat(QLocale::LongFormat);
         else // if (formatType == QLatin1String("custom-timeonly"))
-            mFormat = QString(QLatin1String("%1:mm%2%3")).arg(timePadHour ? QLatin1String("hh") : QLatin1String("h")).arg(timeShowSeconds ? QLatin1String(":ss") : QLatin1String("")).arg(timeAMPM ? QLatin1String(" A") : QLatin1String(""));
+            mFormat = QString(QLatin1String("%1:mm%2%3")).arg(
+                timePadHour ? QLatin1String("hh") : QLatin1String("h"),
+                timeShowSeconds ? QLatin1String(":ss") : QLatin1String(""),
+                timeAMPM ? QLatin1String(" A") : QLatin1String(""));
 
         if (showTimezone)
         {
@@ -309,7 +312,13 @@ void LXQtWorldClock::settingsChanged()
                 else
                 // Little-endian (day, month, year) (dddd, dd MMMM yyyy) -> most of Europe
                     datePortionOrder = QLatin1String("%6%5%4 %3%2%1");
-                datePortion = datePortionOrder.arg(dateShowYear ? QLatin1String("yyyy") : QLatin1String("")).arg(dateShowYear ? QLatin1String(" ") : QLatin1String("")).arg(dateLongNames ? QLatin1String("MMMM") : QLatin1String("MMM")).arg(datePadDay ? QLatin1String("dd") : QLatin1String("d")).arg(dateShowDoW ? QLatin1String(", ") : QLatin1String("")).arg(dateShowDoW ? (dateLongNames ? QLatin1String("dddd") : QLatin1String("ddd")) : QLatin1String(""));
+                datePortion = datePortionOrder.arg(
+                    dateShowYear ? QLatin1String("yyyy") : QLatin1String(""),
+                    dateShowYear ? QLatin1String(" ") : QLatin1String(""),
+                    dateLongNames ? QLatin1String("MMMM") : QLatin1String("MMM"),
+                    datePadDay ? QLatin1String("dd") : QLatin1String("d"),
+                    dateShowDoW ? QLatin1String(", ") : QLatin1String(""),
+                    dateShowDoW ? (dateLongNames ? QLatin1String("dddd") : QLatin1String("ddd")) : QLatin1String(""));
             }
 
             if (datePosition == QLatin1String("below"))


### PR DESCRIPTION
A.I. said for 2 args it is ~20% faster due to reduced reallocations and parsing. For 3-5 args up to 70% faster.

Some chained `.arg`s had to be left due to mix-and-matching `QString` and `int`, ...