### PR TITLE
Fix volume wheel scroll dropping steps on fast mice

### DIFF
--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -45,39 +45,18 @@
 #include <QWheelEvent>
 #include <QScreen>
 
-#include <cmath>
-
 namespace {
 
 // Accumulate fractional wheel notches; write whole steps (trunc toward 0).
-double applyWheelUnits(double accumulator, double units, int *steps)
+double applyWheelUnits(double accumulator, double units, int &steps)
 {
     if ((accumulator > 0.0 && units < 0.0) || (accumulator < 0.0 && units > 0.0))
         accumulator = 0.0;
     accumulator += units;
-    *steps = static_cast<int>(accumulator);
-    accumulator -= *steps;
+    steps = static_cast<int>(accumulator);
+    accumulator -= steps;
     return accumulator;
 }
-
-#ifndef QT_NO_DEBUG
-struct WheelAccumSelfCheck {
-    WheelAccumSelfCheck()
-    {
-        int steps = 0;
-        double a = applyWheelUnits(0.0, 1.0, &steps); // one mouse notch
-        Q_ASSERT(steps == 1 && std::fabs(a) < 1e-9);
-        a = applyWheelUnits(a, 0.5, &steps); // half touchpad unit
-        Q_ASSERT(steps == 0 && std::fabs(a - 0.5) < 1e-9);
-        a = applyWheelUnits(a, 0.5, &steps);
-        Q_ASSERT(steps == 1 && std::fabs(a) < 1e-9);
-        a = applyWheelUnits(a, 3.0, &steps); // three notches in one event
-        Q_ASSERT(steps == 3 && std::fabs(a) < 1e-9);
-        a = applyWheelUnits(0.4, -1.0, &steps); // reverse clears leftover
-        Q_ASSERT(steps == -1 && std::fabs(a) < 1e-9);
-    }
-} wheelAccumSelfCheck;
-#endif
 
 } // namespace
 
@@ -311,7 +290,7 @@ int VolumePopup::wheelVolumeDelta(QWheelEvent *event, int stepSize)
         return 0;
 
     int steps = 0;
-    m_wheelAccumulator = applyWheelUnits(m_wheelAccumulator, units, &steps);
+    m_wheelAccumulator = applyWheelUnits(m_wheelAccumulator, units, steps);
     return steps * stepSize;
 }
 

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -44,19 +44,40 @@
 #include <QTimer>
 #include <QWheelEvent>
 #include <QScreen>
-#include <QElapsedTimer>
+
+#include <cmath>
 
 namespace {
 
-// Map touchpad pixel deltas to the same scale as angleDelta() (one notch = DefaultDeltasPerStep).
-int wheelEventDelta(const QWheelEvent *event)
+// Accumulate fractional wheel notches; write whole steps (trunc toward 0).
+double applyWheelUnits(double accumulator, double units, int *steps)
 {
-    const QPoint pixel = event->pixelDelta();
-    if (!pixel.isNull() && pixel.y() != 0)
-        return pixel.y() * QWheelEvent::DefaultDeltasPerStep / 32;
-
-    return event->angleDelta().y();
+    if ((accumulator > 0.0 && units < 0.0) || (accumulator < 0.0 && units > 0.0))
+        accumulator = 0.0;
+    accumulator += units;
+    *steps = static_cast<int>(accumulator);
+    accumulator -= *steps;
+    return accumulator;
 }
+
+#ifndef QT_NO_DEBUG
+struct WheelAccumSelfCheck {
+    WheelAccumSelfCheck()
+    {
+        int steps = 0;
+        double a = applyWheelUnits(0.0, 1.0, &steps); // one mouse notch
+        Q_ASSERT(steps == 1 && std::fabs(a) < 1e-9);
+        a = applyWheelUnits(a, 0.5, &steps); // half touchpad unit
+        Q_ASSERT(steps == 0 && std::fabs(a - 0.5) < 1e-9);
+        a = applyWheelUnits(a, 0.5, &steps);
+        Q_ASSERT(steps == 1 && std::fabs(a) < 1e-9);
+        a = applyWheelUnits(a, 3.0, &steps); // three notches in one event
+        Q_ASSERT(steps == 3 && std::fabs(a) < 1e-9);
+        a = applyWheelUnits(0.4, -1.0, &steps); // reverse clears leftover
+        Q_ASSERT(steps == -1 && std::fabs(a) < 1e-9);
+    }
+} wheelAccumSelfCheck;
+#endif
 
 } // namespace
 
@@ -65,8 +86,7 @@ VolumePopup::VolumePopup(QWidget* parent):
     m_pos(0, 0),
     m_anchor(Qt::TopLeftCorner),
     m_defaultSink(nullptr),
-    m_sliderStep(SETTINGS_DEFAULT_STEP),
-    m_lastWheelDirection(0)
+    m_sliderStep(SETTINGS_DEFAULT_STEP)
 {
     // Under some Wayland compositors, setting window flags in the c-tor of the base class
     // may not be enough for a correct positioning of the popup.
@@ -274,34 +294,25 @@ int VolumePopup::wheelVolumeDelta(QWheelEvent *event, int stepSize)
     if (stepSize <= 0)
         stepSize = SETTINGS_DEFAULT_STEP;
 
-    const int delta = wheelEventDelta(event);
-    if (delta == 0)
-    {
-        if (event->phase() == Qt::ScrollEnd)
-            m_lastWheelDirection = 0;
-        return 0;
-    }
-
-    const int direction = delta > 0 ? 1 : -1;
-
     if (event->phase() == Qt::ScrollEnd)
     {
-        m_lastWheelDirection = 0;
+        m_wheelAccumulator = 0.0;
         return 0;
     }
 
-    // One configured step per scroll; debounce collapses duplicate OS events per click.
-    constexpr int debounceMs = 120;
-    if (m_lastWheelTime.isValid()
-        && m_lastWheelTime.elapsed() < debounceMs
-        && direction == m_lastWheelDirection)
-    {
+    // Prefer angleDelta (mouse notches); pixelDelta is for touchpads / high-res wheels.
+    double units = 0.0;
+    const int angleY = event->angleDelta().y();
+    if (angleY != 0)
+        units = angleY / double(QWheelEvent::DefaultDeltasPerStep);
+    else if (const QPoint pixel = event->pixelDelta(); !pixel.isNull() && pixel.y() != 0)
+        units = pixel.y() / 32.0;
+    else
         return 0;
-    }
 
-    m_lastWheelTime.start();
-    m_lastWheelDirection = direction;
-    return direction * stepSize;
+    int steps = 0;
+    m_wheelAccumulator = applyWheelUnits(m_wheelAccumulator, units, &steps);
+    return steps * stepSize;
 }
 
 void VolumePopup::handleWheelEvent(QWheelEvent *event, QSlider *sliderFromWheel)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -59,31 +59,20 @@ double applyWheelUnits(double accumulator, double units, int &steps)
     return accumulator;
 }
 
-// Touchpads emit dense continuous deltas; ~8× dampening matches the old
-// debounce feel (full-height swipe ≈ 100/stepSize notches).
-constexpr double touchpadPixelDivisor = 256.0; // 32 * 8
-constexpr double touchpadAngleDivisor = QWheelEvent::DefaultDeltasPerStep * 8.0;
+// Touchpads emit dense continuous deltas. Use the same angle/pixel mapping as
+// mice, then apply a gain so a full-height swipe is nearer ~100/stepSize notches.
+// Prefer angleDelta; preferring pixelDelta with a large divisor over-damps real pads.
+constexpr double touchpadGain = 8.0;
 
-double wheelEventUnits(const QWheelEvent *event)
+double wheelEventUnits(const QWheelEvent &event)
 {
-    const bool touchpad = event->deviceType() == QInputDevice::DeviceType::TouchPad;
+    const bool touchpad = event.deviceType() == QInputDevice::DeviceType::TouchPad;
+    const double gain = touchpad ? touchpadGain : 1.0;
 
-    if (touchpad)
-    {
-        // Prefer pixelDelta on pads; fall back to dampened angleDelta.
-        const QPoint pixel = event->pixelDelta();
-        if (!pixel.isNull() && pixel.y() != 0)
-            return pixel.y() / touchpadPixelDivisor;
-        if (const int angleY = event->angleDelta().y(); angleY != 0)
-            return angleY / touchpadAngleDivisor;
-        return 0.0;
-    }
-
-    // Mouse / other: one physical notch (120) = one configured step.
-    if (const int angleY = event->angleDelta().y(); angleY != 0)
-        return angleY / double(QWheelEvent::DefaultDeltasPerStep);
-    if (const QPoint pixel = event->pixelDelta(); !pixel.isNull() && pixel.y() != 0)
-        return pixel.y() / 32.0;
+    if (const int angleY = event.angleDelta().y(); angleY != 0)
+        return angleY / (double(QWheelEvent::DefaultDeltasPerStep) * gain);
+    if (const QPoint pixel = event.pixelDelta(); !pixel.isNull() && pixel.y() != 0)
+        return pixel.y() / (32.0 * gain);
     return 0.0;
 }
 
@@ -308,7 +297,7 @@ int VolumePopup::wheelVolumeDelta(QWheelEvent *event, int stepSize)
         return 0;
     }
 
-    const double units = wheelEventUnits(event);
+    const double units = wheelEventUnits(*event);
     if (units == 0.0)
         return 0;
 

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -59,20 +59,40 @@ double applyWheelUnits(double accumulator, double units, int &steps)
     return accumulator;
 }
 
-// Touchpads emit dense continuous deltas. Use the same angle/pixel mapping as
-// mice, then apply a gain so a full-height swipe is nearer ~100/stepSize notches.
-// Prefer angleDelta; preferring pixelDelta with a large divisor over-damps real pads.
+// Scale-down for continuous touchpad deltas (not applied to classic ±120 mouse notches).
 constexpr double touchpadGain = 8.0;
 
+// Map a wheel event to fractional "notches" (1.0 = one configured volume step).
+//
+// Mice typically emit discrete angleDelta multiples of DefaultDeltasPerStep (120).
+// Touchpads emit dense continuous angle/pixel deltas. Some mice report as TouchPad
+// but still send classic notches — treat those as mice so touchpadGain is not applied.
 double wheelEventUnits(const QWheelEvent &event)
 {
-    const bool touchpad = event.deviceType() == QInputDevice::DeviceType::TouchPad;
-    const double gain = touchpad ? touchpadGain : 1.0;
+    const auto device = event.deviceType();
+    const int angleY = event.angleDelta().y();
+    if (angleY != 0)
+    {
+        // Classic mouse notch: ±120, ±240, … Prefer this over deviceType() alone.
+        const int absAngle = qAbs(angleY);
+        const bool classicNotch = absAngle >= QWheelEvent::DefaultDeltasPerStep
+            && absAngle % QWheelEvent::DefaultDeltasPerStep == 0;
+        if (device == QInputDevice::DeviceType::Mouse || classicNotch)
+            return angleY / double(QWheelEvent::DefaultDeltasPerStep);
+        // Smooth touchpad scroll: dampen so a full-height swipe is nearer ~100/stepSize notches.
+        if (device == QInputDevice::DeviceType::TouchPad)
+            return angleY / (double(QWheelEvent::DefaultDeltasPerStep) * touchpadGain);
+        // Unknown / other devices: same scale as a mouse notch.
+        return angleY / double(QWheelEvent::DefaultDeltasPerStep);
+    }
 
-    if (const int angleY = event.angleDelta().y(); angleY != 0)
-        return angleY / (double(QWheelEvent::DefaultDeltasPerStep) * gain);
+    // No angleDelta: use pixelDelta (common on some touchpads / high-res wheels).
     if (const QPoint pixel = event.pixelDelta(); !pixel.isNull() && pixel.y() != 0)
-        return pixel.y() / (32.0 * gain);
+    {
+        if (device == QInputDevice::DeviceType::TouchPad)
+            return pixel.y() / (32.0 * touchpadGain);
+        return pixel.y() / 32.0;
+    }
     return 0.0;
 }
 

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -44,6 +44,7 @@
 #include <QTimer>
 #include <QWheelEvent>
 #include <QScreen>
+#include <QInputDevice>
 
 namespace {
 
@@ -56,6 +57,34 @@ double applyWheelUnits(double accumulator, double units, int &steps)
     steps = static_cast<int>(accumulator);
     accumulator -= steps;
     return accumulator;
+}
+
+// Touchpads emit dense continuous deltas; ~8× dampening matches the old
+// debounce feel (full-height swipe ≈ 100/stepSize notches).
+constexpr double touchpadPixelDivisor = 256.0; // 32 * 8
+constexpr double touchpadAngleDivisor = QWheelEvent::DefaultDeltasPerStep * 8.0;
+
+double wheelEventUnits(const QWheelEvent *event)
+{
+    const bool touchpad = event->deviceType() == QInputDevice::DeviceType::TouchPad;
+
+    if (touchpad)
+    {
+        // Prefer pixelDelta on pads; fall back to dampened angleDelta.
+        const QPoint pixel = event->pixelDelta();
+        if (!pixel.isNull() && pixel.y() != 0)
+            return pixel.y() / touchpadPixelDivisor;
+        if (const int angleY = event->angleDelta().y(); angleY != 0)
+            return angleY / touchpadAngleDivisor;
+        return 0.0;
+    }
+
+    // Mouse / other: one physical notch (120) = one configured step.
+    if (const int angleY = event->angleDelta().y(); angleY != 0)
+        return angleY / double(QWheelEvent::DefaultDeltasPerStep);
+    if (const QPoint pixel = event->pixelDelta(); !pixel.isNull() && pixel.y() != 0)
+        return pixel.y() / 32.0;
+    return 0.0;
 }
 
 } // namespace
@@ -279,14 +308,8 @@ int VolumePopup::wheelVolumeDelta(QWheelEvent *event, int stepSize)
         return 0;
     }
 
-    // Prefer angleDelta (mouse notches); pixelDelta is for touchpads / high-res wheels.
-    double units = 0.0;
-    const int angleY = event->angleDelta().y();
-    if (angleY != 0)
-        units = angleY / double(QWheelEvent::DefaultDeltasPerStep);
-    else if (const QPoint pixel = event->pixelDelta(); !pixel.isNull() && pixel.y() != 0)
-        units = pixel.y() / 32.0;
-    else
+    const double units = wheelEventUnits(event);
+    if (units == 0.0)
         return 0;
 
     int steps = 0;

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -29,7 +29,6 @@
 #define VOLUMEPOPUP_H
 
 #include <QDialog>
-#include <QElapsedTimer>
 #include <QList>
 #include <QPointer>
 
@@ -105,8 +104,7 @@ private:
     QList<AudioDevice*> m_sinks;
     QPointer<AudioDevice> m_defaultSink;
     int m_sliderStep;
-    QElapsedTimer m_lastWheelTime;
-    int m_lastWheelDirection;
+    double m_wheelAccumulator = 0.0;
 };
 
 #endif // VOLUMEPOPUP_H


### PR DESCRIPTION
🐛 Mouse-wheel volume scrolling felt stuck on some mice (e.g. Microsoft Basic Optical) because a **120 ms debounce** ate real notches when scrolling fast  
🐷 Replaced debounce with a **notch piggy bank** (`m_wheelAccumulator`) so every click counts  
🖱️ Prefer `angleDelta` for classic wheels; 👆 fall back to `pixelDelta` for touchpads  
⚡ Fast flicks and multi-notch events now apply `steps × configured step` instead of being dropped  
🧹 Removed `QElapsedTimer` / direction debounce; added a tiny Debug self-check ✅  
⏱️ Fixed-time debounce ≠ same notch rate on every mouse  
📉 Reporter: 100% → 50% at 5% steps felt unresponsive

## How it works
1️⃣ Convert wheel motion to notch units (`120` angle = `1.0`)  
2️⃣ Bank fractions until a whole notch (or several)  
3️⃣ Volume change = whole notches × step size (default 5%)  
4️⃣ Reverse direction / `ScrollEnd` → empty the bank 🔄

Closes https://github.com/lxqt/lxqt-panel/issues/2463