### PR TITLE
Make default Close dialog button for relevant plugins

### DIFF
--- a/plugin-cpuload/lxqtcpuloadconfiguration.cpp
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.cpp
@@ -47,7 +47,8 @@ LXQtCpuLoadConfiguration::LXQtCpuLoadConfiguration(PluginSettings *settings, QWi
     fillBarOrientations();
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtCpuLoadConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     loadSettings();
 

--- a/plugin-cpuload/lxqtcpuloadconfiguration.cpp
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.cpp
@@ -28,6 +28,8 @@
 #include "lxqtcpuloadconfiguration.h"
 #include "ui_lxqtcpuloadconfiguration.h"
 
+#include <QPushButton>
+
 #define BAR_ORIENT_BOTTOMUP "bottomUp"
 #define BAR_ORIENT_TOPDOWN "topDown"
 #define BAR_ORIENT_LEFTRIGHT "leftRight"
@@ -45,6 +47,7 @@ LXQtCpuLoadConfiguration::LXQtCpuLoadConfiguration(PluginSettings *settings, QWi
     fillBarOrientations();
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtCpuLoadConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     loadSettings();
 

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -74,7 +74,7 @@ LXQtCustomCommandConfiguration::LXQtCustomCommandConfiguration(PluginSettings *s
 
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose, true);
-    
+
     const QFont monoFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     ui->commandPlainTextEdit->setFont(monoFont);
 
@@ -124,7 +124,8 @@ LXQtCustomCommandConfiguration::LXQtCustomCommandConfiguration(PluginSettings *s
     loadSettings();
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &LXQtCustomCommandConfiguration::dialogButtonsAction);
-    ui->buttonBox->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttonBox->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(ui->autoRotateCheckBox, &QCheckBox::toggled, this, &LXQtCustomCommandConfiguration::autoRotateChanged);
     connect(ui->fontButton, &QPushButton::clicked, this, &LXQtCustomCommandConfiguration::fontButtonClicked);

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -124,6 +124,7 @@ LXQtCustomCommandConfiguration::LXQtCustomCommandConfiguration(PluginSettings *s
     loadSettings();
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &LXQtCustomCommandConfiguration::dialogButtonsAction);
+    ui->buttonBox->button(QDialogButtonBox::Close)->setDefault(true);
 
     connect(ui->autoRotateCheckBox, &QCheckBox::toggled, this, &LXQtCustomCommandConfiguration::autoRotateChanged);
     connect(ui->fontButton, &QPushButton::clicked, this, &LXQtCustomCommandConfiguration::fontButtonClicked);

--- a/plugin-directorymenu/directorymenuconfiguration.cpp
+++ b/plugin-directorymenu/directorymenuconfiguration.cpp
@@ -31,6 +31,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QStandardPaths>
+#include <QPushButton>
 
 #include <XdgIcon>
 
@@ -50,6 +51,7 @@ DirectoryMenuConfiguration::DirectoryMenuConfiguration(PluginSettings *settings,
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &DirectoryMenuConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     ui->buttonStyleCB->addItem(tr("Only icon"), QLatin1String("Icon"));
     ui->buttonStyleCB->addItem(tr("Only text"), QLatin1String("Text"));

--- a/plugin-directorymenu/directorymenuconfiguration.cpp
+++ b/plugin-directorymenu/directorymenuconfiguration.cpp
@@ -51,7 +51,8 @@ DirectoryMenuConfiguration::DirectoryMenuConfiguration(PluginSettings *settings,
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &DirectoryMenuConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     ui->buttonStyleCB->addItem(tr("Only icon"), QLatin1String("Icon"));
     ui->buttonStyleCB->addItem(tr("Only text"), QLatin1String("Text"));

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -35,6 +35,7 @@
 
 #include <QAction>
 #include <QFileDialog>
+#include <QPushButton>
 
 #include "lxqtfancymenutypes.h"
 
@@ -57,6 +58,7 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
     ui->iconPB->setIcon(folder);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtFancyMenuConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     loadSettings();
 

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -58,7 +58,8 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
     ui->iconPB->setIcon(folder);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtFancyMenuConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     loadSettings();
 

--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -28,6 +28,7 @@
 
 #include <QDebug>
 #include <QProcess>
+#include <QPushButton>
 
 #include "kbdstateconfig.h"
 #include "ui_kbdstateconfig.h"
@@ -56,6 +57,7 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
             load();
         }
     });
+    m_ui->btns->button(QDialogButtonBox::Close)->setDefault(true);
 
     connect(m_ui->configureLayouts, &QPushButton::clicked, this, &KbdStateConfig::configureLayouts);
 

--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -57,7 +57,8 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
             load();
         }
     });
-    m_ui->btns->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = m_ui->btns->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(m_ui->configureLayouts, &QPushButton::clicked, this, &KbdStateConfig::configureLayouts);
 

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -53,7 +53,8 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
     ui->iconPB->setIcon(folder);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtMainMenuConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     loadSettings();
 

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -35,6 +35,7 @@
 
 #include <QAction>
 #include <QFileDialog>
+#include <QPushButton>
 
 LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, GlobalKeyShortcut::Action * shortcut, const QString &defaultShortcut, QWidget *parent) :
     LXQtPanelPluginConfigDialog(settings, parent),
@@ -52,6 +53,7 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(PluginSettings *settings, G
     ui->iconPB->setIcon(folder);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtMainMenuConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     loadSettings();
 

--- a/plugin-mount/configuration.cpp
+++ b/plugin-mount/configuration.cpp
@@ -78,7 +78,8 @@ Configuration::Configuration(PluginSettings *settings, QWidget *parent) :
     connect(ui->ejectPressedCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &Configuration::ejectPressedChanged);
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &Configuration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 }
 
 Configuration::~Configuration()

--- a/plugin-mount/configuration.cpp
+++ b/plugin-mount/configuration.cpp
@@ -31,6 +31,7 @@
 
 #include <QComboBox>
 #include <QDialogButtonBox>
+#include <QPushButton>
 
 Configuration::Configuration(PluginSettings *settings, QWidget *parent) :
     LXQtPanelPluginConfigDialog(settings, parent),
@@ -77,6 +78,7 @@ Configuration::Configuration(PluginSettings *settings, QWidget *parent) :
     connect(ui->ejectPressedCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &Configuration::ejectPressedChanged);
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &Configuration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 }
 
 Configuration::~Configuration()

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
@@ -52,7 +52,8 @@ LXQtNetworkMonitorConfiguration::LXQtNetworkMonitorConfiguration(PluginSettings 
     ui->setupUi(this);
 
     connect(ui->buttons,     &QDialogButtonBox::clicked,      this, &LXQtNetworkMonitorConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(ui->iconCB,      &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);
     connect(ui->interfaceCB, &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
@@ -31,6 +31,8 @@
 
 #include <algorithm>
 
+#include <QPushButton>
+
 extern "C" {
 #include <statgrab.h>
 }
@@ -50,6 +52,8 @@ LXQtNetworkMonitorConfiguration::LXQtNetworkMonitorConfiguration(PluginSettings 
     ui->setupUi(this);
 
     connect(ui->buttons,     &QDialogButtonBox::clicked,      this, &LXQtNetworkMonitorConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+
     connect(ui->iconCB,      &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);
     connect(ui->interfaceCB, &QComboBox::currentIndexChanged, this, &LXQtNetworkMonitorConfiguration::saveSettings);
 

--- a/plugin-sensors/lxqtsensorsconfiguration.cpp
+++ b/plugin-sensors/lxqtsensorsconfiguration.cpp
@@ -47,6 +47,8 @@ LXQtSensorsConfiguration::LXQtSensorsConfiguration(PluginSettings *settings, QWi
     loadSettings();
 
     connect(ui->buttons,                        &QDialogButtonBox::clicked, this, &LXQtSensorsConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+
     connect(ui->updateIntervalSB,               &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);
     connect(ui->tempBarWidthSB,                 &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);
     connect(ui->detectedChipsCB,                &QComboBox::activated,      this, &LXQtSensorsConfiguration::detectedChipSelected);

--- a/plugin-sensors/lxqtsensorsconfiguration.cpp
+++ b/plugin-sensors/lxqtsensorsconfiguration.cpp
@@ -47,7 +47,8 @@ LXQtSensorsConfiguration::LXQtSensorsConfiguration(PluginSettings *settings, QWi
     loadSettings();
 
     connect(ui->buttons,                        &QDialogButtonBox::clicked, this, &LXQtSensorsConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(ui->updateIntervalSB,               &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);
     connect(ui->tempBarWidthSB,                 &QSpinBox::valueChanged,    this, &LXQtSensorsConfiguration::saveSettings);

--- a/plugin-sysstat/lxqtsysstatconfiguration.cpp
+++ b/plugin-sysstat/lxqtsysstatconfiguration.cpp
@@ -109,6 +109,9 @@ LXQtSysStatConfiguration::LXQtSysStatConfiguration(PluginSettings *settings, QWi
     connect(ui->logarithmicCB, &QCheckBox::toggled, this, &LXQtSysStatConfiguration::saveSettings);
     connect(ui->sourceCOB, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &LXQtSysStatConfiguration::saveSettings);
     connect(ui->useThemeColoursRB, &QRadioButton::toggled, this, &LXQtSysStatConfiguration::saveSettings);
+
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 }
 
 LXQtSysStatConfiguration::~LXQtSysStatConfiguration()

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -44,7 +44,8 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtTaskbarConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     ui->buttonStyleCB->addItem(tr("Icon and text"), QLatin1String("IconText"));
     ui->buttonStyleCB->addItem(tr("Only icon"), QLatin1String("Icon"));

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -33,6 +33,8 @@
 #include "../panel/lxqtpanelapplication.h"
 #include "../panel/backends/ilxqtabstractwmiface.h"
 
+#include <QPushButton>
+
 LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWidget *parent):
     LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtTaskbarConfiguration)
@@ -42,6 +44,7 @@ LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(PluginSettings *settings, QWi
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtTaskbarConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     ui->buttonStyleCB->addItem(tr("Icon and text"), QLatin1String("IconText"));
     ui->buttonStyleCB->addItem(tr("Only icon"), QLatin1String("Icon"));

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -44,7 +44,8 @@ LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool 
     loadSettings();
     connect(ui->devAddedCombo,                     &QComboBox::currentIndexChanged, this, &LXQtVolumeConfiguration::sinkSelectionChanged);
     connect(ui->buttons,                           &QDialogButtonBox::clicked,      this, &LXQtVolumeConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(ui->muteOnMiddleClickCheckBox,         &QCheckBox::toggled,             this, &LXQtVolumeConfiguration::muteOnMiddleClickChanged);
     connect(ui->mixerLineEdit,                     &QLineEdit::textChanged,         this, &LXQtVolumeConfiguration::mixerLineEditChanged);

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -31,6 +31,7 @@
 #include "audiodevice.h"
 
 #include <QComboBox>
+#include <QPushButton>
 #include <QDebug>
 
 LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool ossAvailable, QWidget *parent) :
@@ -43,6 +44,8 @@ LXQtVolumeConfiguration::LXQtVolumeConfiguration(PluginSettings *settings, bool 
     loadSettings();
     connect(ui->devAddedCombo,                     &QComboBox::currentIndexChanged, this, &LXQtVolumeConfiguration::sinkSelectionChanged);
     connect(ui->buttons,                           &QDialogButtonBox::clicked,      this, &LXQtVolumeConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+
     connect(ui->muteOnMiddleClickCheckBox,         &QCheckBox::toggled,             this, &LXQtVolumeConfiguration::muteOnMiddleClickChanged);
     connect(ui->mixerLineEdit,                     &QLineEdit::textChanged,         this, &LXQtVolumeConfiguration::mixerLineEditChanged);
     connect(ui->stepSpinBox,                       &QSpinBox::valueChanged,         this, &LXQtVolumeConfiguration::stepSpinBoxChanged);

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -37,7 +37,7 @@
 #include <LXQt/Globals>
 
 #include <QInputDialog>
-
+#include <QPushButton>
 
 LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *settings, QWidget *parent) :
     LXQtPanelPluginConfigDialog(settings, parent),
@@ -51,6 +51,7 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtWorldClockConfiguration::dialogButtonsAction);
+    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
 
     connect(ui->timeFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timeShowSecondsCB,    &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -51,7 +51,8 @@ LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(PluginSettings *setting
     ui->setupUi(this);
 
     connect(ui->buttons, &QDialogButtonBox::clicked, this, &LXQtWorldClockConfiguration::dialogButtonsAction);
-    ui->buttons->button(QDialogButtonBox::Close)->setDefault(true);
+    if (auto btn = ui->buttons->button(QDialogButtonBox::Close))
+        btn->setDefault(true);
 
     connect(ui->timeFormatCB,         &QComboBox::currentIndexChanged, this, &LXQtWorldClockConfiguration::saveSettings);
     connect(ui->timeShowSecondsCB,    &QCheckBox::clicked,             this, &LXQtWorldClockConfiguration::saveSettings);


### PR DESCRIPTION
For all plugin configs with a dialog button box, set "Close" to the default button.

The `Enter` key, when no inner widget is activated, triggers the default dialog button.