### PR TITLE
[customcommand] save the icon path when selected via file picker.

### DIFF
--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -276,8 +276,10 @@ void LXQtCustomCommandConfiguration::iconLineEditChanged()
 void LXQtCustomCommandConfiguration::iconBrowseButtonClicked()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Icon File"), QString(), tr("Images (*.png *.svg *.xpm *.jpg)"));
-    ui->iconLineEdit->setText(fileName);
-    iconLineEditChanged();
+    if (!fileName.isEmpty()) {
+        ui->iconLineEdit->setText(fileName);
+        iconLineEditChanged();
+    }
 }
 
 void LXQtCustomCommandConfiguration::textLineEditChanged()

--- a/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
+++ b/plugin-customcommand/lxqtcustomcommandconfiguration.cpp
@@ -277,6 +277,7 @@ void LXQtCustomCommandConfiguration::iconBrowseButtonClicked()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Icon File"), QString(), tr("Images (*.png *.svg *.xpm *.jpg)"));
     ui->iconLineEdit->setText(fileName);
+    iconLineEditChanged();
 }
 
 void LXQtCustomCommandConfiguration::textLineEditChanged()


### PR DESCRIPTION
fixes https://github.com/lxqt/lxqt/discussions/2897

`QLineEdit::setText` doesn't trigger `QLineEdit::editingFinished` so unless the text was edited in some way after picking, it didn't get saved.