### PR TITLE
plugin-sysstat: Use US English source tr

### DIFF
--- a/plugin-sysstat/lxqtsysstatconfiguration.ui
+++ b/plugin-sysstat/lxqtsysstatconfiguration.ui
@@ -324,7 +324,7 @@
         <item row="0" column="0">
          <widget class="QRadioButton" name="useThemeColoursRB">
           <property name="text">
-           <string>Use t&amp;heme colours</string>
+           <string>Use t&amp;heme colors</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -334,14 +334,14 @@
         <item row="1" column="0">
          <widget class="QRadioButton" name="useCustomColoursRB">
           <property name="text">
-           <string>Use c&amp;ustom colours</string>
+           <string>Use c&amp;ustom colors</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
          <widget class="QPushButton" name="customColoursB">
           <property name="text">
-           <string>Custom colour ...</string>
+           <string>Custom color ...</string>
           </property>
          </widget>
         </item>

--- a/plugin-sysstat/translations/sysstat.ts
+++ b/plugin-sysstat/translations/sysstat.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ar.ts
+++ b/plugin-sysstat/translations/sysstat_ar.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>&amp;استخدم ألوان الموضوع</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;استخدم ألوان التخصيص</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>لون مخصص ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_arn.ts
+++ b/plugin-sysstat/translations/sysstat_arn.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ast.ts
+++ b/plugin-sysstat/translations/sysstat_ast.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_bg.ts
+++ b/plugin-sysstat/translations/sysstat_bg.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Използване на цветове от т&amp;емата</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Използване на со&amp;бствени цветове</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Цветове ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ca.ts
+++ b/plugin-sysstat/translations/sysstat_ca.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Utilitza els colors del te&amp;ma</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Utilitza els colors personalitzats</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Colors personalitzats...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_cs.ts
+++ b/plugin-sysstat/translations/sysstat_cs.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Použít barvy &amp;motivu</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Použít &amp;uživatelsky určené barvy</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Uživatelsky určená barva…</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_cy.ts
+++ b/plugin-sysstat/translations/sysstat_cy.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_da.ts
+++ b/plugin-sysstat/translations/sysstat_da.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Brug &amp;temaets farver</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Brug &amp;brugerdefinerede farver</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Brugerdefineret farve ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_de.ts
+++ b/plugin-sysstat/translations/sysstat_de.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>T&amp;hemenfarben verwenden</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Eigene Farben verwenden</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Benutzerdefinierte Farbe ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_el.ts
+++ b/plugin-sysstat/translations/sysstat_el.ts
@@ -345,17 +345,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Χρήση των χρωμάτων του &amp;θέματος</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Χρήση &amp;προσαρμοσμένων χρωμάτων</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Προσαρμοσμένα χρώματα...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_en_GB.ts
+++ b/plugin-sysstat/translations/sysstat_en_GB.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Use t&amp;heme colours</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_es.ts
+++ b/plugin-sysstat/translations/sysstat_es.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Usar los colores del tema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Usar colores personalizados</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Color personalizado...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_et.ts
+++ b/plugin-sysstat/translations/sysstat_et.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Kasuta &amp;teema värve</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Kasuta &amp;kohandatud värve</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Kohandatud värv...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_fi.ts
+++ b/plugin-sysstat/translations/sysstat_fi.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Käytä t&amp;eeman värejä</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Käytä omia värejä</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Mukautettu väri...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_fr.ts
+++ b/plugin-sysstat/translations/sysstat_fr.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Utiliser les couleurs du t&amp;hème</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Utiliser des couleurs personnalisées</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Couleurs personnalisées...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_gl.ts
+++ b/plugin-sysstat/translations/sysstat_gl.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Usar as cores do &amp;tema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Usar cores &amp;personalizadas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Cor personalizado ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_he.ts
+++ b/plugin-sysstat/translations/sysstat_he.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>שימוש בצבעי &amp;ערכת העיצוב</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>שימוש בצבעים בהת&amp;אמה אישית</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>צבע בהתאמה אישית…</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_hr.ts
+++ b/plugin-sysstat/translations/sysstat_hr.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Koristi boj&amp;e teme</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Koristi &amp;prilagođene boje</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Prilagođena boja …</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_hu.ts
+++ b/plugin-sysstat/translations/sysstat_hu.ts
@@ -345,17 +345,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>&amp;Rendszertéma használata</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Egyéni</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Egyéni színek...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_id.ts
+++ b/plugin-sysstat/translations/sysstat_id.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Gunakan warna tema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Gunakan warna kustom</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Warna kustom ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_it.ts
+++ b/plugin-sysstat/translations/sysstat_it.ts
@@ -345,17 +345,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Usa colori del &amp;tema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Colori &amp;personalizzati</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Colore personalizzato ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ja.ts
+++ b/plugin-sysstat/translations/sysstat_ja.ts
@@ -345,17 +345,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>テーマの色を使用する(&amp;H)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>色を指定する(&amp;U)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>色の指定 ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ka.ts
+++ b/plugin-sysstat/translations/sysstat_ka.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>&amp;თემის ფერების გამოყენება</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>მორგებ&amp;ული ფერების გამოყენება</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>მორგებული ფერი ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_kab.ts
+++ b/plugin-sysstat/translations/sysstat_kab.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_kk.ts
+++ b/plugin-sysstat/translations/sysstat_kk.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Т&amp;ема түстерін пайдалану</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Таңдау&amp;ыңызша түстерді пайдалану</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Таңдауыңызша түс ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ko.ts
+++ b/plugin-sysstat/translations/sysstat_ko.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>테마 색상 사용(&amp;H)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>사용자 지정 색상 사용(&amp;U)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>사용자 지정 색상 ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_lg.ts
+++ b/plugin-sysstat/translations/sysstat_lg.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Kozesa lul&amp;yo lwa langi olutegekedwa ku sisitemu</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Werondere langi e&amp;zinaakozesebwa</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Londa langi...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_lt.ts
+++ b/plugin-sysstat/translations/sysstat_lt.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Naudoti t&amp;emos spalvas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Naudoti &amp;tinkintas spalvas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Tinkinta spalva ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_lv.ts
+++ b/plugin-sysstat/translations/sysstat_lv.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Izmantot tē&amp;mas krāsas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Izmantot pielā&amp;gotas krāsas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Pielāgojamā krāsa...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_nb_NO.ts
+++ b/plugin-sysstat/translations/sysstat_nb_NO.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Bruk &amp;temafarger</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Bruk &amp;selvvalgte farger</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Selvvalgte farger...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_nl.ts
+++ b/plugin-sysstat/translations/sysstat_nl.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>T&amp;hemakleuren gebruiken</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Aangepaste kle&amp;uren gebruiken</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Aangepaste kleur…</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_oc.ts
+++ b/plugin-sysstat/translations/sysstat_oc.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Color personalizat...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_pa.ts
+++ b/plugin-sysstat/translations/sysstat_pa.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>ਥੀਮ ਦੇ ਰੰਗ ਵਰਤੋਂ(&amp;h)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>ਕਸਟਮ ਰੰਗਾਂ ਨੂੰ ਵਰਤੋਂ(&amp;u)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>ਕਸਟਮ ਰੰਗ ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_pl.ts
+++ b/plugin-sysstat/translations/sysstat_pl.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Używaj kolorów &amp;motywu</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Używaj &amp;niestandardowych kolorów</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Niestandardowy kolor…</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_pt.ts
+++ b/plugin-sysstat/translations/sysstat_pt.ts
@@ -345,17 +345,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Utili&amp;zar cores do tema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Utilizar cores personalizadas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Cor personalizada...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_pt_BR.ts
+++ b/plugin-sysstat/translations/sysstat_pt_BR.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Usar cores do t&amp;ema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Usar cores per&amp;sonalizadas</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Cor personalizada ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_ru.ts
+++ b/plugin-sysstat/translations/sysstat_ru.ts
@@ -355,17 +355,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Использовать цвета &amp;темы</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Использовать с&amp;вои цвета</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Свои цвета…</translation>
     </message>
 </context>

--- a/plugin-sysstat/translations/sysstat_si.ts
+++ b/plugin-sysstat/translations/sysstat_si.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_sk_SK.ts
+++ b/plugin-sysstat/translations/sysstat_sk_SK.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>&amp;Použiť farbu motívu</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Použiť užívateľsky určené farby</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Užívateľsky určená farba...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_sv.ts
+++ b/plugin-sysstat/translations/sysstat_sv.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Följ &amp;systemtemat</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Använd &amp;eget färgschema</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Anpassa färger ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_tr.ts
+++ b/plugin-sysstat/translations/sysstat_tr.ts
@@ -206,17 +206,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>&amp;Tema rengini kullan</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>&amp;Özel renk kullan</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Özel renk ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_uk.ts
+++ b/plugin-sysstat/translations/sysstat_uk.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>Використати ко&amp;льори теми</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>Вико&amp;ристати власні кольори</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>Власні кольори ...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_zh_CN.ts
+++ b/plugin-sysstat/translations/sysstat_zh_CN.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>使用主题颜色(&amp;H)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>使用自定义颜色(&amp;U)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>自定义颜色...</translation>
     </message>
     <message>

--- a/plugin-sysstat/translations/sysstat_zh_TW.ts
+++ b/plugin-sysstat/translations/sysstat_zh_TW.ts
@@ -205,17 +205,17 @@
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="327"/>
-        <source>Use t&amp;heme colours</source>
+        <source>Use t&amp;heme colors</source>
         <translation>使用主題顏色(&amp;H)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="337"/>
-        <source>Use c&amp;ustom colours</source>
+        <source>Use c&amp;ustom colors</source>
         <translation>使用自訂顏色(&amp;U)</translation>
     </message>
     <message>
         <location filename="../lxqtsysstatconfiguration.ui" line="344"/>
-        <source>Custom colour ...</source>
+        <source>Custom color ...</source>
         <translation>自訂顏色…</translation>
     </message>
     <message>


### PR DESCRIPTION
Same as https://github.com/lxqt/lxqt-globalkeys/pull/343, en_GB → en_US for source tr.

Because it is technically the same word, `<translation>`s should be able to be left the same.

```
lxqt/lxqt-panel$ sed -i "/<string>/s/colour/color/" lxqtsysstatconfiguration.ui
lxqt/lxqt-panel$ sed -i "/<source>/s/colour/color/" translations/*
```