### PR TITLE
plugin-networkmonitor: Improve spacing

### DIFF
--- a/plugin-networkmonitor/lxqtnetworkmonitor.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitor.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #endif
 
 LXQtNetworkMonitor::LXQtNetworkMonitor(ILXQtPanelPlugin *plugin, QWidget* parent):
-    QFrame(parent),
+    QToolButton(parent),
     mPlugin(plugin)
 {
     QHBoxLayout *layout = new QHBoxLayout(this);
@@ -164,7 +164,7 @@ bool LXQtNetworkMonitor::event(QEvent *event)
             network_stats++;
         }
     }
-    return QFrame::event(event);
+    return QToolButton::event(event);
 }
 
 //void LXQtNetworkMonitor::showConfigureDialog()

--- a/plugin-networkmonitor/lxqtnetworkmonitor.h
+++ b/plugin-networkmonitor/lxqtnetworkmonitor.h
@@ -27,14 +27,14 @@
 
 #ifndef LXQTNETWORKMONITOR_H
 #define LXQTNETWORKMONITOR_H
-#include <QFrame>
+#include <QToolButton>
 
 class ILXQtPanelPlugin;
 
 /*!
   TODO: How to define cable is not connected?
   */
-class LXQtNetworkMonitor: public QFrame
+class LXQtNetworkMonitor: public QToolButton
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Because plugin-networkmonitor used a QFrame as its encompassing QWidget, its spacing was relatively too much. This was in all themes.

Before:
<img width="297" height="60" alt="before" src="https://github.com/user-attachments/assets/a5a601b3-2dd7-4f08-9bd6-c1c5925c9aa8" />

After: 
<img width="92" height="71" alt="after" src="https://github.com/user-attachments/assets/04783d93-1390-4ecb-b7b7-5448a0a749e6" />

I simply switched to QToolButton to match other 'status icons' - this normalizes spacing and has a side-effect of easier theming.