### PR TITLE
[customcommand] add minimum width config option

### DIFF
--- a/plugin-customcommand/custombutton.cpp
+++ b/plugin-customcommand/custombutton.cpp
@@ -89,7 +89,7 @@ void CustomButton::wheelEvent(QWheelEvent *event)
 
 void CustomButton::setWidthRange(int minWidth, int maxWidth)
 {
-    mMinWidth = minWidth;
+    mMinWidth = (minWidth <= maxWidth) ? minWidth : maxWidth;
     mMaxWidth = maxWidth;
     updateWidth();
 }

--- a/plugin-customcommand/custombutton.cpp
+++ b/plugin-customcommand/custombutton.cpp
@@ -61,6 +61,7 @@ CustomButton::CustomButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         QToolButton(parent),
         mPlugin(plugin),
         mPanel(plugin->panel()),
+        mMinWidth(20),
         mMaxWidth(200)
 
 {
@@ -86,15 +87,16 @@ void CustomButton::wheelEvent(QWheelEvent *event)
     event->accept();
 }
 
-void CustomButton::setMaxWidth(int maxWidth)
+void CustomButton::setWidthRange(int minWidth, int maxWidth)
 {
+    mMinWidth = minWidth;
     mMaxWidth = maxWidth;
     updateWidth();
 }
 
 void CustomButton::updateWidth()
 {
-    int newWidth = std::min(sizeHint().width(), mMaxWidth);
+    int newWidth = std::clamp(sizeHint().width(), mMinWidth, mMaxWidth);
     if (mOrigin == Qt::TopLeftCorner) {
         setFixedWidth(newWidth);
 

--- a/plugin-customcommand/custombutton.h
+++ b/plugin-customcommand/custombutton.h
@@ -41,7 +41,7 @@ public:
 
 public slots:
     void setAutoRotation(bool value);
-    void setMaxWidth(int maxWidth);
+    void setWidthRange(int minWidth, int maxWidth);
     void updateWidth();
 
 protected:
@@ -55,6 +55,7 @@ private:
     ILXQtPanelPlugin *mPlugin;
     ILXQtPanel *mPanel;
     Qt::Corner mOrigin;
+    int mMinWidth;
     int mMaxWidth;
 
 signals:

--- a/plugin-customcommand/lxqtcustomcommand.cpp
+++ b/plugin-customcommand/lxqtcustomcommand.cpp
@@ -51,6 +51,7 @@ LXQtCustomCommand::LXQtCustomCommand(const ILXQtPanelPluginStartupInfo &startupI
         mContinuousOutput(false),
         mRepeat(true),
         mRepeatTimer(5),
+        mMinWidth(20),
         mMaxWidth(200)
 {
     mButton = new CustomButton(this);
@@ -115,6 +116,7 @@ void LXQtCustomCommand::settingsChanged()
     QString oldIcon = mIcon;
     QString oldText = mText;
     QString oldTooltip = mTooltip;
+    int oldMinWidth = mMinWidth;
     int oldMaxWidth = mMaxWidth;
 
     mAutoRotate = settings()->value(QStringLiteral("autoRotate"), true).toBool();
@@ -134,6 +136,7 @@ void LXQtCustomCommand::settingsChanged()
     mIcon = settings()->value(QStringLiteral("icon"), QString()).toString();
     mText = settings()->value(QStringLiteral("text"), QStringLiteral("%1")).toString();
     mTooltip = settings()->value(QStringLiteral("tooltip"), QString()).toString();
+    mMinWidth = settings()->value(QStringLiteral("minWidth"), 20).toInt();
     mMaxWidth = settings()->value(QStringLiteral("maxWidth"), 200).toInt();
     mClick = settings()->value(QStringLiteral("click"), QString()).toString().trimmed();
     mWheelUp = settings()->value(QStringLiteral("wheelUp"), QString()).toString().trimmed();
@@ -176,8 +179,8 @@ void LXQtCustomCommand::settingsChanged()
     if (oldTooltip != mTooltip)
         mButton->setToolTip(mTooltip);
 
-    if (mFirstRun || oldMaxWidth != mMaxWidth)
-        mButton->setMaxWidth(mMaxWidth);
+    if (mFirstRun || oldMinWidth != mMinWidth || oldMaxWidth != mMaxWidth)
+        mButton->setWidthRange(mMinWidth, mMaxWidth);
 
     if (mFirstRun || oldAutoRotate != mAutoRotate)
         mButton->setAutoRotation(mAutoRotate);
@@ -223,7 +226,7 @@ void LXQtCustomCommand::handleFinished(int exitCode, QProcess::ExitStatus exitSt
 
 void LXQtCustomCommand::handleOutput()
 {
-    if (!mContinuousOutput) 
+    if (!mContinuousOutput)
         return;
 
     bool something_read = false;

--- a/plugin-customcommand/lxqtcustomcommand.h
+++ b/plugin-customcommand/lxqtcustomcommand.h
@@ -89,6 +89,7 @@ private:
     QString mIcon;
     QString mText;
     QString mTooltip;
+    int mMinWidth;
     int mMaxWidth;
     QString mClick;
     QString mWheelUp;

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -141,6 +141,7 @@ LXQtCustomCommandConfiguration::LXQtCustomCommandConfiguration(PluginSettings *s
     connect(ui->iconBrowseButton, &QPushButton::clicked, this, &LXQtCustomCommandConfiguration::iconBrowseButtonClicked);
     connect(ui->textLineEdit, &QLineEdit::editingFinished, this, &LXQtCustomCommandConfiguration::textLineEditChanged);
     connect(ui->tooltipLineEdit, &QLineEdit::editingFinished, this, &LXQtCustomCommandConfiguration::tooltipLineEditChanged);
+    connect(ui->minWidthSpinBox, &QSpinBox::editingFinished, this, &LXQtCustomCommandConfiguration::minWidthSpinBoxChanged);
     connect(ui->maxWidthSpinBox, &QSpinBox::editingFinished, this, &LXQtCustomCommandConfiguration::maxWidthSpinBoxChanged);
     connect(ui->clickLineEdit, &QLineEdit::editingFinished, this, &LXQtCustomCommandConfiguration::clickLineEditChanged);
     connect(ui->wheelUpLineEdit, &QLineEdit::editingFinished, this, &LXQtCustomCommandConfiguration::wheelUpLineEditChanged);
@@ -178,7 +179,14 @@ void LXQtCustomCommandConfiguration::loadSettings()
     ui->iconLineEdit->setText(settings().value(QStringLiteral("icon"), QString()).toString());
     ui->textLineEdit->setText(settings().value(QStringLiteral("text"), QStringLiteral("%1")).toString());
     ui->tooltipLineEdit->setText(settings().value(QStringLiteral("tooltip"), QString()).toString());
-    ui->maxWidthSpinBox->setValue(settings().value(QStringLiteral("maxWidth"), 200).toInt());
+
+    int min = settings().value(QStringLiteral("minWidth"), 20).toInt();
+    int max = settings().value(QStringLiteral("maxWidth"), 200).toInt();
+    ui->minWidthSpinBox->setValue(min);
+    ui->minWidthSpinBox->setMaximum(max);
+    ui->maxWidthSpinBox->setValue(max);
+    ui->maxWidthSpinBox->setMinimum(min);
+
     ui->clickLineEdit->setText(settings().value(QStringLiteral("click"), QString()).toString());
     ui->wheelUpLineEdit->setText(settings().value(QStringLiteral("wheelUp"), QString()).toString());
     ui->wheelDownLineEdit->setText(settings().value(QStringLiteral("wheelDown"), QString()).toString());
@@ -283,10 +291,20 @@ void LXQtCustomCommandConfiguration::tooltipLineEditChanged()
         settings().setValue(QStringLiteral("tooltip"), ui->tooltipLineEdit->text());
 }
 
+void LXQtCustomCommandConfiguration::minWidthSpinBoxChanged()
+{
+    int min = ui->minWidthSpinBox->value();
+    ui->maxWidthSpinBox->setMinimum(min);
+    if (!mLockSettingChanges)
+        settings().setValue(QStringLiteral("minWidth"), min);
+}
+
 void LXQtCustomCommandConfiguration::maxWidthSpinBoxChanged()
 {
+    int max = ui->maxWidthSpinBox->value();
+    ui->minWidthSpinBox->setMaximum(max);
     if (!mLockSettingChanges)
-        settings().setValue(QStringLiteral("maxWidth"), ui->maxWidthSpinBox->value());
+        settings().setValue(QStringLiteral("maxWidth"), max);
 }
 
 void LXQtCustomCommandConfiguration::clickLineEditChanged()

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.h
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.h
@@ -67,6 +67,7 @@ private slots:
     void iconBrowseButtonClicked();
     void textLineEditChanged();
     void tooltipLineEditChanged();
+    void minWidthSpinBoxChanged();
     void maxWidthSpinBoxChanged();
     void clickLineEditChanged();
     void wheelUpLineEditChanged();

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.ui
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.ui
@@ -73,23 +73,64 @@
          </widget>
         </item>
         <item row="11" column="1" colspan="2">
-         <widget class="QSpinBox" name="maxWidthSpinBox">
-          <property name="suffix">
-           <string> px</string>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
           </property>
-          <property name="minimum">
-           <number>10</number>
+          <property name="topMargin">
+           <number>0</number>
           </property>
-          <property name="maximum">
-           <number>9999</number>
+          <property name="rightMargin">
+           <number>0</number>
           </property>
-          <property name="singleStep">
-           <number>5</number>
+          <property name="bottomMargin">
+           <number>0</number>
           </property>
-          <property name="value">
-           <number>200</number>
-          </property>
-         </widget>
+          <item>
+           <widget class="QSpinBox" name="minWidthSpinBox">
+            <property name="prefix">
+             <string>min: </string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="value">
+             <number>20</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="maxWidthSpinBox">
+            <property name="prefix">
+             <string>max: </string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="value">
+             <number>200</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item row="4" column="1" colspan="2">
          <widget class="QCheckBox" name="runWithBashCheckBox">
@@ -144,9 +185,9 @@
          </widget>
         </item>
         <item row="11" column="0">
-         <widget class="QLabel" name="maxWidthLabel">
+         <widget class="QLabel" name="widthLabel">
           <property name="text">
-           <string>Max Width</string>
+           <string>Width</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
@@ -412,6 +453,7 @@
   <tabstop>iconBrowseButton</tabstop>
   <tabstop>textLineEdit</tabstop>
   <tabstop>tooltipLineEdit</tabstop>
+  <tabstop>minWidthSpinBox</tabstop>
   <tabstop>maxWidthSpinBox</tabstop>
   <tabstop>clickLineEdit</tabstop>
   <tabstop>wheelUpLineEdit</tabstop>


### PR DESCRIPTION
fixes #2472

the spinboxes are a bit too small, but i think it's my theme, it's the same for any spinbox here:
<img width="489" height="721" alt="screenshot_1786748296" src="https://github.com/user-attachments/assets/fb62da4f-20ad-4ea6-bafd-228ed889c7e6" />

https://github.com/user-attachments/assets/359fb7ce-02c6-4450-8769-40a794c68a79

