### PR TITLE
Fix word wrapping in Add Plugins listview

### DIFF
--- a/panel/config/addplugindialog.cpp
+++ b/panel/config/addplugindialog.cpp
@@ -60,6 +60,7 @@ AddPluginDialog::AddPluginDialog(QWidget *parent):
 
     ui->pluginList->setItemDelegate(new LXQt::HtmlDelegate(QSize(32, 32), ui->pluginList));
     ui->pluginList->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->pluginList->setWordWrap(true); // update HtmlDelegate on resizing
 
     filter();
 

--- a/panel/config/addplugindialog.ui
+++ b/panel/config/addplugindialog.ui
@@ -79,9 +79,6 @@
      <property name="sortingEnabled">
       <bool>false</bool>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item>

--- a/panel/config/addplugindialog.ui
+++ b/panel/config/addplugindialog.ui
@@ -79,6 +79,9 @@
      <property name="sortingEnabled">
       <bool>false</bool>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Previously I was getting a horizontal scrollbar when opening Add Plugins - it may be dependent on font size, thus hard to reproduce.


This patch enables `wordWrap` which fixes the issue for me (no glitchy horizontal scrollbar).

<img width="437" height="422" alt="Screenshot_20260720_221341" src="https://github.com/user-attachments/assets/16521cf4-a665-4e53-984b-4f45a30949c6" />