### PR TITLE
Fix Network Monitor Plugin not respecting lxqt panel icon size

### DIFF
--- a/plugin-networkmonitor/lxqtnetworkmonitor.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitor.cpp
@@ -70,8 +70,9 @@ LXQtNetworkMonitor::~LXQtNetworkMonitor() = default;
 
 void LXQtNetworkMonitor::resizeEvent(QResizeEvent *)
 {
-    m_stuff.setMinimumWidth(m_pic.width() + 2);
-    m_stuff.setMinimumHeight(m_pic.height() + 2);
+    const int size = mPlugin->panel()->iconSize();
+    m_stuff.setMinimumWidth(size + 2);
+    m_stuff.setMinimumHeight(size + 2);
 
     update();
 }
@@ -96,19 +97,19 @@ void LXQtNetworkMonitor::timerEvent(QTimerEvent * /*event*/)
         {
             if (network_stats->rx != 0 && network_stats->tx != 0)
             {
-                m_pic.load(iconName(QStringLiteral("transmit-receive")));
+                loadPixmap(QStringLiteral("transmit-receive"));
             }
             else if (network_stats->rx != 0 && network_stats->tx == 0)
             {
-                m_pic.load(iconName(QStringLiteral("receive")));
+                loadPixmap(QStringLiteral("receive"));
             }
             else if (network_stats->rx == 0 && network_stats->tx != 0)
             {
-                m_pic.load(iconName(QStringLiteral("transmit")));
+                loadPixmap(QStringLiteral("transmit"));
             }
             else
             {
-                m_pic.load(iconName(QStringLiteral("idle")));
+                loadPixmap(QStringLiteral("idle"));
             }
 
             matched = true;
@@ -121,7 +122,7 @@ void LXQtNetworkMonitor::timerEvent(QTimerEvent * /*event*/)
 
     if (!matched)
     {
-        m_pic.load(iconName(QStringLiteral("error")));
+        loadPixmap(QStringLiteral("error"));
     }
 
     update();
@@ -198,7 +199,23 @@ void LXQtNetworkMonitor::settingsChanged()
             m_interface = QString(QLatin1String(stats[0].interface_name));
     }
 
-    m_pic.load(iconName(QStringLiteral("error")));
+    loadPixmap(QStringLiteral("error"));
+}
+
+void LXQtNetworkMonitor::realign()
+{
+    if (!m_iconState.isEmpty())
+        loadPixmap(m_iconState);
+    update();
+}
+
+void LXQtNetworkMonitor::loadPixmap(const QString &state)
+{
+    m_iconState = state;
+    const int size = mPlugin->panel()->iconSize();
+    m_pic = QPixmap(iconName(state)).scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    m_stuff.setMinimumWidth(size + 2);
+    m_stuff.setMinimumHeight(size + 2);
 }
 
 QString LXQtNetworkMonitor::convertUnits(double num)

--- a/plugin-networkmonitor/lxqtnetworkmonitor.h
+++ b/plugin-networkmonitor/lxqtnetworkmonitor.h
@@ -41,6 +41,7 @@ public:
     LXQtNetworkMonitor(ILXQtPanelPlugin *plugin, QWidget* parent = nullptr);
     ~LXQtNetworkMonitor();
     virtual void settingsChanged();
+    void realign();
 
 protected:
     void virtual timerEvent(QTimerEvent *event);
@@ -51,6 +52,7 @@ protected:
 
 private:
     static QString convertUnits(double num);
+    void loadPixmap(const QString &state);
     QString iconName(const QString& state) const
     {
         return QStringLiteral(":/images/knemo-%1-%2.png")
@@ -58,6 +60,7 @@ private:
     }
 
     QWidget m_stuff;
+    QString m_iconState;
 
     QStringList m_iconList;
 

--- a/plugin-networkmonitor/lxqtnetworkmonitorplugin.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitorplugin.cpp
@@ -56,3 +56,8 @@ void LXQtNetworkMonitorPlugin::settingsChanged()
 {
     mWidget->settingsChanged();
 }
+
+void LXQtNetworkMonitorPlugin::realign()
+{
+    mWidget->realign();
+}

--- a/plugin-networkmonitor/lxqtnetworkmonitorplugin.h
+++ b/plugin-networkmonitor/lxqtnetworkmonitorplugin.h
@@ -50,6 +50,7 @@ public:
 
 protected:
     virtual void settingsChanged();
+    virtual void realign();
 
 private:
     LXQtNetworkMonitor *mWidget;


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-panel/issues/2452 , re-scales the current icon when the panel geometry/icon size changes (wired through the plugin, same pattern as taskbar, kbindicator, etc.).