### PR TITLE
fancy-menu: setting for adjustable delay instead of hardcoded 350ms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 *.kdev4
 CMakeLists.txt.user
+/lxqt-runner/

--- a/plugin-fancymenu/lxqtfancymenu.cpp
+++ b/plugin-fancymenu/lxqtfancymenu.cpp
@@ -217,6 +217,9 @@ void LXQtFancyMenu::settingsChanged()
     int delay = std::clamp(settings()->value(QStringLiteral("autoSelDelay"), 250).toInt(), 50, 1000);
     mWindow->setAutoSelectionDelay(delay);
 
+    int searchDelay = std::clamp(settings()->value(QStringLiteral("searchDelay"), 350).toInt(), 0, 2000);
+    mWindow->setSearchDelay(searchDelay);
+
     realign();
 }
 

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.cpp
@@ -93,6 +93,10 @@ LXQtFancyMenuConfiguration::LXQtFancyMenuConfiguration(PluginSettings *settings,
         this->settings().setValue(QStringLiteral("autoSelDelay"), value);
     });
 
+    connect(ui->searchDelaySB, &QSpinBox::valueChanged, this, [this] (int value) {
+        this->settings().setValue(QStringLiteral("searchDelay"), value);
+    });
+
     connect(mShortcut, &GlobalKeyShortcut::Action::shortcutChanged, this, &LXQtFancyMenuConfiguration::globalShortcutChanged);
 
     connect(ui->filterClearCB, &QCheckBox::toggled, this, [this] (bool value) {
@@ -154,6 +158,8 @@ void LXQtFancyMenuConfiguration::loadSettings()
 
     ui->autoSelSB->setValue(settings().value(QStringLiteral("autoSelDelay"), 250).toInt());
     ui->autoSelCB->setChecked(settings().value(QStringLiteral("autoSel"), false).toBool());
+
+    ui->searchDelaySB->setValue(settings().value(QStringLiteral("searchDelay"), 350).toInt());
 
     bool buttonsAtTop = settings().value(QStringLiteral("buttonsAtTop"), false).toBool();
     int buttRowPosIdx = ui->buttRowPosCB->findData(buttonsAtTop ? LXQtFancyMenuButtonPosition::Top : LXQtFancyMenuButtonPosition::Bottom);

--- a/plugin-fancymenu/lxqtfancymenuconfiguration.ui
+++ b/plugin-fancymenu/lxqtfancymenuconfiguration.ui
@@ -183,6 +183,32 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="searchDelayLabel">
+        <property name="text">
+         <string>Search delay:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="searchDelaySB">
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>2000</number>
+        </property>
+        <property name="singleStep">
+         <number>50</number>
+        </property>
+        <property name="value">
+         <number>350</number>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/plugin-fancymenu/lxqtfancymenuwindow.cpp
+++ b/plugin-fancymenu/lxqtfancymenuwindow.cpp
@@ -145,8 +145,8 @@ LXQtFancyMenuWindow::LXQtFancyMenuWindow(QWidget *parent)
     setStyle(s);
 
     mSearchTimer.setSingleShot(true);
+    mSearchTimer.setInterval(350);
     connect(&mSearchTimer, &QTimer::timeout, this, &LXQtFancyMenuWindow::doSearch);
-    mSearchTimer.setInterval(350); // typing speed (not very fast)
 
     mAutoSelTimer.setSingleShot(true);
     connect(&mAutoSelTimer, &QTimer::timeout, this, &LXQtFancyMenuWindow::autoSelect);

--- a/plugin-fancymenu/lxqtfancymenuwindow.h
+++ b/plugin-fancymenu/lxqtfancymenuwindow.h
@@ -87,6 +87,9 @@ public:
     void setAutoSelectionDelay(int delay) {
         mAutoSelTimer.setInterval(delay);
     }
+    void setSearchDelay(int delay) {
+        mSearchTimer.setInterval(delay);
+    }
 
 signals:
     void aboutToShow();


### PR DESCRIPTION
# Why
If you type fast and press enter quickly, you don't open the intended application because of the hardcoded 350ms delay. So I figured, why not just add a setting for that? Now you can adjust it as you want.