### PR TITLE
Remove hardcoded font size from CPU monitor widget

### DIFF
--- a/plugin-cpuload/lxqtcpuload.cpp
+++ b/plugin-cpuload/lxqtcpuload.cpp
@@ -75,8 +75,6 @@ LXQtCpuLoad::LXQtCpuLoad(ILXQtPanelPlugin* plugin, QWidget* parent):
         perror("Error. Failed to drop privileges");
     }
 
-    m_font.setPointSizeF(8);
-
     settingsChanged();
 }
 
@@ -136,7 +134,7 @@ void LXQtCpuLoad::paintEvent ( QPaintEvent * )
     p.setPen(pen);
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    p.setFont(m_font);
+    p.setFont(font());
     QRectF r = rect();
 
     QRectF r1;

--- a/plugin-cpuload/lxqtcpuload.h
+++ b/plugin-cpuload/lxqtcpuload.h
@@ -78,8 +78,6 @@ private:
     int m_updateInterval;
     int m_timerID;
 
-    QFont m_font;
-
     QColor fontColor;
 };
 


### PR DESCRIPTION
**Replace `m_font` with the global font size.**

Previously, the CPU monitor widget used `m_font` to define its font size. `m_font` was set to a fixed size of 8 pt. This could make the text appear noticeably smaller than other pieces of text when using the default global font size (11 pt) or a custom font size.

By using the global application font instead, the widget now follows the user's configured font settings and remains consistent with the rest of the LXQt desktop.

**Before**
<img width="379" height="62" alt="Before image." src="https://github.com/user-attachments/assets/feb5f43c-6bde-4f82-990a-31450f199d19" />

**After**
<img width="437" height="94" alt="After image. Stop using dialup!" src="https://github.com/user-attachments/assets/6ad48f19-f671-4925-b802-344aefad117e" />
