### PR TITLE
plugin-networkmonitor: Improve margins

### DIFF
--- a/plugin-networkmonitor/lxqtnetworkmonitor.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitor.cpp
@@ -50,6 +50,7 @@ LXQtNetworkMonitor::LXQtNetworkMonitor(ILXQtPanelPlugin *plugin, QWidget* parent
 {
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->addWidget(&m_stuff);
+    layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
     /* Initialise statgrab */
 #ifdef STATGRAB_NEWER_THAN_0_90


### PR DESCRIPTION
An improvement over https://github.com/lxqt/lxqt-panel/pull/2445 - instead of changing the widget type, remove the ~QFrame~ QHBoxLayout  redundant margins.

See also https://github.com/lxqt/lxqt-panel/issues/2452#issuecomment-4876057885 for rationale.