### PR TITLE
plugin-qeyes: Silence warning and clean up headers

### DIFF
--- a/plugin-qeyes/qeyes.cpp
+++ b/plugin-qeyes/qeyes.cpp
@@ -20,11 +20,11 @@
  */
 
 #include <stdio.h>
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QDialog>
-#include <QtCore/QFile>
-#include <QtCore/QTextStream>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QDialog>
+#include <QFile>
+#include <QTextStream>
 
 #include "../panel/pluginsettings.h"
 
@@ -70,7 +70,8 @@ void QEyesPlugin::realign() {
 
 static bool loadImage(QString path, QEyesImageWidget *w) {
     QFile file(path + QStringLiteral("/config"));
-    file.open(QIODevice::ReadOnly);
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
     QTextStream in(&file);
     QString eye, pupil;
     int num=1, wall=1;

--- a/plugin-qeyes/qeyes.h
+++ b/plugin-qeyes/qeyes.h
@@ -18,12 +18,11 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
- 
+
 #include <iostream>
 
-#include <QtWidgets/QApplication>
-#include <QtCore/QCommandLineParser>
-#include <QtWidgets/QVBoxLayout>
+#include <QApplication>
+#include <QVBoxLayout>
 
 #include "../panel/ilxqtpanelplugin.h"
 
@@ -63,5 +62,3 @@ class QEyesPluginLibrary: public QObject, public ILXQtPanelPluginLibrary
 public:
     ILXQtPanelPlugin *instance(const ILXQtPanelPluginStartupInfo &startupInfo) const;
 };
-
-

--- a/plugin-qeyes/qeyesconfigdialog.h
+++ b/plugin-qeyes/qeyesconfigdialog.h
@@ -18,17 +18,15 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
- 
+
 #include <iostream>
 #include <map>
 #include <string>
 
-
-#include <QtWidgets/QDialog>
-#include <QtWidgets/QSpinBox>
-#include <QtWidgets/QComboBox>
-#include <QtCore/QMap>
-
+#include <QDialog>
+#include <QSpinBox>
+#include <QComboBox>
+#include <QMap>
 
 #include "../panel/pluginsettings.h"
 #include "../panel/ilxqtpanelplugin.h"
@@ -49,7 +47,7 @@ private:
     void buildList();
     void resetValue();
     void updateAndClose();
-    
+
     int old_num_eyes;
     QString old_type_eyes;
 

--- a/plugin-qeyes/qeyesimagewidget.cpp
+++ b/plugin-qeyes/qeyesimagewidget.cpp
@@ -19,18 +19,17 @@
  *
  */
 
-#include <QtGui/QPainter>
-#include <QtGui/QPen>
-#include <QtGui/QCursor>
-#include <QtWidgets/QApplication>
-#include <QtCore/QFile>
-#include <QtCore/QTextStream>
+#include <QPainter>
+#include <QPen>
+#include <QCursor>
+#include <QApplication>
+#include <QFile>
+#include <QTextStream>
 
 #include <stdio.h>
 #include <math.h>
 
 #include "qeyesimagewidget.h"
-
 
 bool ImageStretcher::load(const QString& fn)
 {
@@ -50,7 +49,7 @@ bool ImageStretcher::load(const QString& fn)
     stretchedImage = QPixmap();
     return true;
 }
-    
+
 QPixmap & ImageStretcher::ImageStretcher::getImage(int w, int h) {
     if (w == stretchedImage.width() && h == stretchedImage.height())
         return stretchedImage;
@@ -93,7 +92,7 @@ void QEyesImageWidget::drawEye(QPainter &painter, int x, int y, int dx, int dy) 
 }
 void QEyesImageWidget::drawPupil(QPainter &painter, int x, int y) {
 
-    auto & img = pupil.getImage( 
+    auto & img = pupil.getImage(
             pupil.origWidth() * background.stretchedWidth() / background.origWidth(),
             pupil.origHeight() * background.stretchedHeight() / background.origHeight());
 
@@ -124,13 +123,12 @@ void QEyesImageWidget::paintEvent(QPaintEvent *event) {
     if (width() != oldWidth || height() != oldHeight) {
         const auto dx = width() / numEyes;
         background.getImage(dx, height());
-        
+
         borderYStretched = borderY * background.stretchedHeight() / background.origHeight();
         borderXStretched = borderX * background.stretchedWidth() / background.origWidth();
-            
+
         oldWidth = width();
         oldHeight = height();
     }
     QAbstractEyesWidget::paintEvent(event);
 }
-

--- a/plugin-qeyes/qeyesimagewidget.h
+++ b/plugin-qeyes/qeyesimagewidget.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <QtSvg/QSvgRenderer>
+#include <QSvgRenderer>
 #include "qeyeswidget.h"
 
 

--- a/plugin-qeyes/qeyesvectorwidget.cpp
+++ b/plugin-qeyes/qeyesvectorwidget.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-#include <QtGui/QPainter>
-#include <QtGui/QPen>
-#include <QtGui/QCursor>
-#include <QtGui/QRadialGradient>
+#include <QPainter>
+#include <QPen>
+#include <QCursor>
+#include <QRadialGradient>
 
 #include "qeyesvectorwidget.h"
 

--- a/plugin-qeyes/qeyeswidget.cpp
+++ b/plugin-qeyes/qeyeswidget.cpp
@@ -19,12 +19,12 @@
  *
  */
 
-#include <QtGui/QPainter>
-#include <QtGui/QPen>
-#include <QtGui/QCursor>
-#include <QtWidgets/QApplication>
-#include <QtCore/QFile>
-#include <QtCore/QTextStream>
+#include <QPainter>
+#include <QPen>
+#include <QCursor>
+#include <QApplication>
+#include <QFile>
+#include <QTextStream>
 
 #include <stdio.h>
 #include <math.h>
@@ -94,17 +94,17 @@ void QAbstractEyesWidget::paintEvent(QPaintEvent *) {
 
         /*
          *  dy      y      ry      sin(alpha)
-         * ----  = --- =  ---- * -------------  
+         * ----  = --- =  ---- * -------------
          *  dx      x      rx      cos(alpha)
-         * 
-         * 
+         *
+         *
          *  dy / ry      sin(alpha)
          * ---------  = ------------- = tan(alpha)
          *  dx / rx      cos(alpha)
-         * 
-         * 
+         *
+         *
          * alpha = atan2( dy/rx, dx/rx)
-         * 
+         *
          */
 
         const auto alpha = atan2(dy/ry, dx/rx);
@@ -113,7 +113,7 @@ void QAbstractEyesWidget::paintEvent(QPaintEvent *) {
         auto y = ry * sin(alpha);
         auto x = rx * cos(alpha);
 
-        /* 
+        /*
          * if the cursor is inside the eye, the pupil position is
          * the cursor
          */

--- a/plugin-qeyes/qeyeswidget.h
+++ b/plugin-qeyes/qeyeswidget.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QMenu>
-#include <QtCore/QTimer>
-#include <QtGui/QPixmap>
+#include <QWidget>
+#include <QMenu>
+#include <QTimer>
+#include <QPixmap>
 
 class QAbstractEyesWidget : public QWidget
 {


### PR DESCRIPTION
- Warning was:
```
lxqt-panel/plugin-qeyes/qeyes.cpp:73:14: warning: ignoring return value of ‘virtual bool QFile::open(QIODeviceBase::OpenMode)’, declared with attribute ‘nodiscard’ [-Wunused-result]
   73 |     file.open(QIODevice::ReadOnly);
```
- Clean up nested headers
- Clean up whitespace