### PR TITLE
Refactor VolumePopup::rebuildSinkRows to improve widget removal and height adjustment

### DIFF
--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -398,16 +398,23 @@ void VolumePopup::setSliderStep(int step)
 
 void VolumePopup::rebuildSinkRows()
 {
+    QVBoxLayout *layout = qobject_cast<QVBoxLayout*>(m_sinksContainer->layout());
+
     for (const SinkRow &row : std::as_const(m_sinkRows))
     {
         if (row.device)
             disconnect(row.device, nullptr, this, nullptr);
         if (row.rowWidget)
-            row.rowWidget->deleteLater();
+        {
+            // Remove immediately so layout/sizeHint aren't left with stale rows
+            // (deleteLater would keep them until the next event-loop pass).
+            if (layout)
+                layout->removeWidget(row.rowWidget);
+            delete row.rowWidget;
+        }
     }
     m_sinkRows.clear();
 
-    QVBoxLayout *layout = qobject_cast<QVBoxLayout*>(m_sinksContainer->layout());
     if (!layout)
         return;
 
@@ -437,25 +444,35 @@ void VolumePopup::rebuildSinkRows()
     updateDefaultButtons();
     setSliderStep(m_sliderStep);
 
-    // Size the scroll area by row height: show at least 1 row, at most 3 rows.
-    if (!m_sinkRows.isEmpty() && layout)
+    // Show exactly min(n, 3) rows; scrollbar only when there are more than 3 sinks.
+    constexpr int maxVisibleRows = 3;
+    if (!m_sinkRows.isEmpty())
     {
-        m_sinksContainer->adjustSize();
         QWidget *firstRow = m_sinkRows.at(0).rowWidget;
+        firstRow->ensurePolished();
         int rowHeight = firstRow->sizeHint().height();
         if (rowHeight <= 0)
             rowHeight = firstRow->minimumSizeHint().height();
         if (rowHeight > 0)
         {
             const int spacing = layout->spacing();
-            m_sinkScrollArea->setMinimumHeight(rowHeight);
-            m_sinkScrollArea->setMaximumHeight(3 * rowHeight + 2 * spacing);
+            const int visibleRows = qMin(static_cast<int>(m_sinkRows.size()), maxVisibleRows);
+            const int height = visibleRows * rowHeight + (visibleRows - 1) * spacing;
+            m_sinkScrollArea->setMinimumHeight(height);
+            m_sinkScrollArea->setMaximumHeight(height);
         }
     }
     else
     {
         m_sinkScrollArea->setMinimumHeight(0);
         m_sinkScrollArea->setMaximumHeight(QWIDGETSIZE_MAX);
+    }
+
+    if (isVisible())
+    {
+        updateGeometry();
+        adjustSize();
+        realign();
     }
 }
 


### PR DESCRIPTION
🐛 Hot-adding a PulseAudio/PipeWire sink left the volume popup stuck at ~1-row height → bogus scrollbar with only 2 sinks  
🔁 After a panel restart (sinks present from the start) layout looked correct → inconsistent UX  
📏 Root cause: scroll area used **min = 1 row** / **max = 3 rows**, but never set height to `min(n, 3)`  
✅ Now sizes to exactly **1 / 2 / 3** visible rows; scrollbar only when there are **4+** sinks  
🗑️ Dropped `deleteLater()` without `removeWidget` (stale rows in the layout during measure)  
📐 If the popup is already open, `adjustSize()` + `realign()` so it grows/shrinks live  

## Behavior
| Sinks | Expected |
|------:|----------|
| 1–3 | All rows visible, **no** scroll ✨ |
| 4+ | Three rows + scrollbar 📜 |
| Hot-add / remove | Same as after restart 🔄 |


Addresses https://github.com/lxqt/lxqt-panel/issues/2475